### PR TITLE
feat(voxcode): PTT as default, clipboard backend, dual PTT key (LINCE-1)

### DIFF
--- a/backlog/tasks/lince-1 - Enhance-PTT-mode-default-behavior-dual-key-support-clipboard-output.md
+++ b/backlog/tasks/lince-1 - Enhance-PTT-mode-default-behavior-dual-key-support-clipboard-output.md
@@ -1,9 +1,10 @@
 ---
 id: LINCE-1
 title: 'Enhance PTT mode: default behavior, dual-key support, clipboard output'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-03-03 10:34'
+updated_date: '2026-03-05 18:10'
 labels:
   - voxcode
   - feature
@@ -40,3 +41,9 @@ This is a parent task grouping three sequential subtasks. The clipboard backend 
 - Transcription results go through `_check_results` → `buffer` → `_send_buffer` → `bridge.send_text()`
 - No clipboard integration exists; ROADMAP.md mentions it as planned
 <!-- SECTION:DESCRIPTION:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Tutti e tre i subtask completati: PTT come default, clipboard backend con wl-copy/xclip, dual PTT key (Space→pane, Tab→clipboard).
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/lince-1.1 - Make-PTT-the-default-operating-mode.md
+++ b/backlog/tasks/lince-1.1 - Make-PTT-the-default-operating-mode.md
@@ -1,10 +1,10 @@
 ---
 id: LINCE-1.1
 title: Make PTT the default operating mode
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-03-03 10:35'
-updated_date: '2026-03-03 10:35'
+updated_date: '2026-03-05 17:52'
 labels:
   - voxcode
   - ptt
@@ -34,11 +34,11 @@ Currently `GeneralConfig.mode` defaults to `"vad"` in `config.py:18`. Users must
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 GeneralConfig.mode defaults to "ptt" in config.py (no config.toml needed for PTT)
-- [ ] #2 VAD mode still works when explicitly set via mode = "vad" in config.toml
-- [ ] #3 Example config.toml is updated to document the new default and show how to switch to VAD
-- [ ] #4 Application starts in PTT mode when no config.toml exists
-- [ ] #5 UI correctly shows PTT-related status on startup with default config
+- [x] #1 GeneralConfig.mode defaults to "ptt" in config.py (no config.toml needed for PTT)
+- [x] #2 VAD mode still works when explicitly set via mode = "vad" in config.toml
+- [x] #3 Example config.toml is updated to document the new default and show how to switch to VAD
+- [x] #4 Application starts in PTT mode when no config.toml exists
+- [x] #5 UI correctly shows PTT-related status on startup with default config
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -62,3 +62,9 @@ Currently `GeneralConfig.mode` defaults to `"vad"` in `config.py:18`. Users must
 
 ### Estimated effort: Small (< 30 min)
 <!-- SECTION:PLAN:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Changed `GeneralConfig.mode` default from `"vad"` to `"ptt"` in config.py. Updated config.toml to comment out the mode line (since PTT is now default) and document how to switch back to VAD.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/lince-1.2 - Implement-clipboard-output-backend.md
+++ b/backlog/tasks/lince-1.2 - Implement-clipboard-output-backend.md
@@ -1,10 +1,10 @@
 ---
 id: LINCE-1.2
 title: Implement clipboard output backend
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-03-03 10:35'
-updated_date: '2026-03-03 10:35'
+updated_date: '2026-03-05 17:52'
 labels:
   - voxcode
   - feature
@@ -42,13 +42,13 @@ This backend is NOT a replacement for the multiplexer bridge — it will be used
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 ClipboardBridge class exists in clipboard_bridge.py with a send_text(text: str) method
-- [ ] #2 Auto-detects Wayland vs X11 from WAYLAND_DISPLAY / DISPLAY env vars
-- [ ] #3 Uses wl-copy on Wayland and xclip -selection clipboard on X11
-- [ ] #4 Raises a descriptive error at init if neither wl-copy nor xclip is available on the system
-- [ ] #5 send_text() pipes the text to the clipboard tool via subprocess (not writing to temp files)
-- [ ] #6 Text copied to clipboard does NOT include trailing newline unless the transcription itself has one
-- [ ] #7 Unit tests verify Wayland detection logic and command construction (mocking subprocess)
+- [x] #1 ClipboardBridge class exists in clipboard_bridge.py with a send_text(text: str) method
+- [x] #2 Auto-detects Wayland vs X11 from WAYLAND_DISPLAY / DISPLAY env vars
+- [x] #3 Uses wl-copy on Wayland and xclip -selection clipboard on X11
+- [x] #4 Raises a descriptive error at init if neither wl-copy nor xclip is available on the system
+- [x] #5 send_text() pipes the text to the clipboard tool via subprocess (not writing to temp files)
+- [x] #6 Text copied to clipboard does NOT include trailing newline unless the transcription itself has one
+- [x] #7 Unit tests verify Wayland detection logic and command construction (mocking subprocess)
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -98,3 +98,9 @@ Key details:
 
 ### Estimated effort: Medium (1-2 hours)
 <!-- SECTION:PLAN:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created `voxcode/src/voxcode/clipboard_bridge.py` with `ClipboardBridge` class. Detects Wayland (WAYLAND_DISPLAY → wl-copy) vs X11 (DISPLAY → xclip), verifies tool availability at init, and pipes text via subprocess without adding trailing newlines. Created `voxcode/tests/test_clipboard_bridge.py` with 12 passing tests covering detection logic, error cases, and command construction.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/lince-1.3 - Add-dual-PTT-key-support-Space-for-pane-Tab-for-clipboard.md
+++ b/backlog/tasks/lince-1.3 - Add-dual-PTT-key-support-Space-for-pane-Tab-for-clipboard.md
@@ -1,10 +1,10 @@
 ---
 id: LINCE-1.3
 title: 'Add dual PTT key support: Space for pane, Tab for clipboard'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-03-03 10:35'
-updated_date: '2026-03-03 10:36'
+updated_date: '2026-03-05 17:52'
 labels:
   - voxcode
   - feature
@@ -73,15 +73,15 @@ Tab toggle   → ptt_active + target=clipboard → accumulate → transcribe →
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Space toggles PTT recording and routes transcription to multiplexer pane (existing behavior preserved)
-- [ ] #2 Tab toggles PTT recording and routes transcription to system clipboard
-- [ ] #3 Only one PTT session can be active at a time (pressing Tab while Space-PTT is active is ignored, and vice versa)
-- [ ] #4 UI shows recording target during PTT: "recording → pane" or "recording → clipboard"
-- [ ] #5 config.ptt.key is actually read from config and used (fixing current bug where Space is hardcoded)
-- [ ] #6 config.ptt.clipboard_key is configurable with default "tab"
-- [ ] #7 Both keys work as toggles: first press starts recording, second press stops and routes
-- [ ] #8 When clipboard PTT completes, a brief UI confirmation shows the text was copied
-- [ ] #9 VAD mode is unaffected by these changes (dual-key only applies in PTT mode)
+- [x] #1 Space toggles PTT recording and routes transcription to multiplexer pane (existing behavior preserved)
+- [x] #2 Tab toggles PTT recording and routes transcription to system clipboard
+- [x] #3 Only one PTT session can be active at a time (pressing Tab while Space-PTT is active is ignored, and vice versa)
+- [x] #4 UI shows recording target during PTT: "recording → pane" or "recording → clipboard"
+- [x] #5 config.ptt.key is actually read from config and used (fixing current bug where Space is hardcoded)
+- [x] #6 config.ptt.clipboard_key is configurable with default "tab"
+- [x] #7 Both keys work as toggles: first press starts recording, second press stops and routes
+- [x] #8 When clipboard PTT completes, a brief UI confirmation shows the text was copied
+- [x] #9 VAD mode is unaffected by these changes (dual-key only applies in PTT mode)
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -156,3 +156,9 @@ clipboard_key = "tab"   # PTT key for copying to clipboard
 
 ### Estimated effort: Medium-Large (2-4 hours)
 <!-- SECTION:PLAN:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented dual PTT key support: Space→pane, Tab→clipboard. Added `clipboard_key: str = "tab"` to PTTConfig. Added `_KEY_MAP` for symbolic→char resolution (fixing the config.ptt.key bug). Added `ptt_target` field to VoxCode and VoxCodeUI. ClipboardBridge initialized at startup with graceful fallback if unavailable. `_handle_key` uses config-driven key chars with mutual-exclusion guard. Transcription routed in `_check_results` based on `ptt_target`. Added `_send_to_clipboard` method. UI shows "recording → pane" / "recording → clipboard" and updated keybindings hint. VAD mode unaffected.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/voxcode/config.toml
+++ b/voxcode/config.toml
@@ -1,5 +1,5 @@
 [general]
-mode = "vad"              # "vad" (continuous listening) | "ptt" (push-to-talk)
+# mode = "ptt"            # "ptt" (default, push-to-talk) | "vad" (continuous listening)
 language = "auto"         # "auto" | "it" | "en"
 auto_send = true         # true = send immediately after transcription, false = wait for confirm
 
@@ -14,7 +14,8 @@ silence_duration = 1.5    # seconds of silence before ending speech segment
 pre_roll = 0.3            # seconds of audio to keep before speech onset
 
 [ptt]
-key = "space"             # key for push-to-talk toggle
+key = "space"             # PTT key for sending to multiplexer pane
+clipboard_key = "tab"     # PTT key for copying to clipboard
 
 [commands]
 enabled = true            # enable voice commands

--- a/voxcode/src/voxcode/cli.py
+++ b/voxcode/src/voxcode/cli.py
@@ -11,12 +11,19 @@ import tty
 import numpy as np
 
 from voxcode.audio import AudioCapture
+from voxcode.clipboard_bridge import ClipboardBridge
 from voxcode.commands import CommandType, parse_transcription
 from voxcode.config import VoxCodeConfig, load_config
 from voxcode.multiplexer import create_bridge
 from voxcode.transcriber import TranscriptionResult, Transcriber
 from voxcode.ui import VoxCodeUI
 from voxcode.vad import EnergyVAD, VADState
+
+_KEY_MAP: dict[str, str] = {
+    "space": " ",
+    "tab": "\t",
+    "enter": "\n",
+}
 
 
 class VoxCode:
@@ -28,6 +35,10 @@ class VoxCode:
         self.paused = False
         self.buffer = ""
         self.ptt_active = False
+        self.ptt_target: str | None = None  # "pane" or "clipboard"
+
+        self._ptt_key_char = _KEY_MAP.get(config.ptt.key, config.ptt.key)
+        self._ptt_clipboard_key_char = _KEY_MAP.get(config.ptt.clipboard_key, config.ptt.clipboard_key)
 
         self._result_queue: queue.Queue[TranscriptionResult] = queue.Queue()
         self._transcription_queue: queue.Queue[np.ndarray] = queue.Queue()
@@ -46,6 +57,12 @@ class VoxCode:
         )
         self.bridge = create_bridge(config)
         self.ui = VoxCodeUI()
+
+        try:
+            self.clipboard_bridge: ClipboardBridge | None = ClipboardBridge()
+        except RuntimeError as e:
+            self.clipboard_bridge = None
+            # Warning shown after UI starts via print_message
 
     def run(self):
         if not self._validate_environment():
@@ -188,13 +205,29 @@ class VoxCode:
         elif key == "c":
             self.buffer = ""
             self.ui.update(buffer="")
-        elif key == " " and self.config.general.mode == "ptt":
+        elif key == self._ptt_key_char and self.config.general.mode == "ptt":
+            if self.ptt_active and self.ptt_target != "pane":
+                return  # different PTT key is active, ignore
             self.ptt_active = not self.ptt_active
             if self.ptt_active:
+                self.ptt_target = "pane"
                 ptt_frames.clear()
-                self.ui.update(status="recording", ptt_active=True)
+                self.ui.update(status="recording", ptt_active=True, ptt_target="pane")
             else:
-                self.ui.update(ptt_active=False)
+                self.ui.update(ptt_active=False, ptt_target=None)
+        elif key == self._ptt_clipboard_key_char and self.config.general.mode == "ptt":
+            if self.clipboard_bridge is None:
+                self.ui.print_message("[yellow]Clipboard unavailable — no wl-copy or xclip found.[/]")
+                return
+            if self.ptt_active and self.ptt_target != "clipboard":
+                return  # different PTT key is active, ignore
+            self.ptt_active = not self.ptt_active
+            if self.ptt_active:
+                self.ptt_target = "clipboard"
+                ptt_frames.clear()
+                self.ui.update(status="recording", ptt_active=True, ptt_target="clipboard")
+            else:
+                self.ui.update(ptt_active=False, ptt_target=None)
 
     def _transcription_worker(self):
         while self.running:
@@ -228,6 +261,8 @@ class VoxCode:
 
         if parsed.is_command:
             self._handle_command(parsed.command)
+        elif self.ptt_target == "clipboard":
+            self._send_to_clipboard(parsed.text)
         else:
             self.buffer += (" " if self.buffer else "") + parsed.text
             self.ui.update(buffer=self.buffer, status="listening")
@@ -261,6 +296,18 @@ class VoxCode:
             self.ui.print_message(f"[red]Send failed: {e}[/]")
 
         self.buffer = ""
+
+    def _send_to_clipboard(self, text: str):
+        self.ptt_target = None
+        text = text.strip()
+        if not text or self.clipboard_bridge is None:
+            return
+
+        try:
+            self.clipboard_bridge.send_text(text)
+            self.ui.update(last_sent=f"[clipboard] {text}", status="listening")
+        except Exception as e:
+            self.ui.print_message(f"[red]Clipboard send failed: {e}[/]")
 
 
 

--- a/voxcode/src/voxcode/clipboard_bridge.py
+++ b/voxcode/src/voxcode/clipboard_bridge.py
@@ -1,0 +1,47 @@
+"""Clipboard output backend using wl-copy (Wayland) or xclip (X11)."""
+
+import os
+import shutil
+import subprocess
+
+
+class ClipboardBridge:
+    """Copy transcribed text to the system clipboard.
+
+    Detects Wayland vs X11 from environment variables and uses the appropriate tool.
+    """
+
+    def __init__(self) -> None:
+        wayland = os.environ.get("WAYLAND_DISPLAY")
+        display = os.environ.get("DISPLAY")
+
+        if wayland:
+            self._backend = "wl-copy"
+            if not shutil.which("wl-copy"):
+                raise RuntimeError(
+                    "wl-copy not found. Install with: sudo dnf install wl-clipboard  "
+                    "(or: sudo apt install wl-clipboard)"
+                )
+        elif display:
+            self._backend = "xclip"
+            if not shutil.which("xclip"):
+                raise RuntimeError(
+                    "xclip not found. Install with: sudo dnf install xclip  "
+                    "(or: sudo apt install xclip)"
+                )
+        else:
+            raise RuntimeError(
+                "No display server detected (WAYLAND_DISPLAY and DISPLAY are both unset). "
+                "Clipboard output requires a running Wayland or X11 session."
+            )
+
+    def send_text(self, text: str) -> None:
+        """Copy text to the system clipboard."""
+        if self._backend == "wl-copy":
+            subprocess.run(["wl-copy", "--", text], check=True)
+        else:
+            subprocess.run(
+                ["xclip", "-selection", "clipboard"],
+                input=text.encode(),
+                check=True,
+            )

--- a/voxcode/src/voxcode/config.py
+++ b/voxcode/src/voxcode/config.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 @dataclass
 class GeneralConfig:
-    mode: str = "vad"
+    mode: str = "ptt"
     language: str = "auto"
     auto_send: bool = False
 
@@ -29,6 +29,7 @@ class VADConfig:
 @dataclass
 class PTTConfig:
     key: str = "space"
+    clipboard_key: str = "tab"
 
 
 @dataclass

--- a/voxcode/src/voxcode/ui.py
+++ b/voxcode/src/voxcode/ui.py
@@ -29,6 +29,7 @@ class VoxCodeUI:
         self.last_sent: str = ""
         self.detected_language: str = ""
         self.ptt_active: bool = False
+        self.ptt_target: str | None = None  # "pane" or "clipboard"
         self.target_pane: str = ""
         self._live: Live | None = None
 
@@ -40,7 +41,11 @@ class VoxCodeUI:
         # Mode
         mode_icon = "VAD" if self.mode == "vad" else "PTT"
         style, label = STATUS_STYLES.get(self.status, ("white", self.status.upper()))
-        table.add_row(f"Mode:", f"{mode_icon}  [{style}]{label}[/]")
+        if self.ptt_active and self.ptt_target:
+            target_label = "→ pane" if self.ptt_target == "pane" else "→ clipboard"
+            table.add_row("Mode:", f"{mode_icon}  [{style}]{label} {target_label}[/]")
+        else:
+            table.add_row("Mode:", f"{mode_icon}  [{style}]{label}[/]")
 
         # Audio level bar
         bar_len = 35
@@ -69,7 +74,7 @@ class VoxCodeUI:
 
         # Keybindings help
         if self.mode == "ptt":
-            keys = "[dim][Space] record  [Enter] send  [c] clear  [q] quit[/]"
+            keys = "[dim][Space] record→pane  [Tab] record→clipboard  [Enter] send  [c] clear  [q] quit[/]"
         else:
             keys = "[dim][Enter] send  [c] clear  [q] quit  | voice: comando:invia/cancella/pausa[/]"
         table.add_row("Keys:", keys)

--- a/voxcode/tests/test_clipboard_bridge.py
+++ b/voxcode/tests/test_clipboard_bridge.py
@@ -1,0 +1,106 @@
+"""Tests for ClipboardBridge."""
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from voxcode.clipboard_bridge import ClipboardBridge
+
+
+class TestClipboardBridgeInit:
+    def test_wayland_detection(self):
+        with (
+            patch.dict("os.environ", {"WAYLAND_DISPLAY": "wayland-0"}, clear=False),
+            patch("shutil.which", return_value="/usr/bin/wl-copy"),
+        ):
+            bridge = ClipboardBridge()
+            assert bridge._backend == "wl-copy"
+
+    def test_x11_detection_no_wayland(self):
+        env = {"DISPLAY": ":0"}
+        # Ensure WAYLAND_DISPLAY is absent
+        with (
+            patch.dict("os.environ", env, clear=True),
+            patch("shutil.which", return_value="/usr/bin/xclip"),
+        ):
+            bridge = ClipboardBridge()
+            assert bridge._backend == "xclip"
+
+    def test_wayland_takes_priority_over_x11(self):
+        env = {"WAYLAND_DISPLAY": "wayland-0", "DISPLAY": ":0"}
+        with (
+            patch.dict("os.environ", env, clear=True),
+            patch("shutil.which", return_value="/usr/bin/wl-copy"),
+        ):
+            bridge = ClipboardBridge()
+            assert bridge._backend == "wl-copy"
+
+    def test_no_display_raises(self):
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(RuntimeError, match="No display server detected"):
+                ClipboardBridge()
+
+    def test_wl_copy_missing_raises(self):
+        with (
+            patch.dict("os.environ", {"WAYLAND_DISPLAY": "wayland-0"}, clear=True),
+            patch("shutil.which", return_value=None),
+        ):
+            with pytest.raises(RuntimeError, match="wl-copy not found"):
+                ClipboardBridge()
+
+    def test_xclip_missing_raises(self):
+        with (
+            patch.dict("os.environ", {"DISPLAY": ":0"}, clear=True),
+            patch("shutil.which", return_value=None),
+        ):
+            with pytest.raises(RuntimeError, match="xclip not found"):
+                ClipboardBridge()
+
+
+class TestClipboardBridgeSendText:
+    def _make_bridge(self, backend: str) -> ClipboardBridge:
+        bridge = ClipboardBridge.__new__(ClipboardBridge)
+        bridge._backend = backend
+        return bridge
+
+    def test_wl_copy_command(self):
+        bridge = self._make_bridge("wl-copy")
+        with patch("subprocess.run") as mock_run:
+            bridge.send_text("hello world")
+            mock_run.assert_called_once_with(["wl-copy", "--", "hello world"], check=True)
+
+    def test_wl_copy_text_starting_with_dash(self):
+        bridge = self._make_bridge("wl-copy")
+        with patch("subprocess.run") as mock_run:
+            bridge.send_text("-dangerous flag")
+            mock_run.assert_called_once_with(["wl-copy", "--", "-dangerous flag"], check=True)
+
+    def test_xclip_command(self):
+        bridge = self._make_bridge("xclip")
+        with patch("subprocess.run") as mock_run:
+            bridge.send_text("hello world")
+            mock_run.assert_called_once_with(
+                ["xclip", "-selection", "clipboard"],
+                input=b"hello world",
+                check=True,
+            )
+
+    def test_no_trailing_newline_added_wl_copy(self):
+        bridge = self._make_bridge("wl-copy")
+        with patch("subprocess.run") as mock_run:
+            bridge.send_text("text without newline")
+            args = mock_run.call_args[0][0]
+            assert args[-1] == "text without newline"
+
+    def test_no_trailing_newline_added_xclip(self):
+        bridge = self._make_bridge("xclip")
+        with patch("subprocess.run") as mock_run:
+            bridge.send_text("text without newline")
+            assert mock_run.call_args[1]["input"] == b"text without newline"
+
+    def test_existing_newline_preserved_xclip(self):
+        bridge = self._make_bridge("xclip")
+        with patch("subprocess.run") as mock_run:
+            bridge.send_text("line\n")
+            assert mock_run.call_args[1]["input"] == b"line\n"


### PR DESCRIPTION
- Make PTT the default mode (GeneralConfig.mode: "vad" → "ptt")
- Add ClipboardBridge: auto-detects wl-copy (Wayland) or xclip (X11), raises descriptive error if tool missing, pipes text without trailing newline
- Dual PTT key: Space → multiplexer pane, Tab → system clipboard
  - config.ptt.key and config.ptt.clipboard_key drive key resolution (fixing the existing bug where Space was hardcoded regardless of config)
  - ptt_target tracks routing; mutual exclusion prevents overlapping sessions
  - UI shows "RECORDING → pane" / "RECORDING → clipboard" during active PTT
  - last_sent prefixed with "[clipboard]" on clipboard send
  - ClipboardBridge initialized at startup with graceful fallback if unavailable
- Update config.toml: mode line commented out, clipboard_key documented
- Add 12 unit tests for ClipboardBridge (tests/test_clipboard_bridge.py)

Closes LINCE-1, LINCE-1.1, LINCE-1.2, LINCE-1.3