### PR TITLE
dashboard: enable Ctrl+Shift+C copy with auto-detected clipboard backend

### DIFF
--- a/lince-dashboard/install.sh
+++ b/lince-dashboard/install.sh
@@ -20,6 +20,63 @@ confirm() {
     [[ $REPLY =~ ^[Yy]$ ]]
 }
 
+# Detect clipboard backend (X11/Wayland/macOS) and uncomment the matching
+# copy_command line in the installed Zellij config so Ctrl+Shift+C reaches
+# the system clipboard even when the host terminal lacks OSC 52 support.
+# Idempotent: re-running leaves an already-uncommented line untouched.
+setup_clipboard_backend() {
+    local config="$1"
+    local os_name backend cmd_name pkg_hint install_hint
+    os_name="$(uname -s)"
+
+    if [ "$os_name" = "Darwin" ]; then
+        backend="macOS"
+        cmd_name="pbcopy"
+        pkg_hint=""
+        install_hint=""
+    elif [ -n "${WAYLAND_DISPLAY:-}" ] || [ "${XDG_SESSION_TYPE:-}" = "wayland" ]; then
+        backend="Wayland"
+        cmd_name="wl-copy"
+        pkg_hint="wl-clipboard"
+    else
+        backend="X11"
+        cmd_name="xclip"
+        pkg_hint="xclip"
+    fi
+
+    echo -e "${GREEN}  Clipboard backend: $backend ($cmd_name)${NC}"
+
+    if [ -n "$pkg_hint" ] && ! command -v "$cmd_name" >/dev/null 2>&1; then
+        if command -v apt-get >/dev/null 2>&1; then
+            install_hint="sudo apt-get install $pkg_hint"
+        elif command -v dnf >/dev/null 2>&1; then
+            install_hint="sudo dnf install $pkg_hint"
+        elif command -v pacman >/dev/null 2>&1; then
+            install_hint="sudo pacman -S $pkg_hint"
+        elif command -v zypper >/dev/null 2>&1; then
+            install_hint="sudo zypper install $pkg_hint"
+        else
+            install_hint="install '$pkg_hint' via your package manager"
+        fi
+        echo -e "${YELLOW}  ⚠ '$cmd_name' not found — copy will rely on terminal OSC 52.${NC}"
+        echo -e "${YELLOW}    For reliable copy: $install_hint${NC}"
+    fi
+
+    case "$cmd_name" in
+        xclip)
+            sed -i.bak -E 's|^// (copy_command "xclip[^"]*"[[:space:]]*// x11)$|\1|' "$config"
+            ;;
+        wl-copy)
+            sed -i.bak -E 's|^// (copy_command "wl-copy"[[:space:]]*// wayland)$|\1|' "$config"
+            ;;
+        pbcopy)
+            sed -i.bak -E 's|^// (copy_command "pbcopy"[[:space:]]*// osx)$|\1|' "$config"
+            ;;
+    esac
+    rm -f "${config}.bak"
+    echo -e "${GREEN}  ✓ copy_command set for $backend${NC}"
+}
+
 # ── Step 1: Prerequisites ─────────────────────────────────────────────
 echo -e "${GREEN}[1/12] Checking prerequisites...${NC}"
 
@@ -170,6 +227,7 @@ if [ -f "$LINCE_ZELLIJ_CONFIG" ]; then
             echo -e "${GREEN}  ✓ Backup: $BACKUP${NC}"
             cp "$LINCE_ZELLIJ_CONFIG" "$ZELLIJ_CONFIG"
             echo -e "${GREEN}  ✓ LINCE keybindings installed${NC}"
+            setup_clipboard_backend "$ZELLIJ_CONFIG"
         else
             echo -e "${YELLOW}  Skipped — keeping your existing config${NC}"
             echo -e "${YELLOW}  Note: some keybindings may conflict with AI coding agents${NC}"
@@ -180,6 +238,7 @@ if [ -f "$LINCE_ZELLIJ_CONFIG" ]; then
             mkdir -p "$(dirname "$ZELLIJ_CONFIG")"
             cp "$LINCE_ZELLIJ_CONFIG" "$ZELLIJ_CONFIG"
             echo -e "${GREEN}  ✓ LINCE keybindings installed${NC}"
+            setup_clipboard_backend "$ZELLIJ_CONFIG"
         else
             echo -e "${YELLOW}  Skipped${NC}"
         fi

--- a/lince-dashboard/zellij-config/config.kdl
+++ b/lince-dashboard/zellij-config/config.kdl
@@ -155,6 +155,7 @@ keybinds clear-defaults=true {
         bind "Alt p" { TogglePaneInGroup; }
         bind "Alt Shift p" { ToggleGroupMarking; }
         bind "Ctrl q" { Quit; }
+        bind "Ctrl Shift c" { Copy; }
     }
     shared_except "locked" "move" {
         bind "Ctrl h" { SwitchToMode "move"; }


### PR DESCRIPTION
Fixes #43. Adds a Ctrl+Shift+C keybind to the LINCE Zellij config that fires the Copy action across all non-locked modes. install.sh now auto-detects the display server (X11 / Wayland / macOS), warns if the matching clipboard tool is missing with a distro-specific install hint, and uncomments the right copy_command line in the installed config so copies reach the system clipboard even on terminals without OSC 52. Paste (Ctrl+Shift+V) is handled by the host terminal emulator and needs no Zellij binding.