### PR TITLE
feat(dashboard): show exit code when agent pane stops

### DIFF
--- a/lince-dashboard/plugin/src/agent.rs
+++ b/lince-dashboard/plugin/src/agent.rs
@@ -194,6 +194,7 @@ fn spawn_inner(
         current_tool: None,
         started_at: if started_at > 0 { Some(started_at) } else { None },
         last_error: None,
+        exit_code: None,
         group,
         running_subagents: 0,
         model: None,
@@ -264,9 +265,12 @@ pub fn reconcile_panes(
             if !all_pane_ids.contains(&pid) {
                 agent.status = AgentStatus::Stopped;
                 agent.pane_id = None;
+                agent.exit_code = None;
                 changed = true;
             } else if let Some(pane) = all_panes.iter().find(|p| p.id == pid) {
                 if pane.exited && agent.status != AgentStatus::Stopped {
+                    agent.exit_code = pane.exit_status;
+                    agent.last_error = pane.exit_status.filter(|&c| c != 0).map(|c| format!("Process exited with code {c}"));
                     agent.status = AgentStatus::Stopped;
                     changed = true;
                 }

--- a/lince-dashboard/plugin/src/dashboard.rs
+++ b/lince-dashboard/plugin/src/dashboard.rs
@@ -353,14 +353,7 @@ fn render_agent_table(
                 let is_focused = focused.map_or(false, |f| f == agent.id);
                 let prefix = if is_focused { ">" } else { " " };
                 let idx_str = format!("{}", agent_idx + 1);
-                let status_label = if agent.status == AgentStatus::Stopped {
-                    match agent.exit_code {
-                        Some(code) => format!("Stopped ({code})"),
-                        None => "Stopped".to_string(),
-                    }
-                } else {
-                    agent.status.label().to_string()
-                };
+                let status_label = agent.status_display();
                 let status_color = agent.status.color();
                 let subagent_suffix = if agent.running_subagents > 0 {
                     format!(" \x1b[36m{}⚙", agent.running_subagents)
@@ -489,14 +482,7 @@ fn render_detail_panel(agent: &AgentInfo, cols: usize, max_rows: usize, agent_ty
             } else {
                 (agent.agent_type.as_str(), RESET, String::new())
             };
-        let detail_status = if agent.status == AgentStatus::Stopped {
-            match agent.exit_code {
-                Some(code) => format!("Stopped ({code})"),
-                None => "Stopped".to_string(),
-            }
-        } else {
-            agent.status.label().to_string()
-        };
+        let detail_status = agent.status_display();
         println!(
             " {}Agent:{} {}  {}{}{}{} {}{}{}",
             CYAN, RESET, agent.name,

--- a/lince-dashboard/plugin/src/dashboard.rs
+++ b/lince-dashboard/plugin/src/dashboard.rs
@@ -353,7 +353,14 @@ fn render_agent_table(
                 let is_focused = focused.map_or(false, |f| f == agent.id);
                 let prefix = if is_focused { ">" } else { " " };
                 let idx_str = format!("{}", agent_idx + 1);
-                let status_label = agent.status.label();
+                let status_label = if agent.status == AgentStatus::Stopped {
+                    match agent.exit_code {
+                        Some(code) => format!("Stopped ({code})"),
+                        None => "Stopped".to_string(),
+                    }
+                } else {
+                    agent.status.label().to_string()
+                };
                 let status_color = agent.status.color();
                 let subagent_suffix = if agent.running_subagents > 0 {
                     format!(" \x1b[36m{}⚙", agent.running_subagents)
@@ -406,7 +413,7 @@ fn render_agent_table(
                         prefix, pad_left(&idx_str, col_idx), type_col,
                         pad_left(&agent.name, col_name),
                     );
-                    let status_str = pad_left(status_label, col_status);
+                    let status_str = pad_left(&status_label, col_status);
                     let trailing = format!(" {}{}", sandbox_col, profile_col);
                     let main_visible = strip_ansi_len(&main_part);
                     let suffix_visible_len = strip_ansi_len(&subagent_suffix);
@@ -441,7 +448,7 @@ fn render_agent_table(
                         "{}{}{} {} {}{}{}{}{} {}{}",
                         prefix, pad_left(&idx_str, col_idx), type_col, name_field,
                         status_color, if needs_attention { BOLD } else { "" },
-                        pad_left(status_label, col_status), subagent_suffix, RESET,
+                        pad_left(&status_label, col_status), subagent_suffix, RESET,
                         sandbox_col, profile_col,
                     );
                     println!("{}", truncate(&line, cols));
@@ -482,11 +489,19 @@ fn render_detail_panel(agent: &AgentInfo, cols: usize, max_rows: usize, agent_ty
             } else {
                 (agent.agent_type.as_str(), RESET, String::new())
             };
+        let detail_status = if agent.status == AgentStatus::Stopped {
+            match agent.exit_code {
+                Some(code) => format!("Stopped ({code})"),
+                None => "Stopped".to_string(),
+            }
+        } else {
+            agent.status.label().to_string()
+        };
         println!(
             " {}Agent:{} {}  {}{}{}{} {}{}{}",
             CYAN, RESET, agent.name,
             type_color, type_display, RESET, sandbox_info,
-            agent.status.color(), agent.status.label(), RESET,
+            agent.status.color(), detail_status, RESET,
         );
         row += 1;
     }

--- a/lince-dashboard/plugin/src/types.rs
+++ b/lince-dashboard/plugin/src/types.rs
@@ -207,6 +207,18 @@ impl AgentInfo {
             self.running_subagents = 0;
         }
     }
+
+    /// Status label with exit code annotation for stopped agents.
+    pub fn status_display(&self) -> String {
+        if self.status == AgentStatus::Stopped {
+            match self.exit_code {
+                Some(code) => format!("Stopped ({code})"),
+                None => "Stopped".to_string(),
+            }
+        } else {
+            self.status.label().to_string()
+        }
+    }
 }
 
 // ── Save/Restore Types ───────────────────────────────────────────────

--- a/lince-dashboard/plugin/src/types.rs
+++ b/lince-dashboard/plugin/src/types.rs
@@ -185,6 +185,7 @@ pub struct AgentInfo {
     pub current_tool: Option<String>,
     pub started_at: Option<u64>,
     pub last_error: Option<String>,
+    pub exit_code: Option<i32>,
     pub group: Option<String>,
     pub running_subagents: u32,
     pub model: Option<String>,


### PR DESCRIPTION
## Summary

Closes #35

- Capture `PaneInfo.exit_status` from Zellij when an agent pane exits and display it alongside the "Stopped" status (e.g., "Stopped (127)")
- Non-zero exit codes also populate the red "Error:" row in the detail panel ("Process exited with code N")
- Extracted `AgentInfo::status_display()` to keep formatting logic in one place

## Test plan

- [ ] Spawn a sandboxed agent that succeeds → status shows "Running" normally
- [ ] Force a failure (e.g., point agent command at a nonexistent binary) → status shows "Stopped (127)" in list view and detail panel
- [ ] Stop a running agent normally (exit 0) → status shows "Stopped (0)" without a red error row
- [ ] Pane disappears entirely (e.g., killed externally) → status shows "Stopped" (no exit code, pane is gone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)