### PR TITLE
dashboard: three-level sandbox per agent (paranoid/normal/permissive) — claude prototype

### DIFF
--- a/backlog/tasks/lince-100 - Three-sandbox-levels-—-gemini-follow-up.md
+++ b/backlog/tasks/lince-100 - Three-sandbox-levels-—-gemini-follow-up.md
@@ -1,0 +1,102 @@
+---
+id: LINCE-100
+title: Three sandbox levels — gemini follow-up
+status: To Do
+assignee: []
+created_date: '2026-05-04 20:32'
+updated_date: '2026-05-04 20:50'
+labels:
+  - sandbox
+  - lince-dashboard
+  - follow-up
+milestone: m-13
+dependencies:
+  - LINCE-98
+references:
+  - 'https://github.com/RisorseArtificiali/lince/issues/50'
+  - 'https://github.com/RisorseArtificiali/lince/issues/47'
+  - 'https://github.com/RisorseArtificiali/lince/issues/48'
+  - lince-dashboard/agents-defaults.toml
+  - lince-dashboard/nono-profiles/lince-gemini.json
+documentation:
+  - 'https://nono.sh/docs/cli/features/networking.md'
+  - 'https://nono.sh/docs/cli/features/credential-injection.md'
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Scope
+
+Apply the three-level sandbox model to **gemini**, following the pattern established in lince-98 (GH [#48](https://github.com/RisorseArtificiali/lince/issues/48)).
+
+Tracks GH issue [#50](https://github.com/RisorseArtificiali/lince/issues/50). Umbrella: [#47](https://github.com/RisorseArtificiali/lince/issues/47).
+
+> **Do not start until lince-98 is done.** Reuse the runtime dispatch logic and sandbox-policy mechanism from the claude prototype.
+
+## Background — full design context (no need to re-brainstorm)
+
+LINCE today exposes `[agents.gemini]` (unsandboxed), `[agents.gemini-bwrap]`, `[agents.gemini-nono]` as separate entries. Collapse to a **single** `[agents.gemini]` with `sandbox_level` + `sandbox_backend`, alternative levels as commented templates.
+
+LLM provider for proxy/credential injection: **gemini** (nono keystore account: `gemini_api_key`).
+
+## Gemini-specific notes
+
+- `disable_inner_sandbox_args = []` — no internal sandbox conflict
+- env var: `GEMINI_API_KEY` (passthrough today; in paranoid → injected by proxy)
+- **Verify during execution**: gemini CLI may require Google OAuth domains (accounts.google.com, oauth2.googleapis.com) if user is logged in via OAuth instead of API key. Check actual auth flow with debug logging or strace.
+
+## Three levels — gemini specifics
+
+| | paranoid | normal | permissive |
+|---|---|---|---|
+| nono `network` | `credentials: ["gemini"]` (verify if Google OAuth domains needed) | inherited | + `allow_domain` (github + objects) + `credentials: ["gemini"]` |
+| nono `filesystem` | `$WORKDIR` rw + scratch copy of `~/.gemini` | as today (`lince-gemini.json`) | + `~/.config/gh`, `~/.cache`, `~/.ssh/known_hosts` (read) |
+| bwrap | `use_real_config = false` forced + no-network | as today | + standard permissive paths |
+| Tools | — | — | `gh` CLI (no docker, no podman, no `git push`) |
+
+## File touch list
+
+**New:**
+- `lince-dashboard/nono-profiles/lince-gemini-paranoid.json`
+- `lince-dashboard/nono-profiles/lince-gemini-permissive.json`
+- `sandbox/profiles/gemini-paranoid.toml`
+- `sandbox/profiles/gemini-permissive.toml`
+
+**Modified:**
+- `lince-dashboard/agents-defaults.toml` — collapse gemini entries (~lines 72-101 + 166-182)
+- `lince-dashboard/install.sh` — copy new nono profiles
+
+## Decision point during execution
+
+If Gemini OAuth requires additional Google domains:
+- Document them in profile comment
+- Add to permissive `allow_domain`
+- For paranoid: decide whether to allow OAuth refresh (more network) or require pre-existing token (more lockdown). Document the trade-off.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 agents-defaults.toml has a single [agents.gemini] with sandbox_level/sandbox_backend; gemini-nono removed
+- [ ] #2 GEMINI_API_KEY: passthrough in normal/permissive, proxy-injected in paranoid
+- [ ] #3 sandbox_level=paranoid on nono: only Gemini API endpoints reachable; arbitrary outbound fails
+- [ ] #4 sandbox_level=permissive: gh auth + gh pr work; docker ps fails
+- [ ] #5 N-picker shows 'Google Gemini CLI' once
+- [ ] #6 OAuth flow behavior documented for paranoid (allow refresh or require pre-existing token)
+- [ ] #7 Master doc page extended with gemini-specific rows and OAuth trade-off explanation for paranoid (allow refresh vs. require pre-existing token)
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+## Documentation contribution
+
+Master doc page (created by lince-98) already covers the overall mechanism. This task **extends** it with **gemini-specific rows/notes**:
+- Add gemini row to the level-comparison table
+- Document GEMINI_API_KEY proxy injection in paranoid
+- **Document the OAuth decision** made during execution: whether paranoid allows Google OAuth domains (accounts.google.com, oauth2.googleapis.com) for token refresh, or requires pre-existing token. Include the trade-off explanation.
+- Brief note on common custom-profile patterns for gemini (e.g. Vertex AI users)
+
+Do **not** re-explain the overall mechanism.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/lince-100 - Three-sandbox-levels-—-gemini-follow-up.md
+++ b/backlog/tasks/lince-100 - Three-sandbox-levels-—-gemini-follow-up.md
@@ -4,7 +4,7 @@ title: Three sandbox levels — gemini follow-up
 status: To Do
 assignee: []
 created_date: '2026-05-04 20:32'
-updated_date: '2026-05-04 20:50'
+updated_date: '2026-05-05 13:40'
 labels:
   - sandbox
   - lince-dashboard
@@ -99,4 +99,71 @@ Master doc page (created by lince-98) already covers the overall mechanism. This
 - Brief note on common custom-profile patterns for gemini (e.g. Vertex AI users)
 
 Do **not** re-explain the overall mechanism.
+
+## Lessons from lince-98 (don't repeat the bugs we already hit)
+
+The claude prototype landed via PR #57. Capturing the operational gotchas here so gemini doesn't redo them.
+
+### Required for gemini (per-agent work)
+
+1. **Auto-map the API key in `sandbox/profiles/gemini-paranoid.toml`'s `[env.extra]`.**
+   Without this, the credential proxy starts with zero rules and paranoid bails out with `unshare_net = true requires credential_proxy = true` (the message blames the wrong knob — it's actually "proxy enabled but no API keys found"). Pattern:
+   ```toml
+   [env.extra]
+   GEMINI_API_KEY = "$GEMINI_API_KEY"
+   GOOGLE_API_KEY = "$GOOGLE_API_KEY"
+   ```
+   Both forms get a credential rule entry mapping to `generativelanguage.googleapis.com` (see `CREDENTIAL_PROXY_RULES` ~line 238). `_collect_proxy_rules` skips empties, so unset vars are silently dropped — safe to map both even if the user only has one.
+
+2. **OAuth-only users are a special case.** If the user authenticates Gemini via Google OAuth (browser flow) instead of API key, the host env has no `GEMINI_API_KEY` set and the rule collector returns empty. The user's `gh auth status`-equivalent for gemini is via `~/.gemini/`, which the fragment bind-mounts read-only — but for **paranoid** the scratch copy isolates that, AND the OAuth refresh endpoint is on `oauth2.googleapis.com` (not in the credential rule). Two options:
+   - (a) Document that gemini paranoid requires API key auth; OAuth-authenticated users should use normal/permissive.
+   - (b) Extend the credential rule table to allow `oauth2.googleapis.com` and `accounts.google.com` for paranoid via `[security].allow_domains`. This loosens paranoid for one agent in a way that's hard to reverse. (a) is cleaner.
+   Either way, document the decision in the master doc and in the fragment header.
+
+3. **Add a gemini match arm in `synthesize_sandboxed_command`** in `lince-dashboard/plugin/src/agent.rs`:
+   - `agent_home_subdir`: `.gemini`
+   - `inner_command`: `vec!["gemini".to_string()]`
+   No internal sandbox conflict to handle (`disable_inner_sandbox_args = []` in current `[agents.gemini-bwrap]`), so the codex-style hardcode-or-pass-agent_cfg dilemma doesn't apply to gemini. Just add the arm.
+
+4. **Permissive must passthrough `GH_TOKEN` / `GITHUB_TOKEN`** — copy from `claude-permissive.toml`. Same reasoning as claude: keyring-auth users rely on the env path.
+
+5. **Do NOT enumerate `allow_domains = ["generativelanguage.googleapis.com"]`** in the paranoid fragment. `_is_allowed_host` auto-includes credential-rule domains. Ship `allow_domains = []` with the header comment pattern from `claude-paranoid.toml`.
+
+### Things ALREADY in master code (don't redo them)
+
+- Fragment lookup tries `<agent>-<level>.toml` before `<level>.toml` — `gemini-paranoid.toml` is found automatically.
+- bwrap `--unshare-net` setup, outer `unshare -U -n -r` wrapper, socat bridge, `--uid <real_uid>` remap.
+- Stale unix-socket cleanup at startup.
+- CredentialProxy framing (Connection: close, no duplicate headers, BrokenPipe-safe).
+- socat readiness fail-fast.
+- shell_quote in the bash wrapper.
+
+### Sanity checks before declaring done
+
+```bash
+agent-sandbox run -a gemini --sandbox-level paranoid -- bash
+
+# 1. Scratch copy of ~/.gemini
+ls -la ~/.gemini/   # scratch contents, not your real ~/.gemini
+
+# 2. Kernel-level network isolation
+curl -s https://attacker.com 2>&1   # must fail at netns level (no route / DNS error)
+
+# 3. Gemini API works through the proxy
+curl -s -x http://127.0.0.1:8118 \
+  https://generativelanguage.googleapis.com/v1beta/models | head
+
+# 4. OAuth flow: document the decision (allow refresh URL via allow_domains, OR
+#    document that paranoid requires API-key auth and OAuth users should use
+#    normal/permissive)
+
+# 5. Confirm no socat / socket leak on stop (same as claude)
+pgrep -af 'socat.*8118'
+ls ~/.agent-sandbox/proxy-*.sock 2>/dev/null
+```
+
+### Reference: lince-98 commits worth reading
+
+- `077b37d3` (fragment lookup), `9b214451` (auto-map API key), `9142c367` (UID remap), `a7933b48` (unshare wrapper), `9e62cf12` (proxy framing), `7f5898c4` (BrokenPipe), `858fe521` (GH_TOKEN passthrough), `405c3a11`/`5f987859` (review fixes).
+Reading those diffs is faster than re-discovering the same problems.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/lince-101 - Three-sandbox-levels-—-opencode-follow-up.md
+++ b/backlog/tasks/lince-101 - Three-sandbox-levels-—-opencode-follow-up.md
@@ -4,7 +4,7 @@ title: Three sandbox levels — opencode follow-up
 status: To Do
 assignee: []
 created_date: '2026-05-04 20:33'
-updated_date: '2026-05-04 20:50'
+updated_date: '2026-05-05 13:42'
 labels:
   - sandbox
   - lince-dashboard
@@ -107,4 +107,68 @@ Master doc page (created by lince-98) already covers the overall mechanism. This
 - Document OPENCODE_API_KEY handling per level (passthrough vs. proxy injection)
 
 Do **not** re-explain the overall mechanism.
+
+## Lessons from lince-98 (don't repeat the bugs we already hit)
+
+The claude prototype landed via PR #57. opencode is the trickiest of the four follow-ups because the **Bun/Landlock workaround interacts non-trivially with the paranoid bash wrapper**.
+
+### Required for opencode (per-agent work)
+
+1. **API key auto-mapping is provider-dependent.** opencode is a router, not a single-provider client — it forwards to whichever LLM the user has configured. Auto-map the most common ones in `sandbox/profiles/opencode-paranoid.toml`'s `[env.extra]`:
+   ```toml
+   [env.extra]
+   OPENCODE_API_KEY = "$OPENCODE_API_KEY"
+   ANTHROPIC_API_KEY = "$ANTHROPIC_API_KEY"
+   OPENAI_API_KEY = "$OPENAI_API_KEY"
+   GEMINI_API_KEY = "$GEMINI_API_KEY"
+   ```
+   `_collect_proxy_rules` skips empties and dedups by domain. Unset vars are silently dropped, so over-mapping is safe — the user gets exactly the providers they actually have configured.
+
+2. **The Bun/Landlock workaround inside the paranoid bash wrapper is the hard bit.** opencode's existing `[agents.opencode-nono]` command (current agents-defaults.toml ~line 188) is:
+   ```
+   bash -c 'exec "$(dirname "$(readlink -f "$(which opencode)")")/.opencode" "$@"' --
+   ```
+   This bypasses the Node.js launcher's `spawnSync` (which crashes under Landlock with SIGABRT on Bun-based binaries). For paranoid+nono, the OUTER paranoid wrapper from `synthesize_sandboxed_command` is *also* a bash invocation that does scratch-copy + HOME override + nono run. The two must compose. Two safe forms:
+   - **(a) Pass the bun-resolution as `inner_command`** — the outer paranoid wrapper joins this with shell_quote, embedding the inner bash as `'bash' '-c' '<resolution-script>' '--'` after `nono run ... --`. nono treats everything after `--` as argv and exec's it without further shell interpretation. Should work; **verify that `which opencode` resolves correctly inside the nono filesystem allowlist** — opencode's binary path needs to be readable through the profile's filesystem.read.
+   - **(b) Pre-resolve the binary path on the host** before constructing the inner_command, embed the absolute path directly. Simpler runtime; loses a layer of indirection. Drawback: stale path if the user's `which opencode` changes between dashboard launches. Acceptable trade.
+   Pick (a) or (b) and document in the doc page that opencode paranoid+bwrap is NOT needed for the same reason (bwrap doesn't use Landlock; the Bun/spawnSync bug doesn't apply). For paranoid+bwrap, the inner_command is just `["opencode"]`.
+
+3. **Add an opencode match arm in `synthesize_sandboxed_command`**:
+   - `agent_home_subdir`: `.config/opencode` — note this is **not flat under `$HOME`** like `.claude` / `.codex`. The rsync source/dest paths are `"$HOME/.config/opencode/"` and `"$SCRATCH/.config/opencode/"`. The current AGENT_HOME_SUBDIR placeholder is dropped into both — it's a relative path so subdirs work, but verify the bash form once.
+   - `inner_command`: see (2) above.
+
+4. **Permissive must passthrough `GH_TOKEN` / `GITHUB_TOKEN`** — copy from `claude-permissive.toml`.
+
+5. **Do NOT enumerate `allow_domains` for known LLM providers** in paranoid. The credential rules already cover them. Ship `allow_domains = []` with the header pattern.
+
+### Things ALREADY in master code (don't redo them)
+
+- Fragment lookup with agent prefix.
+- bwrap `--unshare-net` + outer unshare wrapper + socat + UID remap.
+- Stale socket cleanup, proxy framing, BrokenPipe handling, fail-fast socat.
+- shell_quote in the bash wrapper.
+
+### Sanity checks before declaring done
+
+```bash
+agent-sandbox run -a opencode --sandbox-level paranoid -- bash
+
+# 1. opencode binary launches inside paranoid (NO SIGABRT)
+opencode --version || echo "BUG: Bun/Landlock workaround broken"
+
+# 2. Scratch copy of ~/.config/opencode
+ls -la ~/.config/opencode/
+
+# 3. Kernel-level network block
+curl -s https://attacker.com 2>&1   # netns-level fail
+
+# 4. Whichever LLM provider the user has configured works through the proxy
+# (depends on OPENCODE_API_KEY / ANTHROPIC_API_KEY / etc. on the host)
+```
+
+### Reference: lince-98 commits worth reading
+
+- `077b37d3` (fragment lookup), `9b214451` (auto-map API key), `9142c367` (UID remap), `a7933b48` (unshare wrapper), `9e62cf12` (proxy framing), `858fe521` (GH_TOKEN passthrough), `405c3a11`/`5f987859` (review fixes).
+
+For the Bun/Landlock workaround specifically, the existing `[agents.opencode-nono]` entry in `agents-defaults.toml` is the canonical reference.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/lince-101 - Three-sandbox-levels-—-opencode-follow-up.md
+++ b/backlog/tasks/lince-101 - Three-sandbox-levels-—-opencode-follow-up.md
@@ -1,0 +1,110 @@
+---
+id: LINCE-101
+title: Three sandbox levels — opencode follow-up
+status: To Do
+assignee: []
+created_date: '2026-05-04 20:33'
+updated_date: '2026-05-04 20:50'
+labels:
+  - sandbox
+  - lince-dashboard
+  - follow-up
+milestone: m-13
+dependencies:
+  - LINCE-98
+references:
+  - 'https://github.com/RisorseArtificiali/lince/issues/51'
+  - 'https://github.com/RisorseArtificiali/lince/issues/47'
+  - 'https://github.com/RisorseArtificiali/lince/issues/48'
+  - lince-dashboard/agents-defaults.toml
+  - lince-dashboard/nono-profiles/lince-opencode.json
+documentation:
+  - 'https://nono.sh/docs/cli/features/networking.md'
+  - 'https://nono.sh/docs/cli/features/credential-injection.md'
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Scope
+
+Apply the three-level sandbox model to **opencode**, following the pattern established in lince-98 (GH [#48](https://github.com/RisorseArtificiali/lince/issues/48)).
+
+Tracks GH issue [#51](https://github.com/RisorseArtificiali/lince/issues/51). Umbrella: [#47](https://github.com/RisorseArtificiali/lince/issues/47).
+
+> **Do not start until lince-98 is done.** Reuse the runtime dispatch logic and sandbox-policy mechanism.
+
+## Background — full design context (no need to re-brainstorm)
+
+LINCE today exposes `[agents.opencode]` (unsandboxed), `[agents.opencode-bwrap]`, `[agents.opencode-nono]` as separate entries. Collapse to a **single** `[agents.opencode]` with `sandbox_level` + `sandbox_backend`.
+
+## ⚠️ OpenCode-specific Bun/Landlock workaround (CRITICAL)
+
+OpenCode is Bun-based. **Bun-based binaries crash (SIGABRT) when spawned as subprocesses under Landlock.** Current workaround in `agents-defaults.toml:185-188`:
+
+```toml
+command = ["nono", "run", "--profile", "lince-opencode", "--workdir", "{project_dir}", "--",
+           "bash", "-c", "exec \"$(dirname \"$(readlink -f \"$(which opencode)\")\")/.opencode\" \"$@\"", "--"]
+```
+
+This resolves the native binary and execs it directly, bypassing the Node.js launcher's `spawnSync`. **Preserve this command shape across all three nono levels.** For bwrap, verify whether the same issue applies (likely no, since bwrap doesn't use Landlock).
+
+## LLM provider — open question (resolve during execution)
+
+OpenCode uses `OPENCODE_API_KEY` (custom routing) and may not be tied to a single Anthropic/OpenAI/Gemini endpoint. **Verify during execution** what API endpoints opencode actually contacts at runtime (run with debug logging, or check opencode source/docs).
+
+If opencode talks to many providers (like pi), paranoid mode needs one of:
+- (a) Allow only the specific provider the user has configured (require user to declare it)
+- (b) Allow `network.credentials: ["openai", "anthropic", "gemini"]` collectively
+- (c) A permissive variant of paranoid that allows the user's set
+
+Decide and document the trade-off.
+
+## Three levels — opencode specifics
+
+| | paranoid | normal | permissive |
+|---|---|---|---|
+| nono `network` | TBD (see provider question above) | inherited (`lince-opencode.json`) | + github allowlist |
+| nono `filesystem` | `$WORKDIR` rw + scratch copy of `~/.config/opencode` | as today | + standard permissive paths |
+| bwrap | `use_real_config = false` forced (verify opencode equivalent — `home_ro_dirs = ["~/.config/opencode/"]` today) + no-network | as today | + standard permissive paths |
+| Bun workaround | preserve in command | preserve | preserve |
+| Tools | — | — | `gh` CLI (no docker, no podman, no `git push`) |
+
+## File touch list
+
+**New:**
+- `lince-dashboard/nono-profiles/lince-opencode-paranoid.json`
+- `lince-dashboard/nono-profiles/lince-opencode-permissive.json`
+- `sandbox/profiles/opencode-paranoid.toml`
+- `sandbox/profiles/opencode-permissive.toml`
+
+**Modified:**
+- `lince-dashboard/agents-defaults.toml` — collapse opencode entries (~lines 104-128 + 184-200)
+- `lince-dashboard/install.sh` — copy new nono profiles
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 agents-defaults.toml has a single [agents.opencode] with sandbox_level/sandbox_backend; opencode-nono removed
+- [ ] #2 Bun/Landlock workaround preserved in all three nono levels (no SIGABRT regression)
+- [ ] #3 Documented decision on opencode's LLM endpoint allowlist for paranoid (which providers, why)
+- [ ] #4 OPENCODE_API_KEY handling documented (likely passthrough; not a 'credentials' provider in nono)
+- [ ] #5 N-picker shows 'OpenCode' once
+- [ ] #6 sandbox_level=permissive: gh CLI works; docker ps fails
+- [ ] #7 Master doc page extended with opencode-specific rows: Bun/Landlock workaround explained, LLM-endpoint allowlist decision documented, OPENCODE_API_KEY handling per level
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+## Documentation contribution
+
+Master doc page (created by lince-98) already covers the overall mechanism. This task **extends** it with **opencode-specific rows/notes**:
+- Add opencode row to the level-comparison table
+- **Document the Bun/Landlock workaround** prominently — it's the most surprising opencode-specific behavior. Explain why the command is wrapped in `bash -c "exec ..."` and that this must be preserved across all levels.
+- Document the LLM-endpoint allowlist decision made during execution (which providers are allowed in paranoid for opencode; rationale)
+- Document OPENCODE_API_KEY handling per level (passthrough vs. proxy injection)
+
+Do **not** re-explain the overall mechanism.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/lince-102 - Three-sandbox-levels-—-pi-follow-up.md
+++ b/backlog/tasks/lince-102 - Three-sandbox-levels-—-pi-follow-up.md
@@ -1,0 +1,104 @@
+---
+id: LINCE-102
+title: Three sandbox levels — pi follow-up
+status: To Do
+assignee: []
+created_date: '2026-05-04 20:33'
+updated_date: '2026-05-04 20:50'
+labels:
+  - sandbox
+  - lince-dashboard
+  - follow-up
+milestone: m-13
+dependencies:
+  - LINCE-98
+references:
+  - 'https://github.com/RisorseArtificiali/lince/issues/52'
+  - 'https://github.com/RisorseArtificiali/lince/issues/47'
+  - 'https://github.com/RisorseArtificiali/lince/issues/48'
+  - lince-dashboard/agents-defaults.toml
+  - lince-dashboard/nono-profiles/lince-pi.json
+documentation:
+  - 'https://nono.sh/docs/cli/features/networking.md'
+  - 'https://nono.sh/docs/cli/features/credential-injection.md'
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Scope
+
+Apply the three-level sandbox model to **pi**, following the pattern established in lince-98 (GH [#48](https://github.com/RisorseArtificiali/lince/issues/48)).
+
+Tracks GH issue [#52](https://github.com/RisorseArtificiali/lince/issues/52). Umbrella: [#47](https://github.com/RisorseArtificiali/lince/issues/47).
+
+> **Do not start until lince-98 is done.** Reuse the runtime dispatch logic and sandbox-policy mechanism.
+
+## Background — full design context (no need to re-brainstorm)
+
+LINCE today exposes `[agents.pi]` (unsandboxed), `[agents.pi-bwrap]`, `[agents.pi-nono]`. Collapse to a **single** `[agents.pi]` with `sandbox_level` + `sandbox_backend`.
+
+## ⚠️ Pi-specific multi-provider complexity (CRITICAL)
+
+Pi supports **18+ LLM providers** simultaneously. Current entries pass through env vars for: anthropic, openai, azure-openai, gemini (api+vertex), deepseek, mistral, groq, cerebras, cloudflare, xai, openrouter, ai-gateway, zai, opencode, fireworks, kimi, minimax (regular + cn), AWS Bedrock. See `agents-defaults.toml:214-246` for the full list.
+
+This means **paranoid mode for pi cannot statically allowlist a single LLM endpoint** — the user has to declare which providers they actually use. Recommended approach:
+
+- **paranoid**: introduce a config field `pi_providers = ["anthropic", "openai"]` that the plugin reads and translates to `network.credentials: [...]` for nono. Default: empty → no network at all (true paranoid). User must opt-in to specific providers.
+- **normal**: today's behavior (env var passthrough)
+- **permissive**: env var passthrough + github allowlist
+
+This is the most architecturally interesting follow-up. Document the design decision clearly.
+
+## Three levels — pi specifics
+
+| | paranoid | normal | permissive |
+|---|---|---|---|
+| nono `network` | `credentials: $pi_providers` (user-declared subset) — empty means full block | inherited (`lince-pi.json`) | + github allowlist + credentials = full env passthrough |
+| nono `filesystem` | `$WORKDIR` rw + scratch copy of `~/.pi` | as today | + standard permissive paths |
+| bwrap | `use_real_config` equivalent forced (verify pi equivalent — `home_ro_dirs = ["~/.pi/"]`) + no-network | as today | + standard permissive paths |
+| env vars | only declared providers' keys passed (rest filtered) | full passthrough | full passthrough |
+
+## File touch list
+
+**New:**
+- `lince-dashboard/nono-profiles/lince-pi-paranoid.json`
+- `lince-dashboard/nono-profiles/lince-pi-permissive.json`
+- `sandbox/profiles/pi-paranoid.toml`
+- `sandbox/profiles/pi-permissive.toml`
+
+**Modified:**
+- `lince-dashboard/agents-defaults.toml` — collapse pi entries (~lines 202-292 + 294-340), add `pi_providers` config field commentary
+- `lince-dashboard/install.sh` — copy new nono profiles
+- Plugin Rust: read `pi_providers` and translate to nono `credentials` array + filter env_vars accordingly
+
+## References
+
+- Multi-provider rationale: PR #40 ("agents/pi: passthrough all 18 Pi-supported provider env vars")
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 agents-defaults.toml has a single [agents.pi] with sandbox_level/sandbox_backend + pi_providers field; pi-nono removed
+- [ ] #2 pi_providers field respected: declared providers' keys passed in env; others filtered
+- [ ] #3 paranoid with no pi_providers declared = full network block; pi can launch but cannot reach any LLM
+- [ ] #4 paranoid with pi_providers=['anthropic'] = anthropic API works, others fail (e.g. openai unreachable)
+- [ ] #5 Env-var filtering verified: 'printenv | grep _API_KEY' inside paranoid sandbox shows only declared providers
+- [ ] #6 N-picker shows 'Pi' once
+- [ ] #7 Master doc page extended with pi-specific rows: pi_providers design rationale, env-var filtering behavior, worked examples for paranoid with different provider subsets
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+## Documentation contribution
+
+Master doc page (created by lince-98) already covers the overall mechanism. This task **extends** it with **pi-specific rows/notes**:
+- Add pi row to the level-comparison table
+- **Document the multi-provider design**: `pi_providers` field, why pi cannot statically allowlist a single LLM endpoint, how the field maps to nono `network.credentials` and to env-var filtering
+- Worked example: paranoid with `pi_providers = ["anthropic"]` vs. paranoid with `pi_providers = ["anthropic", "openrouter"]` vs. paranoid with empty list (full block)
+- Custom profile examples: e.g. `lince-pi-bedrock-only.json` extending normal with AWS Bedrock allowlist
+
+Do **not** re-explain the overall mechanism.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/lince-102 - Three-sandbox-levels-—-pi-follow-up.md
+++ b/backlog/tasks/lince-102 - Three-sandbox-levels-—-pi-follow-up.md
@@ -4,7 +4,7 @@ title: Three sandbox levels — pi follow-up
 status: To Do
 assignee: []
 created_date: '2026-05-04 20:33'
-updated_date: '2026-05-04 20:50'
+updated_date: '2026-05-05 13:41'
 labels:
   - sandbox
   - lince-dashboard
@@ -101,4 +101,68 @@ Master doc page (created by lince-98) already covers the overall mechanism. This
 - Custom profile examples: e.g. `lince-pi-bedrock-only.json` extending normal with AWS Bedrock allowlist
 
 Do **not** re-explain the overall mechanism.
+
+## Lessons from lince-98 (don't repeat the bugs we already hit)
+
+The claude prototype landed via PR #57. pi is the most architecturally interesting of the four follow-ups because of its **18+ provider env vars** and the design question around `pi_providers` (already raised in this task's description).
+
+### Required for pi (per-agent work)
+
+1. **API key auto-mapping is the EASY part for pi.** Every provider in pi's env passthrough list (see `[agents.pi.env_vars]` ~line 214 of agents-defaults.toml) that matches a `CREDENTIAL_PROXY_RULES` entry will get a proxy rule automatically. Auto-map all of them in `sandbox/profiles/pi-paranoid.toml`:
+   ```toml
+   [env.extra]
+   ANTHROPIC_API_KEY = "$ANTHROPIC_API_KEY"
+   ANTHROPIC_AUTH_TOKEN = "$ANTHROPIC_AUTH_TOKEN"
+   OPENAI_API_KEY = "$OPENAI_API_KEY"
+   GEMINI_API_KEY = "$GEMINI_API_KEY"
+   GOOGLE_API_KEY = "$GOOGLE_API_KEY"
+   # ...remaining 13+ providers...
+   ```
+   `_collect_proxy_rules` (sandbox/agent-sandbox:890) skips empties and dedups by domain — so over-mapping is safe. The user only gets rules for providers they have actually exported in their host env.
+
+2. **The HARD part is `pi_providers` — design before code.** Auto-mapping all 18 vars makes paranoid "reachable to whichever providers the user has". That's already strict (kernel netns + per-domain proxy allowlist) but it's not user-controllable: a user with all 18 keys in env reaches all 18 endpoints. The description proposes a `pi_providers` config field for explicit subsetting. Two layers to decide:
+   - **(a) Whitelist at proxy level**: `pi_providers = ["anthropic"]` → proxy only inserts rules for the anthropic key, even if other keys are in env. Simplest. Implementation: pass `pi_providers` to `_collect_proxy_rules` and filter out non-matching env vars before the rule scan.
+   - **(b) Whitelist at env-passthrough level**: pi_providers also restricts which env vars cross into the sandbox. The agent inside doesn't even SEE keys for non-listed providers. Stricter. Implementation: filter `agent_cfg.env_vars` and `[env.extra]` before they hit `cmd += ["--setenv", ...]` in build_bwrap_cmd.
+   - **(c) Both**: defense in depth. Probably the right answer, but more code.
+   Document the decision in the fragment header AND in the master doc page (sandbox-levels.md). This is the architectural call this task exists to make.
+
+3. **Add a pi match arm in `synthesize_sandboxed_command`**:
+   - `agent_home_subdir`: `.pi`
+   - `inner_command`: `vec!["pi".to_string()]`
+   No internal-sandbox conflict (`bwrap_conflict = false`), no Bun workaround, no OAuth — pi is the simplest of the four for the bash-wrapper layer.
+
+4. **Permissive must passthrough `GH_TOKEN` / `GITHUB_TOKEN`** — copy from `claude-permissive.toml`.
+
+5. **Do NOT enumerate `allow_domains = ["api.anthropic.com", "api.openai.com", ...]`** in paranoid. The credential rules auto-include the matched domains. Ship `allow_domains = []` with the header pattern.
+
+### Things ALREADY in master code (don't redo them)
+
+- Fragment lookup with agent prefix.
+- bwrap `--unshare-net` + outer unshare wrapper + socat bridge + UID remap.
+- Stale socket cleanup, proxy framing fixes, BrokenPipe handling, fail-fast socat.
+- shell_quote in the bash wrapper.
+
+### Sanity checks before declaring done
+
+```bash
+agent-sandbox run -a pi --sandbox-level paranoid -- bash
+
+# 1. Scratch copy of ~/.pi
+ls -la ~/.pi/
+
+# 2. Kernel network block
+curl -s https://attacker.com 2>&1   # netns-level fail
+
+# 3. Only allowlisted providers reachable
+# With pi_providers = ["anthropic"], OPENAI_API_KEY in env:
+curl -s -x http://127.0.0.1:8118 https://api.openai.com/v1/models
+# expected: 403 from the proxy (key wasn't injected because openai is not in pi_providers)
+# AND the OPENAI_API_KEY env var should NOT be visible inside the sandbox if you went with option (b) or (c) above:
+printenv OPENAI_API_KEY    # empty
+```
+
+### Reference: lince-98 commits worth reading
+
+- `077b37d3` (fragment lookup), `9b214451` (auto-map API key), `9142c367` (UID remap), `a7933b48` (unshare wrapper), `9e62cf12` (proxy framing), `7f5898c4` (BrokenPipe), `858fe521` (GH_TOKEN passthrough), `405c3a11`/`5f987859` (review fixes).
+For pi's multi-provider model specifically, see the original PR #40 commit history (when the 18-var passthrough was added) and the `[agents.pi.env_vars]` block in `lince-dashboard/agents-defaults.toml`.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/lince-98 - Three-sandbox-levels-paranoid-normal-permissive-—-claude-prototype.md
+++ b/backlog/tasks/lince-98 - Three-sandbox-levels-paranoid-normal-permissive-—-claude-prototype.md
@@ -1,10 +1,10 @@
 ---
 id: LINCE-98
 title: Three sandbox levels (paranoid/normal/permissive) — claude prototype
-status: Done
+status: In Progress
 assignee: []
 created_date: '2026-05-04 20:32'
-updated_date: '2026-05-04 21:23'
+updated_date: '2026-05-05 09:34'
 labels:
   - sandbox
   - lince-dashboard
@@ -490,44 +490,57 @@ Bwrap path: no Phase 2 work needed — `use_real_config = false` (default) alrea
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 ## What shipped
 
-7 commits on `feature/lince-98-sandbox-levels-claude` (rebased on upstream/main):
+10 commits on `feature/lince-98-sandbox-levels-claude` (rebased on upstream/main):
 
-1. `dashboard: introduce sandbox_level field + paranoid scratch wrapper` — `Option<String>` field on `AgentTypeConfig` + dispatch in `spawn_inner` that synthesizes the command from `(agent_type, sandbox_backend, sandbox_level)`. For nono+paranoid the synthesized command is a self-contained bash wrapper that creates a per-agent scratch dir under `$XDG_RUNTIME_DIR`, rsyncs `~/.claude` into it, exports `HOME=<scratch>`, runs nono, and `rm -rf`'s the scratch on exit (trap EXIT). No plugin-side state machine needed — simpler than the original Phase 2 plan.
+### Initial implementation (7 commits)
+
+1. `dashboard: introduce sandbox_level field + paranoid scratch wrapper` — `Option<String>` field on `AgentTypeConfig` + dispatch in `spawn_inner` that synthesizes the command from `(agent_type, sandbox_backend, sandbox_level)`. For nono+paranoid the synthesized command is a self-contained bash wrapper that creates a per-agent scratch dir under `$XDG_RUNTIME_DIR`, rsyncs `~/.claude` into it, exports `HOME=<scratch>`, runs nono, and `rm -rf`'s the scratch on exit (trap EXIT).
 2. `sandbox-profiles: ship claude paranoid + permissive (nono + bwrap)` — 2 nono JSON profiles (extending `lince-claude`) + 2 TOML fragments under `sandbox/profiles/`.
-3. `sandbox: --sandbox-level flag + policy-fragment overlay` — `agent-sandbox run --sandbox-level NAME` loads `sandbox/profiles/NAME.toml` and deep-merges (lists like `home_ro_dirs` are appended, not replaced). Search path: `./.agent-sandbox/profiles/` → `~/.agent-sandbox/profiles/` → `<script-dir>/profiles/`.
+3. `sandbox: --sandbox-level flag + policy-fragment overlay` — `agent-sandbox run --sandbox-level NAME` loads `sandbox/profiles/NAME.toml` and deep-merges (lists like `home_ro_dirs` are appended, not replaced).
 4. `agents-defaults: collapse [agents.claude] / claude-nono into one entry` — single `[agents.claude]` with `sandbox_level = "normal"`, alternative levels as commented templates, `[agents.claude-nono]` removed, `[agents.claude-unsandboxed]` kept.
 5. `install: ship sandbox-policy fragments + paranoid keystore reminder` — `sandbox/install.sh` and `sandbox/update.sh` copy `profiles/*.toml` into `~/.agent-sandbox/profiles/`; `lince-dashboard/install.sh` prints platform-specific keystore command when nono is detected.
-6. `docs: sandbox-levels reference + manual test plan` — `docs/documentation/dashboard/sandbox-levels.md` (level breakdown, decision guide, customization with worked `lince-claude-with-aws.json` example, keystore setup) + `docs/documentation/dashboard/sandbox-levels-testing.md` (level × backend matrix with copy-pasteable verification commands, custom-level smoke test, regression checklist) + cross-links from `lince-dashboard/README.md`.
-7. `backlog: record lince-98 phase 0 research outcomes + status In Progress` — task notes capturing the resolved R1–R4 decisions so lince-99..102 inherit them without re-investigation.
+6. `docs: sandbox-levels reference + manual test plan` — `docs/documentation/dashboard/sandbox-levels.md` + `docs/documentation/dashboard/sandbox-levels-testing.md` + cross-links from `lince-dashboard/README.md`.
+7. `backlog: record lince-98 phase 0 research outcomes + status In Progress` — task notes capturing the resolved R1–R4 decisions.
+
+### Hardening commits (added after design review)
+
+8. `sandbox: kernel-enforced bwrap paranoid (--unshare-net + socat bridge)` — promotes bwrap paranoid from credential-proxy-only to kernel-enforced. CredentialProxy gets `allow_domains` + `enforce_allowlist` + `start_unix_bridge` + `_forward_passthrough`. cmd_run wires `[security] unshare_net = true` to add `--unshare-net` to bwrap, bind-mount the proxy unix socket at `/run/lince-proxy.sock`, and wrap the inner agent command in a bash setup that runs `socat TCP-LISTEN:8118 ... UNIX-CONNECT:/run/lince-proxy.sock`. Agents see plain TCP localhost — no SDK changes. install.sh detects `socat`. merge_sandbox_level adds `allow_domains` to append-merge keys.
+9. `sandbox-profiles: claude paranoid/permissive use allow_domains` — paranoid ships `unshare_net = true` + `allow_domains = ["api.anthropic.com"]`; permissive moves github allowlist into `[security] allow_domains`. Headers document the merge semantics so users extend via `~/.agent-sandbox/config.toml` instead of forking the fragment.
+10. `docs: bwrap paranoid is now kernel-enforced` — threat-model table promotes bwrap paranoid (raw socket exfil now blocked at kernel level on both backends); customization section documents `allow_domains` + worked "paranoid + pypi.org" example via config.toml override; testing doc replaces "soft paranoid" cell with kernel-isolation tests (curl to attacker.com fails at netns level, raw socket fails with OSError, host-side socat visible per running paranoid agent); GH #54 reframed as "fragment-level extends inheritance" (smaller scope follow-up).
+
+## Threat model — final state (post-hardening)
+
+| Scenario | bwrap normal | bwrap paranoid | nono paranoid |
+|---|---|---|---|
+| Leak `ANTHROPIC_API_KEY` via env dump | unsafe | safe (proxy strips) | safe (keystore) |
+| Modify real `~/.claude` | unsafe | safe (use_real_config=false) | safe (scratch copy) |
+| Open raw socket to attacker.com | unsafe | safe (netns has no route) | safe (Landlock) |
+| `curl https://attacker.com` via HTTP_PROXY | unsafe | safe (proxy 403) | safe (nono allowlist) |
+
+Both paranoid backends are now kernel-enforced. Implementation paths differ (Linux netns + socat bridge vs. Landlock + nono native proxy) but the security guarantee converges.
 
 ## Verified at code-review time
 
-- ✅ AC #1 — `agents-defaults.toml` validated by tomllib parse: claude entry has `sandbox_level = "normal"`, `claude-nono` absent, `claude-unsandboxed` present
-- ✅ AC #7, #8, #9, #10 — documentation files exist with the required structure
-- ✅ AC #11 — plugin's `synthesize_sandboxed_command` returns `None` for unknown agent types (graceful fallback) and `agent-sandbox --sandbox-level` emits a hard error for missing fragment files
-- ✅ AC #12 — cross-links present in `lince-dashboard/README.md` and `agents-defaults.toml` header
-- ✅ WASM plugin builds clean; agent-sandbox parses; smoke tests on `load_sandbox_level_fragment` + `merge_sandbox_level` pass
+- ✅ AC #1 — `agents-defaults.toml` validated by tomllib parse
+- ✅ AC #7..#12 — documentation files exist, allowlist-based customization documented, plugin accepts free-form sandbox_level
+- ✅ WASM plugin builds clean
+- ✅ agent-sandbox parses; smoke tests on `load_sandbox_level_fragment`, `merge_sandbox_level`, `CredentialProxy(allow_domains, enforce_allowlist)`, and `build_bwrap_cmd(unshare_net=True, proxy_unix_socket=...)` all pass
+- ✅ The assembled bwrap command for paranoid contains `--unshare-net`, the unix-socket bind, and the bash wrapper invoking socat with the right flags
 
-## Pending manual verification (AC #2–6)
+## Pending manual verification
 
-These require a running dashboard and cannot be checked from code review alone. Per `docs/documentation/dashboard/sandbox-levels-testing.md`, the tester runs each (level × backend) cell:
-
-- AC #2 (paranoid on nono: arbitrary network blocked, Anthropic via proxy works, `~/.claude` isolated)
-- AC #3 (permissive on nono: gh CLI works, docker fails, direct `git push` fails)
-- AC #4 (N-picker shows "Claude Code" once)
-- AC #5 (default backend per OS; explicit override on linux)
-- AC #6 (install.sh re-run idempotent)
-
-Reviewer should run the cells before merging the PR. The manual test plan doc is the executable form of these criteria.
+Per `docs/documentation/dashboard/sandbox-levels-testing.md`, the tester runs each (level × backend) cell. The hardening introduces tests that need a running paranoid bwrap sandbox to exercise (e.g. `curl https://attacker.com` failing at netns level, `pgrep socat` showing one helper per running agent). The doc spells the steps and expected outcomes.
 
 ## Architectural decisions worth highlighting in the PR description
 
-- **`sandbox_level` is free-form on purpose**: users drop a custom profile and reference it by name, no plugin changes needed. Documented prominently.
-- **bwrap paranoid is proxy-enforced, not kernel-enforced**: adding `--unshare-net` to bwrap would break the host-side credential proxy (each netns has its own `lo`). Documented as known asymmetry; future hardening tracked separately.
-- **MCP-on-internet for permissive is opt-in**: users who run MCP servers that reach internet inside the sandbox write their own `lince-claude-permissive-with-mcp.json`. Out of scope for the prototype.
+- **`sandbox_level` is free-form on purpose** — users drop a custom profile and reference it by name, no plugin changes needed.
+- **`[security] allow_domains` is the per-level allowlist knob** — append-merged so users extend without forking fragments. `[security] unshare_net = true` automatically activates strict-allowlist mode in the proxy.
+- **bwrap paranoid is now kernel-enforced** via `bwrap --unshare-net` + a unix-socket bridge to the credential proxy. socat is the in-sandbox helper; the agent's HTTP_PROXY points at a fixed in-sandbox port; the unix socket is bind-mounted from the host.
+- **MCP-on-internet for permissive is opt-in** — users who run MCP servers that reach internet inside the sandbox extend `allow_domains` with the MCP endpoints they need.
 
 ## Follow-ups (already filed)
 
 - lince-99..102 (codex/gemini/opencode/pi) — depend on this PR
 - GH #53 — wizard 'N' picker UX changes enabled by the single-entry-per-agent model
+- GH #54 — fragment-level `extends` inheritance (so `paranoid-with-pypi.toml` can `extends = "paranoid"` instead of self-contained or config.toml-overlay)
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/lince-98 - Three-sandbox-levels-paranoid-normal-permissive-—-claude-prototype.md
+++ b/backlog/tasks/lince-98 - Three-sandbox-levels-paranoid-normal-permissive-—-claude-prototype.md
@@ -1,10 +1,10 @@
 ---
 id: LINCE-98
 title: Three sandbox levels (paranoid/normal/permissive) — claude prototype
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-04 20:32'
-updated_date: '2026-05-04 21:04'
+updated_date: '2026-05-04 21:23'
 labels:
   - sandbox
   - lince-dashboard
@@ -97,18 +97,18 @@ The N-picker shows only **uncommented** entries. Users opt into non-default leve
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 agents-defaults.toml has a single [agents.claude] with sandbox_level/sandbox_backend; claude-nono removed; claude-unsandboxed kept
+- [x] #1 agents-defaults.toml has a single [agents.claude] with sandbox_level/sandbox_backend; claude-nono removed; claude-unsandboxed kept
 - [ ] #2 sandbox_level=paranoid on nono: arbitrary outbound network fails (curl https://example.com), Claude Code reaches Anthropic API via proxy, modifications to ~/.claude inside sandbox stay isolated from real ~/.claude
 - [ ] #3 sandbox_level=permissive on nono: gh auth status works, gh pr create works, docker ps fails, direct git push fails (use gh)
 - [ ] #4 N-picker shows 'Claude Code' once (not three times)
 - [ ] #5 Default backend per OS works (linux=bwrap, mac=nono); explicit sandbox_backend=nono on linux works
 - [ ] #6 install.sh copies new nono profiles idempotently and is safe to re-run
-- [ ] #7 Manual test doc in docs/ covering each (level x backend) cell
-- [ ] #8 Documentation page created (e.g. docs/documentation/dashboard/sandbox-levels.md) covering: what each of paranoid/normal/permissive does, how to choose, backend selection, customization mechanism
-- [ ] #9 Doc explicitly states sandbox_level is a free-form profile suffix (not a closed enum); the three shipped levels are opinionated examples
-- [ ] #10 Doc includes a worked customization example (e.g. lince-claude-with-aws.json) showing file location, naming convention, extends, and how to enable via config.toml
-- [ ] #11 Plugin accepts any sandbox_level value: well-known names get shipped profiles; arbitrary names resolved by file lookup with clear error if profile missing
-- [ ] #12 lince-dashboard/README.md and agents-defaults.toml header comment cross-link to the new doc page
+- [x] #7 Manual test doc in docs/ covering each (level x backend) cell
+- [x] #8 Documentation page created (e.g. docs/documentation/dashboard/sandbox-levels.md) covering: what each of paranoid/normal/permissive does, how to choose, backend selection, customization mechanism
+- [x] #9 Doc explicitly states sandbox_level is a free-form profile suffix (not a closed enum); the three shipped levels are opinionated examples
+- [x] #10 Doc includes a worked customization example (e.g. lince-claude-with-aws.json) showing file location, naming convention, extends, and how to enable via config.toml
+- [x] #11 Plugin accepts any sandbox_level value: well-known names get shipped profiles; arbitrary names resolved by file lookup with clear error if profile missing
+- [x] #12 lince-dashboard/README.md and agents-defaults.toml header comment cross-link to the new doc page
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -484,3 +484,50 @@ Bwrap path: no Phase 2 work needed — `use_real_config = false` (default) alrea
 - Phase 2: shell-wrapper pattern for HOME override (Option A confirmed); rsync hook + cleanup hook locations identified.
 - Phase 3: bwrap fragment uses `credential_proxy = true`, NOT `unshare_net = true` (architectural decision documented above).
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+## What shipped
+
+7 commits on `feature/lince-98-sandbox-levels-claude` (rebased on upstream/main):
+
+1. `dashboard: introduce sandbox_level field + paranoid scratch wrapper` — `Option<String>` field on `AgentTypeConfig` + dispatch in `spawn_inner` that synthesizes the command from `(agent_type, sandbox_backend, sandbox_level)`. For nono+paranoid the synthesized command is a self-contained bash wrapper that creates a per-agent scratch dir under `$XDG_RUNTIME_DIR`, rsyncs `~/.claude` into it, exports `HOME=<scratch>`, runs nono, and `rm -rf`'s the scratch on exit (trap EXIT). No plugin-side state machine needed — simpler than the original Phase 2 plan.
+2. `sandbox-profiles: ship claude paranoid + permissive (nono + bwrap)` — 2 nono JSON profiles (extending `lince-claude`) + 2 TOML fragments under `sandbox/profiles/`.
+3. `sandbox: --sandbox-level flag + policy-fragment overlay` — `agent-sandbox run --sandbox-level NAME` loads `sandbox/profiles/NAME.toml` and deep-merges (lists like `home_ro_dirs` are appended, not replaced). Search path: `./.agent-sandbox/profiles/` → `~/.agent-sandbox/profiles/` → `<script-dir>/profiles/`.
+4. `agents-defaults: collapse [agents.claude] / claude-nono into one entry` — single `[agents.claude]` with `sandbox_level = "normal"`, alternative levels as commented templates, `[agents.claude-nono]` removed, `[agents.claude-unsandboxed]` kept.
+5. `install: ship sandbox-policy fragments + paranoid keystore reminder` — `sandbox/install.sh` and `sandbox/update.sh` copy `profiles/*.toml` into `~/.agent-sandbox/profiles/`; `lince-dashboard/install.sh` prints platform-specific keystore command when nono is detected.
+6. `docs: sandbox-levels reference + manual test plan` — `docs/documentation/dashboard/sandbox-levels.md` (level breakdown, decision guide, customization with worked `lince-claude-with-aws.json` example, keystore setup) + `docs/documentation/dashboard/sandbox-levels-testing.md` (level × backend matrix with copy-pasteable verification commands, custom-level smoke test, regression checklist) + cross-links from `lince-dashboard/README.md`.
+7. `backlog: record lince-98 phase 0 research outcomes + status In Progress` — task notes capturing the resolved R1–R4 decisions so lince-99..102 inherit them without re-investigation.
+
+## Verified at code-review time
+
+- ✅ AC #1 — `agents-defaults.toml` validated by tomllib parse: claude entry has `sandbox_level = "normal"`, `claude-nono` absent, `claude-unsandboxed` present
+- ✅ AC #7, #8, #9, #10 — documentation files exist with the required structure
+- ✅ AC #11 — plugin's `synthesize_sandboxed_command` returns `None` for unknown agent types (graceful fallback) and `agent-sandbox --sandbox-level` emits a hard error for missing fragment files
+- ✅ AC #12 — cross-links present in `lince-dashboard/README.md` and `agents-defaults.toml` header
+- ✅ WASM plugin builds clean; agent-sandbox parses; smoke tests on `load_sandbox_level_fragment` + `merge_sandbox_level` pass
+
+## Pending manual verification (AC #2–6)
+
+These require a running dashboard and cannot be checked from code review alone. Per `docs/documentation/dashboard/sandbox-levels-testing.md`, the tester runs each (level × backend) cell:
+
+- AC #2 (paranoid on nono: arbitrary network blocked, Anthropic via proxy works, `~/.claude` isolated)
+- AC #3 (permissive on nono: gh CLI works, docker fails, direct `git push` fails)
+- AC #4 (N-picker shows "Claude Code" once)
+- AC #5 (default backend per OS; explicit override on linux)
+- AC #6 (install.sh re-run idempotent)
+
+Reviewer should run the cells before merging the PR. The manual test plan doc is the executable form of these criteria.
+
+## Architectural decisions worth highlighting in the PR description
+
+- **`sandbox_level` is free-form on purpose**: users drop a custom profile and reference it by name, no plugin changes needed. Documented prominently.
+- **bwrap paranoid is proxy-enforced, not kernel-enforced**: adding `--unshare-net` to bwrap would break the host-side credential proxy (each netns has its own `lo`). Documented as known asymmetry; future hardening tracked separately.
+- **MCP-on-internet for permissive is opt-in**: users who run MCP servers that reach internet inside the sandbox write their own `lince-claude-permissive-with-mcp.json`. Out of scope for the prototype.
+
+## Follow-ups (already filed)
+
+- lince-99..102 (codex/gemini/opencode/pi) — depend on this PR
+- GH #53 — wizard 'N' picker UX changes enabled by the single-entry-per-agent model
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/lince-98 - Three-sandbox-levels-paranoid-normal-permissive-—-claude-prototype.md
+++ b/backlog/tasks/lince-98 - Three-sandbox-levels-paranoid-normal-permissive-—-claude-prototype.md
@@ -1,0 +1,423 @@
+---
+id: LINCE-98
+title: Three sandbox levels (paranoid/normal/permissive) — claude prototype
+status: To Do
+assignee: []
+created_date: '2026-05-04 20:32'
+updated_date: '2026-05-04 20:53'
+labels:
+  - sandbox
+  - lince-dashboard
+  - prototype
+milestone: m-13
+dependencies: []
+references:
+  - 'https://github.com/RisorseArtificiali/lince/issues/48'
+  - 'https://github.com/RisorseArtificiali/lince/issues/47'
+  - lince-dashboard/agents-defaults.toml
+  - lince-dashboard/nono-profiles/lince-claude.json
+  - sandbox/agent-sandbox
+  - sandbox/config.toml.example
+documentation:
+  - 'https://nono.sh/docs/cli/features/networking.md'
+  - 'https://nono.sh/docs/cli/features/credential-injection.md'
+  - 'https://nono.sh/docs/cli/features/profile-authoring.md'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Goal
+
+Implement the three-level sandbox model (paranoid/normal/permissive) on **claude** as the canonical prototype. The runtime dispatch logic, sandbox-policy mechanism, and TOML schema introduced here are reused by the codex/gemini/opencode/pi follow-up tasks.
+
+Tracks GH issue [#48](https://github.com/RisorseArtificiali/lince/issues/48). Umbrella: [#47](https://github.com/RisorseArtificiali/lince/issues/47).
+
+## Background — full design context (no need to re-brainstorm)
+
+LINCE today exposes `[agents.claude]` (bwrap), `[agents.claude-unsandboxed]`, `[agents.claude-nono]` as separate entries; the N-picker shows all three. Decision: collapse to a **single** `[agents.claude]` driven by two new attributes:
+
+- `sandbox_level = "paranoid" | "normal" | "permissive"` — default `"normal"`
+- `sandbox_backend = "bwrap" | "nono"` — default per OS (linux=bwrap, mac=nono); explicit override allowed
+
+`[agents.claude-unsandboxed]` stays as a separate entry (opt-out, not a level). Alternative levels appear as **commented templates** in agents-defaults.toml so the picker stays uncluttered while remaining self-discoverable.
+
+## Three levels — claude specifics
+
+LLM provider for proxy/credential injection: **anthropic** (nono keystore account: `anthropic_api_key`).
+
+| | paranoid | normal | permissive |
+|---|---|---|---|
+| nono `network` | `credentials: ["anthropic"]` (proxy LLM only, blocks the rest) | inherited from `claude-code` preset | `network_profile: "developer"` + `allow_domain: ["api.github.com","github.com","objects.githubusercontent.com"]` + `credentials: ["anthropic"]` |
+| nono `filesystem` | `$WORKDIR` rw + scratch copy of `~/.claude` (rsync pre-launch) | as today (`lince-claude.json`) | + `~/.config/gh` r, `~/.cache` r, `~/.ssh/known_hosts` r |
+| bwrap `[claude]` | `use_real_config = false` forced + no-network | as today (default) | + bind-read of `~/.config/gh`, `~/.cache`, `~/.ssh/known_hosts` |
+| Tools | — | — | `gh` CLI (no docker, no podman, no `git push` — push goes via gh) |
+
+**Out of scope (deliberately excluded)**: docker, podman, direct `git push`.
+
+## nono native features used (no need to reinvent)
+
+- `network.block: true` — full lockdown
+- `network.credentials: [...]` — LLM proxy with credential injection from system keystore (or 1Password / Apple Passwords)
+- `network.network_profile: "developer"` + `allow_domain: [...]` — permissive allowlist
+- nono profile inheritance (`extends: "claude-code"`)
+
+## File touch list
+
+**New:**
+- `lince-dashboard/nono-profiles/lince-claude-paranoid.json`
+- `lince-dashboard/nono-profiles/lince-claude-permissive.json`
+- `sandbox/profiles/claude-paranoid.toml` (built-in, format depends on R1)
+- `sandbox/profiles/claude-permissive.toml` (built-in)
+
+**Modified:**
+- `lince-dashboard/agents-defaults.toml` — single `[agents.claude]` with `sandbox_level`/`sandbox_backend` + commented templates for paranoid/permissive; remove `[agents.claude-nono]`
+- `lince-dashboard/plugin/src/...` — read both attributes, dispatch to right profile/command; auto-default backend per OS
+- `sandbox/agent-sandbox` — support sandbox-policy profiles (or layer on top of `[claude]` config section) — see R1
+- `lince-dashboard/install.sh` — copy new nono profiles, idempotent
+
+## Wizard "N" behavior
+
+The N-picker shows only **uncommented** entries. Users opt into non-default levels by uncommenting alternative `[agents.X]` blocks shipped as commented templates. **No plugin changes for the picker itself.**
+
+## Research items (resolve during execution, not blockers)
+
+- **R1** Does `agent-sandbox` already have a sandbox-policy profile mechanism? Today `[profiles.*]` in `sandbox/config.toml` = LLM credential injection, not filesystem/network policy. Either add policy profiles or layer paranoid/permissive on top of `[claude]` section.
+- **R2** "Scratch copy" of `~/.claude` under nono: pre-spawn rsync hook in lince-dashboard plugin (rsync to `$XDG_RUNTIME_DIR/lince-<agent-id>/.claude`, set HOME or bind mount), or built into nono profile activation?
+- **R3** bwrap: existing `--no-network` or equivalent for paranoid, or do we need to add it?
+- **R4** Permissive allowlist for MCP servers running over internet (Context7, Sequential, etc.) — opt-in or default?
+
+## Out of scope for this task
+
+- codex, gemini, opencode, pi (covered by separate follow-up tasks/issues)
+- docker/podman in permissive
+- direct `git push`
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 agents-defaults.toml has a single [agents.claude] with sandbox_level/sandbox_backend; claude-nono removed; claude-unsandboxed kept
+- [ ] #2 sandbox_level=paranoid on nono: arbitrary outbound network fails (curl https://example.com), Claude Code reaches Anthropic API via proxy, modifications to ~/.claude inside sandbox stay isolated from real ~/.claude
+- [ ] #3 sandbox_level=permissive on nono: gh auth status works, gh pr create works, docker ps fails, direct git push fails (use gh)
+- [ ] #4 N-picker shows 'Claude Code' once (not three times)
+- [ ] #5 Default backend per OS works (linux=bwrap, mac=nono); explicit sandbox_backend=nono on linux works
+- [ ] #6 install.sh copies new nono profiles idempotently and is safe to re-run
+- [ ] #7 Manual test doc in docs/ covering each (level x backend) cell
+- [ ] #8 Documentation page created (e.g. docs/documentation/dashboard/sandbox-levels.md) covering: what each of paranoid/normal/permissive does, how to choose, backend selection, customization mechanism
+- [ ] #9 Doc explicitly states sandbox_level is a free-form profile suffix (not a closed enum); the three shipped levels are opinionated examples
+- [ ] #10 Doc includes a worked customization example (e.g. lince-claude-with-aws.json) showing file location, naming convention, extends, and how to enable via config.toml
+- [ ] #11 Plugin accepts any sandbox_level value: well-known names get shipped profiles; arbitrary names resolved by file lookup with clear error if profile missing
+- [ ] #12 lince-dashboard/README.md and agents-defaults.toml header comment cross-link to the new doc page
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+## Implementation plan — lince-98 (claude prototype)
+
+> Sequencing rationale: research items first (Phase 0) because their answers shape the code in Phases 1–3. The schema + dispatch (Phase 1) is the load-bearing piece; subsequent phases are decoupled file work.
+
+### Phase 0 — Research (resolve R1–R4)
+
+Concrete artifacts: a short markdown note inside this task's notes (via `notesAppend`) capturing the answers, so follow-up tasks (lince-99..102) inherit the resolved decisions without re-investigation.
+
+- **R1** Read `sandbox/agent-sandbox` (Python single-file). Inspect: existing `[claude]` / `[codex]` / `[gemini]` / `[opencode]` / `[pi]` config sections, `resolve_profiles()`, `generate_nono_profile()`. Decide ONE of:
+  - **(a)** Add new `[sandbox_policies.NAME]` table type that layers on top of agent sections
+  - **(b)** Reuse existing `[claude]` etc. and pass `--sandbox-level NAME` flag that toggles a few keys at runtime
+  - **(c)** Ship presets as TOML fragments under `sandbox/profiles/` and the script merges them into the resolved `[claude]` section
+  
+  Bias toward (c) — minimal new abstraction, easy to ship as built-in.
+- **R2** Read `lince-dashboard/plugin/src/agent.rs` (or wherever `open_command_pane` is invoked). Decide where the scratch copy of `~/.claude` happens for nono paranoid:
+  - Option A: pre-spawn step in plugin (Rust): `run_command(["rsync", "-a", "~/.claude/", "$XDG_RUNTIME_DIR/lince-<id>/.claude/"])` then bind into nono profile via `$HOME` override
+  - Option B: nono profile activation hook (if nono supports pre/post hooks)
+  - Option C: shell wrapper in the `command` field
+  
+  Bias toward A (Option C is brittle, Option B unverified). For bwrap, this is **already solved** by `use_real_config = false` (default).
+- **R3** Inspect `agent-sandbox` for existing network-disable flag. Search for `unshare`, `--unshare-net`, `--share-net`, `--no-network` in the script. If none, add `--no-network` flag that toggles bwrap's `--unshare-net`. Document the result in notes.
+- **R4** Catalog: which MCP servers (Context7, Sequential, Magic, Playwright, Tavily, Serena, Morphllm) call out to internet from inside the agent? Decision tree:
+  - If MCP runs **outside** the sandbox (host process), no allowlist needed
+  - If MCP runs **inside** the sandbox (Claude Code spawns it), permissive must allow its endpoints
+  - For prototype: **permissive does NOT auto-allow MCP endpoints**. Document that MCP-on-internet users need a custom profile (`lince-claude-permissive-with-mcp.json`).
+
+### Phase 1 — Plugin schema + dispatch
+
+**File:** `lince-dashboard/plugin/src/config.rs` (or wherever `AgentConfig` is defined; grep for `sandboxed: bool` to find it).
+
+1. Add fields to the agent config struct:
+   ```rust
+   pub sandbox_level: Option<String>,      // default: Some("normal")
+   pub sandbox_backend: Option<String>,    // default: per OS (see fn below)
+   ```
+2. Default-resolution helper:
+   ```rust
+   fn default_backend() -> &'static str {
+       if cfg!(target_os = "macos") { "nono" } else { "bwrap" }
+   }
+   ```
+3. Profile-resolution helper (free-form, not enum):
+   ```rust
+   fn resolve_nono_profile(agent: &str, level: &str) -> String {
+       if level == "normal" { format!("lince-{}", agent) }
+       else { format!("lince-{}-{}", agent, level) }
+   }
+   ```
+4. **Command generation**: today the entries hardcode `command = ["nono", "run", "--profile", "lince-claude", ...]` etc. Replace this for entries that opt into the new model: when `sandbox_level` is present, the plugin **overrides** the static `command` with one generated from the (level, backend) pair. Concretely:
+   - bwrap: `["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}", "--sandbox-level", level, ...]` (assumes Phase 0 R1/R3 result)
+   - nono: `["nono", "run", "--profile", resolve_nono_profile(agent, level), "--workdir", "{project_dir}", "--", "claude", "--dangerously-skip-permissions"]`
+5. **Profile-file existence check** at agent spawn time. If the resolved profile does not exist (nono profile JSON missing, or bwrap profile fragment missing), surface a user-visible error in the dashboard pane title or a short pop-up. **Do not silently fall back.**
+6. **Unit test**: add a test in `plugin/src/config.rs` (or sibling test file) covering `resolve_nono_profile()` for `normal` / `paranoid` / arbitrary `with-aws`.
+
+### Phase 2 — Scratch copy of `~/.claude` for paranoid (R2 → Option A)
+
+**File:** `lince-dashboard/plugin/src/agent.rs`
+
+1. New helper `prepare_paranoid_scratch(agent_id: &str, agent_name: &str) -> PathBuf`:
+   - Computes scratch dir: `$XDG_RUNTIME_DIR/lince-{agent_id}` (fallback `/tmp/lince-{agent_id}`)
+   - Determines source `~/.claude/` for claude (data-driven from `agents-defaults.toml` `home_ro_dirs[0]`)
+   - Calls `run_command(["rsync", "-a", "--delete", source, dest])` async, returns dest path
+   - Returns the scratch path
+2. Spawn flow: when `sandbox_level == "paranoid"`, before `open_command_pane`, call `prepare_paranoid_scratch()`. Wait for completion event, then spawn the pane with `HOME` env overridden to the scratch dir.
+3. **Cleanup**: on agent stop event, remove the scratch dir (best-effort, log on failure). Tie into the existing agent-stop pipeline (search `Event::PaneClosed` or similar).
+4. **bwrap path**: no Phase 2 work needed — `use_real_config = false` (default in `sandbox/`) already handles this. Document the asymmetry in the doc page.
+
+### Phase 3 — Build sandbox profiles
+
+**Nono profiles** (`lince-dashboard/nono-profiles/`):
+
+`lince-claude-paranoid.json`:
+```json
+{
+  "extends": "lince-claude",
+  "meta": { "name": "lince-claude-paranoid", "description": "claude — network locked except Anthropic API via proxy; ~/.claude isolated scratch" },
+  "filesystem": {
+    "allow": ["$WORKDIR"],
+    "read": []
+  },
+  "network": {
+    "credentials": ["anthropic"]
+  }
+}
+```
+
+`lince-claude-permissive.json`:
+```json
+{
+  "extends": "lince-claude",
+  "meta": { "name": "lince-claude-permissive", "description": "claude — github + gh CLI access; ~/.config/gh, ~/.cache, ~/.ssh/known_hosts readable" },
+  "filesystem": {
+    "allow": ["$WORKDIR"],
+    "read": ["$HOME/.config/gh", "$HOME/.cache", "$HOME/.ssh/known_hosts", "$HOME/.local/lib"]
+  },
+  "network": {
+    "network_profile": "developer",
+    "credentials": ["anthropic"],
+    "allow_domain": ["api.github.com", "github.com", "objects.githubusercontent.com"]
+  }
+}
+```
+
+**Bwrap profiles** (`sandbox/profiles/`) — final form depends on Phase 0 R1. Sketch (Option c):
+
+`claude-paranoid.toml`:
+```toml
+# Layered on top of [claude] when sandbox_level = "paranoid"
+[claude]
+use_real_config = false   # forced (overrides user override)
+[sandbox]
+network = false            # (R3-dependent key name)
+```
+
+`claude-permissive.toml`:
+```toml
+[claude]
+extra_ro_binds = ["~/.config/gh", "~/.cache", "~/.ssh/known_hosts"]
+[sandbox]
+network = true
+```
+
+### Phase 4 — agents-defaults.toml
+
+**File:** `lince-dashboard/agents-defaults.toml`
+
+1. Replace lines 15–25 (current `[agents.claude]`) with:
+   ```toml
+   [agents.claude]
+   command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}"]   # overridden by plugin when sandbox_level set
+   pane_title_pattern = "agent-sandbox"
+   status_pipe_name = "claude-status"
+   display_name = "Claude Code"
+   short_label = "CLA"
+   color = "blue"
+   sandboxed = true
+   has_native_hooks = true
+   home_ro_dirs = ["~/.claude/"]
+   profiles = ["__discover__"]
+   sandbox_level = "normal"          # paranoid | normal | permissive (or any custom — see docs)
+   # sandbox_backend = "bwrap"       # default per OS; uncomment to override
+   
+   # Alternative levels — uncomment ONE [agents.claude-XXX] block below to opt into paranoid or permissive.
+   # See docs/documentation/dashboard/sandbox-levels.md for what each level does and how to customize.
+   #
+   # [agents.claude-paranoid]
+   # ...same as [agents.claude] but with sandbox_level = "paranoid"...
+   #
+   # [agents.claude-permissive]
+   # ...same as [agents.claude] but with sandbox_level = "permissive"...
+   ```
+2. Remove lines 134–145 (`[agents.claude-nono]`) — its functionality is now `sandbox_backend = "nono"` on `[agents.claude]`.
+3. Keep lines 27–36 (`[agents.claude-unsandboxed]`) untouched — it's a separate opt-out path.
+4. Update header comment (lines 1–13) to point readers to `docs/documentation/dashboard/sandbox-levels.md`.
+
+### Phase 5 — install.sh / update.sh
+
+**Files:** `lince-dashboard/install.sh`, `lince-dashboard/update.sh`
+
+1. Step 10 (nono profiles): the existing `for profile in "$NONO_PROFILES_SRC"/lince-*.json` glob already picks up the two new files. Verify it matches the new naming (`lince-claude-paranoid.json`, `lince-claude-permissive.json`).
+2. Add a printed reminder after profile install (only if nono is detected as installed) telling the user to populate the keystore for paranoid level:
+   ```
+   For paranoid sandbox level: populate the nono keystore with your Anthropic key:
+     security add-generic-password -s "nono" -a "anthropic_api_key" -w "sk-ant-..."     # macOS
+     # or use 1Password / Apple Passwords integration; see https://nono.sh/docs/cli/features/credential-injection.md
+   ```
+3. update.sh: mirror the profile copy (same loop pattern). No interactive step needed for these — they're per-agent profiles, not user-config.
+4. Verify idempotency by running `install.sh` twice in a clean clone; second run prints no new copies.
+
+### Phase 6 — Documentation
+
+**File:** `docs/documentation/dashboard/sandbox-levels.md` (new)
+
+Sections (rough headings):
+1. **Overview** — one paragraph: what sandboxing buys you, the three shipped levels at a glance
+2. **Levels in detail** — for each of `paranoid` / `normal` / `permissive`:
+   - Network policy (English + nono JSON snippet + bwrap equivalent)
+   - Filesystem policy
+   - Tools available / unavailable
+   - "What does Claude Code see / fail to do" worked example
+3. **How to choose** — short decision guide with trade-offs
+4. **Backend selection** — `sandbox_backend = "bwrap" | "nono"`, default per OS, when to override (Linux user wanting Landlock-based isolation, etc.)
+5. **Customization** — *prominent* section:
+   - `sandbox_level` is a free-form profile suffix; the three shipped names are opinionated examples
+   - File location convention: `~/.config/nono/profiles/lince-{agent}-{name}.json`, `sandbox/profiles/{agent}-{name}.toml`
+   - `extends` mechanism for nono profiles
+   - **Worked example**: `lince-claude-with-aws.json` (full JSON shown above in implementation notes)
+   - How to enable: `[agents.claude] sandbox_level = "with-aws"` in `~/.config/lince-dashboard/config.toml`
+   - How to verify: command to run inside the sandbox to confirm allowlist works
+6. **Keystore setup** — short section pointing to nono docs for populating the keystore
+7. **Future work** — link to GH #53 (wizard UX) so readers know there's more coming
+
+**Cross-links to add:**
+- `lince-dashboard/README.md`: 3–4 lines summary + link
+- `lince-dashboard/agents-defaults.toml` header comment: one-line link
+
+### Phase 7 — Manual test plan
+
+**File:** `docs/documentation/dashboard/sandbox-levels-testing.md` (new) — explicit manual checklist.
+
+Cells (level × backend):
+
+| | bwrap (linux) | nono (linux) | nono (macOS) |
+|---|---|---|---|
+| paranoid | ✅ test | ✅ test | ✅ test (if mac available) |
+| normal | ✅ test (regression) | ✅ test (regression) | ✅ test (regression) |
+| permissive | ✅ test | ✅ test | ✅ test (if mac available) |
+
+Per cell, the doc spells out the commands to run from inside the agent and the expected outcome:
+- paranoid: `curl https://example.com` → fails; Claude Code chat works; `ls ~/.claude` shows isolated copy
+- normal: existing behavior unchanged (smoke test)
+- permissive: `gh auth status` → success; `gh pr create` → success (with token); `docker ps` → fails; direct `git push origin HEAD` → fails
+
+### Phase 8 — Branch / PR / merge
+
+1. Branch: `feature/lince-98-sandbox-levels-claude` from `upstream/main`
+2. Commits: prefer multiple small commits per phase (easier review):
+   - `dashboard: add sandbox_level/sandbox_backend fields to AgentConfig`
+   - `dashboard: paranoid scratch copy of agent home dir for nono`
+   - `nono-profiles: add claude-paranoid and claude-permissive`
+   - `sandbox: add claude-paranoid/permissive policy fragments` (Phase 0 R1 result)
+   - `agents-defaults: collapse claude/claude-nono into single entry`
+   - `install: ship new nono profiles + keystore reminder`
+   - `docs: sandbox-levels page + manual test plan`
+3. PR title: `dashboard: three-level sandbox per agent (paranoid/normal/permissive) — claude prototype`
+4. PR body: link issue #48, summary by phase, screenshots if N-picker UX changed at all, manual test results table
+
+### Verification before declaring done
+
+Run all 7 acceptance criteria from the task header. The test plan doc (Phase 7) is the executable form of those.
+
+### Risks / known unknowns
+
+- **Phase 0 R1 outcome may force schema redesign.** If `agent-sandbox` cannot reasonably accept layered policy fragments, fall back to passing CLI flags from the plugin (e.g. `--sandbox-level paranoid`) and have agent-sandbox read them. Either way, isolate the change to a new module so follow-up tasks can lift it cleanly.
+- **MCP-on-internet for permissive (R4)** is deliberately out of scope. Users who hit this can write a custom profile — already covered by the customization story.
+- **Scratch copy size** — `~/.claude` can be large (skill caches, MCP downloads). rsync should be fast on local FS but log timing if > 1s and consider only copying the subset claude actually needs (settings + skills, not caches). Decide during Phase 2 implementation.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+## Documentation requirements (added after design review)
+
+The task **must** ship documentation as part of the prototype. The doc establishes structure that the codex/gemini/opencode/pi follow-ups extend with their own agent-specific entries.
+
+### Where the doc lives
+
+- New page: `docs/documentation/dashboard/sandbox-levels.md` (or extend an existing page if it fits — TBD during execution)
+- Cross-link from `lince-dashboard/README.md` (a 3–4 line summary + link)
+- Cross-link from `agents-defaults.toml` header comment (point to the doc URL/path for full explanation)
+
+### Doc content checklist
+
+1. **What the three levels mean** — for each of `paranoid` / `normal` / `permissive`:
+   - Network policy (in plain English, then the concrete `network.*` JSON snippet for nono and the equivalent in bwrap)
+   - Filesystem policy (paths granted/denied, scratch-copy behavior)
+   - Tools available (gh, etc.) and tools deliberately *not* available (docker, podman, direct git push)
+   - Concrete worked example: "what does Claude Code see / fail to do in this level?"
+2. **How to choose a level** — short decision guide (e.g. "use paranoid for untrusted prompts or new agents; normal for daily work; permissive when you need gh push and don't mind broader filesystem read"). Be honest about trade-offs.
+3. **Backend selection** — `sandbox_backend = "bwrap" | "nono"`, default per OS, when to override.
+4. **Customization is supported** — these three are **opinionated examples**, not a closed enum.
+
+### Customization mechanism (architecture clarification)
+
+`sandbox_level` is treated by the plugin as the **suffix of the profile name**, not as a closed enum:
+
+- nono: `sandbox_level = "X"` → looks for `~/.config/nono/profiles/lince-{agent}-{X}.json` (falls back to `lince-{agent}.json` if `X = "normal"`)
+- bwrap: `sandbox_level = "X"` → looks for `sandbox/profiles/{agent}-{X}.toml`
+
+The plugin **must** accept any string for `sandbox_level` (well-known names `paranoid|normal|permissive` get the shipped profiles; any other name is resolved by file lookup, with a clear error message if the profile file is missing).
+
+### Worked customization example to include in the doc
+
+Walk the user through creating `lince-claude-with-aws.json`:
+
+```json
+{
+  "extends": "lince-claude",
+  "meta": { "name": "lince-claude-with-aws", "description": "claude + AWS Bedrock access" },
+  "filesystem": {
+    "allow": ["$WORKDIR"],
+    "read": ["$HOME/.aws"]
+  },
+  "network": {
+    "credentials": ["anthropic"],
+    "allow_domain": ["bedrock-runtime.us-east-1.amazonaws.com"]
+  }
+}
+```
+
+Then in `~/.config/lince-dashboard/config.toml`:
+```toml
+[agents.claude]
+sandbox_level = "with-aws"
+```
+
+Show: file location, naming convention, `extends`, what each addition grants, and how to verify it works.
+
+Mention that the same applies to bwrap profiles (`sandbox/profiles/claude-with-aws.toml`).
+
+### What the follow-up tasks (lince-99..102) inherit
+
+The follow-up agent tasks **do not re-invent** this doc structure. Each of them:
+- Adds its agent-specific row to the level-comparison table
+- Documents agent-specific quirks (e.g. codex inner-sandbox conflict, opencode Bun/Landlock, pi multi-provider)
+- Does **not** re-explain the overall mechanism — that lives in the master doc page from this task
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/lince-98 - Three-sandbox-levels-paranoid-normal-permissive-—-claude-prototype.md
+++ b/backlog/tasks/lince-98 - Three-sandbox-levels-paranoid-normal-permissive-—-claude-prototype.md
@@ -1,10 +1,10 @@
 ---
 id: LINCE-98
 title: Three sandbox levels (paranoid/normal/permissive) — claude prototype
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-05-04 20:32'
-updated_date: '2026-05-04 20:53'
+updated_date: '2026-05-04 21:04'
 labels:
   - sandbox
   - lince-dashboard
@@ -420,4 +420,67 @@ The follow-up agent tasks **do not re-invent** this doc structure. Each of them:
 - Adds its agent-specific row to the level-comparison table
 - Documents agent-specific quirks (e.g. codex inner-sandbox conflict, opencode Bun/Landlock, pi multi-provider)
 - Does **not** re-explain the overall mechanism — that lives in the master doc page from this task
+
+## Phase 0 research outcomes (resolved 2026-05-04)
+
+### R1 — sandbox-policy mechanism in agent-sandbox
+
+**Decision: strategy (c) — TOML fragment overlays + new `--sandbox-level` CLI flag.**
+
+Key findings:
+- `load_config()` (sandbox/agent-sandbox:751) is the merge point
+- Existing `default_profile` key in `[sandbox]` is **already taken** for credential profiles (`-P` flag) — we need a NEW key, e.g. `sandbox_level` in `[sandbox]` (parallel to dashboard side)
+- `resolve_agent_config()` (line 812) shows the existing 4-layer merge pattern; we extend it for fragment overlay
+- Risk: list fields like `home_ro_dirs` must be **appended** by the merge, not replaced
+
+**Implementation**:
+1. Add `--sandbox-level NAME` flag to `agent-sandbox run` (cmd_run, line 1816)
+2. Fragment files live in `sandbox/profiles/<name>.toml` (script-dir search path, mirroring agents-defaults.toml resolution)
+3. After main config load, if flag set, load fragment and deep-merge (append for known list keys: `home_ro_dirs`, `ro_dirs`, `extra_rw`)
+
+### R2 — Scratch copy of `~/.claude` for nono paranoid
+
+**Decision: Option A — pre-spawn rsync from plugin + HOME override via shell wrapper.**
+
+Key findings:
+- Spawn entry: `lince-dashboard/plugin/src/agent.rs:206-227` (`spawn_agent_custom` → `spawn_inner`)
+- `CommandToRun` (agent.rs:167-171) has no env field → use shell wrapper to set HOME
+- `run_typed_command()` pattern (config.rs:288-303) for async rsync; result via `Event::RunCommandResult`
+- Pane lifecycle: `reconcile_panes` (agent.rs:263-277) detects close → cleanup hook here
+- Nono profiles (`lince-dashboard/nono-profiles/lince-claude.json`) do **not** have pre/post-spawn hooks
+
+**Implementation flow**:
+```
+1. Plugin: rsync ~/.claude → $XDG_RUNTIME_DIR/lince-{agent_id}/.claude (async run_command)
+2. On rsync OK: spawn pane with command:
+   bash -c 'export HOME=$XDG_RUNTIME_DIR/lince-{agent_id} && exec nono run --profile lince-claude-paranoid --workdir {project_dir} -- claude --dangerously-skip-permissions'
+3. Nono profile allow_path uses $HOME → resolves to scratch dir
+4. On agent stop (reconcile_panes detects close): rm -rf scratch dir (best-effort)
+```
+
+Bwrap path: no Phase 2 work needed — `use_real_config = false` (default) already handles isolation. Documented asymmetry.
+
+### R3 — bwrap network isolation
+
+**Status**: `--unshare-net` flag is **not implemented today** in agent-sandbox.
+
+**Architectural caveat (CRITICAL)**: Adding `--unshare-net` naively breaks the credential proxy. The proxy runs on the host's network namespace; with `--unshare-net`, the sandbox gets a fresh netns with only its own `lo` interface — it **cannot** reach the host's 127.0.0.1:PORT (each netns has independent loopback).
+
+**Decision for prototype**:
+- Bwrap paranoid: **do NOT add `--unshare-net`** in this prototype. Instead, rely on the existing `credential_proxy` (which strips API keys + only allows configured URLs). This is functionally similar to nono's `network.credentials` but enforced at the proxy layer rather than at the kernel.
+- Document the asymmetry: nono paranoid is kernel-enforced (Landlock + network policy); bwrap paranoid is proxy-enforced (lighter but real). Future hardening would require unix-socket proxy or in-namespace proxy.
+- File follow-up issue if user wants kernel-level bwrap paranoid (out of scope for this prototype).
+
+**Implementation**: paranoid bwrap fragment forces `use_real_config = false` + `credential_proxy = true`; permissive adds extra `home_ro_dirs`.
+
+### R4 — MCP-on-internet allowlist for permissive
+
+**Decision**: out of scope for prototype. Permissive does NOT auto-allow MCP endpoints. Users running MCP-on-internet servers inside the sandbox must create a custom profile (`lince-claude-permissive-with-mcp.json`) — exactly the customization story already documented.
+
+## Updated Phase 1/2 plan based on research
+
+- Phase 1: introduce `sandbox_level`/`sandbox_backend` fields in plugin AgentConfig as planned. Profile-resolution logic unchanged.
+- Phase 1.5 (NEW, in agent-sandbox): add `--sandbox-level NAME` CLI flag + fragment loader + deep merge. This is in `sandbox/agent-sandbox` (Python), not the dashboard plugin.
+- Phase 2: shell-wrapper pattern for HOME override (Option A confirmed); rsync hook + cleanup hook locations identified.
+- Phase 3: bwrap fragment uses `credential_proxy = true`, NOT `unshare_net = true` (architectural decision documented above).
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/lince-98 - Three-sandbox-levels-paranoid-normal-permissive-—-claude-prototype.md
+++ b/backlog/tasks/lince-98 - Three-sandbox-levels-paranoid-normal-permissive-—-claude-prototype.md
@@ -1,10 +1,10 @@
 ---
 id: LINCE-98
 title: Three sandbox levels (paranoid/normal/permissive) — claude prototype
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-04 20:32'
-updated_date: '2026-05-05 09:34'
+updated_date: '2026-05-05 09:35'
 labels:
   - sandbox
   - lince-dashboard

--- a/backlog/tasks/lince-99 - Three-sandbox-levels-—-codex-follow-up.md
+++ b/backlog/tasks/lince-99 - Three-sandbox-levels-—-codex-follow-up.md
@@ -1,0 +1,110 @@
+---
+id: LINCE-99
+title: Three sandbox levels — codex follow-up
+status: To Do
+assignee: []
+created_date: '2026-05-04 20:32'
+updated_date: '2026-05-04 20:50'
+labels:
+  - sandbox
+  - lince-dashboard
+  - follow-up
+milestone: m-13
+dependencies:
+  - LINCE-98
+references:
+  - 'https://github.com/RisorseArtificiali/lince/issues/49'
+  - 'https://github.com/RisorseArtificiali/lince/issues/47'
+  - 'https://github.com/RisorseArtificiali/lince/issues/48'
+  - lince-dashboard/agents-defaults.toml
+  - lince-dashboard/nono-profiles/lince-codex.json
+documentation:
+  - 'https://nono.sh/docs/cli/features/networking.md'
+  - 'https://nono.sh/docs/cli/features/credential-injection.md'
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Scope
+
+Apply the three-level sandbox model to **codex**, following the pattern established in lince-98 (GH [#48](https://github.com/RisorseArtificiali/lince/issues/48)).
+
+Tracks GH issue [#49](https://github.com/RisorseArtificiali/lince/issues/49). Umbrella: [#47](https://github.com/RisorseArtificiali/lince/issues/47).
+
+> **Do not start until lince-98 is done.** This task assumes the runtime dispatch logic in the lince-dashboard plugin and the sandbox-policy mechanism in `agent-sandbox` are already in place from the claude prototype. Reuse them; don't redesign.
+
+## Background — full design context (no need to re-brainstorm)
+
+LINCE today exposes `[agents.codex]` (unsandboxed), `[agents.codex-bwrap]`, `[agents.codex-nono]` as separate entries. Decision: collapse to a **single** `[agents.codex]` driven by:
+
+- `sandbox_level = "paranoid" | "normal" | "permissive"` — default `"normal"`
+- `sandbox_backend = "bwrap" | "nono"` — default per OS
+
+`codex` (unsandboxed) becomes redundant if `sandbox_level = "off"` is supported by lince-98; otherwise keep as separate entry.
+
+LLM provider for proxy/credential injection: **openai** (nono keystore account: `openai_api_key`).
+
+## Codex-specific quirks (read carefully)
+
+- `bwrap_conflict = true` on `codex-bwrap` — codex has its own internal sandbox that conflicts with bwrap. The current entry passes `disable_inner_sandbox_args = ["--sandbox", "danger-full-access"]` to disable it. **Preserve this in all three levels.**
+- `ignore_wrapper_start = true` — keep
+- env var: `OPENAI_API_KEY` (passthrough today; in paranoid → injected by proxy, **not passed in env** to avoid leak)
+
+## Three levels — codex specifics
+
+| | paranoid | normal | permissive |
+|---|---|---|---|
+| nono `network` | `credentials: ["openai"]` | inherited from default preset | + `allow_domain` (api.github.com, github.com, objects.githubusercontent.com) + `credentials: ["openai"]` |
+| nono `filesystem` | `$WORKDIR` rw + scratch copy of `~/.codex` | as today (`lince-codex.json`) | + `~/.config/gh`, `~/.cache`, `~/.ssh/known_hosts` (read) |
+| bwrap | `use_real_config = false` forced + no-network + `disable_inner_sandbox_args` preserved | as today | + standard permissive paths + `disable_inner_sandbox_args` preserved |
+| Tools | — | — | `gh` CLI (no docker, no podman, no direct `git push`) |
+
+## File touch list
+
+**New:**
+- `lince-dashboard/nono-profiles/lince-codex-paranoid.json`
+- `lince-dashboard/nono-profiles/lince-codex-permissive.json`
+- `sandbox/profiles/codex-paranoid.toml`
+- `sandbox/profiles/codex-permissive.toml`
+
+**Modified:**
+- `lince-dashboard/agents-defaults.toml` — collapse codex entries (~lines 38-70 + 147-164)
+- `lince-dashboard/install.sh` — copy new nono profiles
+
+## Out of scope
+
+- docker/podman in permissive
+- direct `git push` (use gh)
+- Other agents (separate tasks)
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 agents-defaults.toml has a single [agents.codex] with sandbox_level/sandbox_backend; codex-nono removed
+- [ ] #2 Codex internal sandbox conflict preserved across all three levels (no regression in disable_inner_sandbox_args = ['--sandbox', 'danger-full-access'])
+- [ ] #3 OPENAI_API_KEY: passthrough in normal/permissive, proxy-injected in paranoid (no env var leak)
+- [ ] #4 sandbox_level=paranoid on nono: only api.openai.com reachable; arbitrary outbound fails
+- [ ] #5 sandbox_level=permissive: gh auth + gh pr work; docker ps fails
+- [ ] #6 N-picker shows 'OpenAI Codex' once
+- [ ] #7 Master doc page (sandbox-levels.md) extended with codex-specific rows: per-level behavior, codex quirks (inner-sandbox conflict, bwrap_conflict), OPENAI_API_KEY handling per level
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+## Documentation contribution
+
+Master doc page (created by lince-98 at `docs/documentation/dashboard/sandbox-levels.md`) already explains:
+- What paranoid/normal/permissive do in general
+- The customization mechanism (`sandbox_level` as free-form profile suffix)
+- The general worked example
+
+This task **extends** that doc with **codex-specific rows/notes**:
+- Add codex column or row to the level-comparison table (network, filesystem, tools per level)
+- Document codex-specific quirks: inner-sandbox conflict (`disable_inner_sandbox_args = ["--sandbox", "danger-full-access"]`), `bwrap_conflict = true`, OPENAI_API_KEY proxy injection in paranoid
+- Brief note on which custom-profile patterns are common for codex (e.g. "lince-codex-with-azure" for Azure OpenAI users)
+
+Do **not** re-explain the overall mechanism — link back to the master doc page.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/lince-99 - Three-sandbox-levels-—-codex-follow-up.md
+++ b/backlog/tasks/lince-99 - Three-sandbox-levels-—-codex-follow-up.md
@@ -4,7 +4,7 @@ title: Three sandbox levels — codex follow-up
 status: To Do
 assignee: []
 created_date: '2026-05-04 20:32'
-updated_date: '2026-05-04 20:50'
+updated_date: '2026-05-05 13:42'
 labels:
   - sandbox
   - lince-dashboard
@@ -107,4 +107,74 @@ This task **extends** that doc with **codex-specific rows/notes**:
 - Brief note on which custom-profile patterns are common for codex (e.g. "lince-codex-with-azure" for Azure OpenAI users)
 
 Do **not** re-explain the overall mechanism — link back to the master doc page.
+
+## Lessons from lince-98 (don't repeat the bugs we already hit)
+
+The claude prototype landed via PR #57 with 14+ commits, several of which were bug-fix iterations on issues that surfaced *during* execution. Capturing them here so codex doesn't redo them.
+
+### Required for codex (per-agent work)
+
+1. **Auto-map the API key in `sandbox/profiles/codex-paranoid.toml`'s `[env.extra]`.**
+   Without this, the credential proxy starts with zero rules and paranoid bails out with `unshare_net = true requires credential_proxy = true` (which is misleading because the proxy IS enabled — it just has nothing to inject). Pattern:
+   ```toml
+   [env.extra]
+   OPENAI_API_KEY = "$OPENAI_API_KEY"
+   ```
+   OpenAI does not have an `_AUTH_TOKEN` variant; one entry is enough. `_expand_env_value` returns empty string for unset host vars, and `_collect_proxy_rules` skips empties (sandbox/agent-sandbox:905), so this is safe even if the user hasn't exported the var — they just get the same "no rules" error which is the right outcome.
+
+2. **Add a codex match arm in `synthesize_sandboxed_command`** in `lince-dashboard/plugin/src/agent.rs`:
+   - `agent_home_subdir`: `.codex`
+   - `inner_command`: `vec!["codex".to_string(), "--full-auto".to_string()]`
+   You also need to handle the **codex inner-sandbox conflict** that breaks bwrap nesting. The existing `[agents.codex-bwrap]` entry passes `disable_inner_sandbox_args = ["--sandbox", "danger-full-access"]`. The synthesized argv currently does NOT read these from `agent_cfg`, so either hardcode them into codex's `inner_command` arm, or extend `synthesize_sandboxed_command` to take `agent_cfg` and append `disable_inner_sandbox_args` like the legacy path does (build_bwrap_cmd ~line 1917). Pick one and stick to it for the gemini/opencode/pi tasks.
+
+3. **Permissive must passthrough `GH_TOKEN` / `GITHUB_TOKEN`.** Copy the `[env]\npassthrough = ["GH_TOKEN", "GITHUB_TOKEN"]` block from `sandbox/profiles/claude-permissive.toml`. Users on gh keyring auth rely on the env-var path; the default `--clearenv` in bwrap wipes them otherwise.
+
+4. **Do NOT enumerate `allow_domains = ["api.openai.com"]`** in the paranoid fragment. `_is_allowed_host` already auto-includes any domain that has a credential rule. Ship `allow_domains = []` with a header comment showing how users extend it — same shape as `claude-paranoid.toml`. This was a back-and-forth in the review and the empty-list version is the correct one.
+
+### Things ALREADY in master code (don't redo them)
+
+- Fragment lookup tries `<agent>-<level>.toml` before `<level>.toml` (commit 077b37d3) — your `codex-paranoid.toml` is found automatically.
+- bwrap `--unshare-net` is set up by `cmd_run` via an outer `unshare -U -n -r` wrapper that brings up `lo`, runs socat as a TCP→unix-socket bridge, then exec's bwrap with `--unshare-user --uid <real_uid> --gid <real_gid>` so the agent does NOT inherit `getuid()==0` (Claude refused `--dangerously-skip-permissions` early on for that exact reason — same applies to codex's `--full-auto`).
+- Stale `~/.agent-sandbox/proxy-PID.sock` files from killed runs are swept at startup.
+- CredentialProxy framing fixes are global: `Connection: close`, no duplicate `Date`/`Server`, no stale `Content-Length` over chunked, `BrokenPipe`-safe `_safe_send_error`.
+- socat readiness fail-fast (`READY=0` loop + `exit 1`) — your wrapper inherits it.
+- shell_quote of `agent_id` / `project_dir` / `nono_profile` in the bash wrapper — already done in the synthesize function.
+
+### Sanity checks before declaring done
+
+```bash
+# Drop into a paranoid codex sandbox shell
+agent-sandbox run -a codex --sandbox-level paranoid -- bash
+
+# 1. Scratch copy works (should show scratch contents, not your real ~/.codex)
+ls -la ~/.codex/
+
+# 2. Network is kernel-isolated (expected: connection failure, NOT 403 from proxy)
+curl -s -o /dev/null https://attacker.com 2>&1
+
+# 3. OpenAI API still works through the proxy
+curl -s -x http://127.0.0.1:8118 https://api.openai.com/v1/models | head
+
+# 4. Inner-sandbox conflict still resolved (codex's own --sandbox flag was disabled)
+# verify by running codex normally and confirming it doesn't fail with bwrap-nesting errors
+
+# 5. From the host, only ONE running socat per running agent; killing the agent removes it
+pgrep -af 'socat.*8118'
+
+# 6. Stale-socket cleanup works (only the live agent's socket; no leftovers)
+ls ~/.agent-sandbox/proxy-*.sock 2>/dev/null
+```
+
+### Reference: the lince-98 commits that resolved each gotcha
+
+- `077b37d3` — fragment lookup with agent prefix
+- `9b214451` — auto-map ANTHROPIC_API_KEY in paranoid fragment
+- `9142c367` — `--unshare-user --uid` to remap UID
+- `a7933b48` — outer `unshare -U -n -r` wrapper instead of bwrap `--unshare-net`
+- `9e62cf12` — proxy framing (Connection: close, no duplicate headers)
+- `7f5898c4` — BrokenPipe handling in proxy
+- `858fe521` — GH_TOKEN/GITHUB_TOKEN passthrough
+- `405c3a11` / `5f987859` — review fixes (fail-fast socat, drop redundant `allow_domains`, dedupe shell_quote, stale-socket sweep)
+
+Reading the diffs of those commits is faster than re-discovering the same problem from a stack trace.
 <!-- SECTION:NOTES:END -->

--- a/docs/documentation/dashboard/sandbox-levels-testing.md
+++ b/docs/documentation/dashboard/sandbox-levels-testing.md
@@ -13,6 +13,11 @@ The Claude prototype is the only agent type wired to `sandbox_level` in this ite
   ```bash
   agent-sandbox --version
   ```
+- `socat` installed on the host (required for paranoid + bwrap; the bwrap netns reaches the credential proxy via a unix-socket bridge driven by `socat`). Verify:
+  ```bash
+  socat -V | head -n 1
+  ```
+  If missing: `sudo dnf install socat` (Fedora) or `sudo apt install socat` (Debian/Ubuntu).
 - nono installed and on `$PATH`. Verify:
   ```bash
   nono --version
@@ -61,22 +66,30 @@ The Claude prototype is the only agent type wired to `sandbox_level` in this ite
 3. Spawn a Claude agent: press `n` in the dashboard, accept defaults.
 
 #### Inside the sandbox (run in claude's bash pane)
-- Command: `curl -s -o /dev/null -w "%{http_code}\n" https://example.com`
-  - Expected: non-200 / connection failure (DNS or TCP error). Network outside Anthropic must be blocked.
+- Command: `curl -s -o /dev/null -w "%{http_code}\n" https://attacker.com 2>&1`
+  - Expected: kernel-level connection failure (e.g. `Could not resolve host: attacker.com` or `Network is unreachable`), **not** a 403 from a proxy. This verifies the bwrap netns isolation: the sandbox has no route to anywhere except its own loopback.
+- Command: `python3 -c "import socket; s=socket.socket(); s.settimeout(3); s.connect(('1.1.1.1', 443))"`
+  - Expected: `OSError` (typically `Network is unreachable` or `No route to host`). The fresh netns has no route to non-loopback addresses, so even raw-socket bypasses of `HTTP_PROXY` fail.
+- Command: `printenv | grep -E "(ANTHROPIC|OPENAI|GEMINI)_API_KEY"`
+  - Expected: empty output. The credential proxy strips API keys from the sandbox environment.
 - Command: send a chat message that triggers a real Anthropic API call.
-  - Expected: normal response. The credential proxy injects the API key on the host side.
+  - Expected: normal response. The agent reaches the credential proxy via `HTTP_PROXY=http://127.0.0.1:8118`, which the in-sandbox `socat` helper bridges to the host-side proxy over the unix socket at `/run/lince-proxy.sock`.
 - Command: `ls -la ~/.claude/`
   - Expected: a scratch copy of claude settings, NOT the real one. No personal history files outside what was rsync-seeded at spawn.
 - Command: `touch ~/.claude/MUTATED_BY_AGENT && ls ~/.claude/MUTATED_BY_AGENT`
   - Expected: file exists inside the scratch copy.
 
-#### Outside the sandbox (host shell, after the previous step)
+#### Outside the sandbox (host shell, while the agent is still running)
 - Command: `ls ~/.claude/MUTATED_BY_AGENT`
   - Expected: `No such file or directory`. The real config is untouched.
+- Command: `pgrep -af socat`
+  - Expected: at least one `socat` process per running paranoid+bwrap agent, listening on the per-agent unix socket and bridging to `127.0.0.1:8118` inside the netns.
 
 #### After agent stop
 - Command: `ls "$XDG_RUNTIME_DIR"/lince-* 2>/dev/null`
   - Expected: no output. Cleanup ran and the scratch copy is gone.
+- Command: `pgrep -af socat | grep lince-proxy`
+  - Expected: no output. The bridge `socat` was torn down with the agent.
 
 ### 3.2 Cell: paranoid x nono (linux)
 
@@ -231,6 +244,35 @@ Run only if a macOS host is available. Same commands as 3.5.
 
 Run only if a macOS host is available. Same commands as 3.8.
 
+### 3.10 Cell: paranoid + extra domain via `config.toml` override (linux, bwrap)
+
+Verifies that `allow_domains` is append-merged with the paranoid fragment, so a user can extend the allowlist without writing a custom level.
+
+#### Setup
+1. In `~/.agent-sandbox/config.toml` (create the file if absent), add:
+   ```toml
+   [security]
+   allow_domains = ["github.com", "api.github.com", "objects.githubusercontent.com"]
+   ```
+2. In `~/.config/lince-dashboard/config.toml`:
+   ```toml
+   [agents.claude]
+   sandbox_level = "paranoid"
+   sandbox_backend = "bwrap"
+   ```
+3. Restart Zellij and spawn a Claude agent inside the test project.
+
+#### Inside the sandbox
+- Command: `gh auth status`
+  - Expected: `Logged in to github.com`. The proxy CONNECT to `api.github.com` is allowed by the extended allowlist; kernel netns isolation is unchanged because traffic still flows through the proxy.
+- Command: `curl -s -o /dev/null -w "%{http_code}\n" https://attacker.com 2>&1`
+  - Expected: still a kernel-level failure. Extending `allow_domains` does not punch a hole for non-allowlisted hosts.
+- Command: `printenv | grep -E "(ANTHROPIC|OPENAI|GEMINI)_API_KEY"`
+  - Expected: empty. Credential injection still applies to Anthropic; GitHub traffic passes through without injection.
+
+#### Cleanup
+Remove the `[security]` block from `~/.agent-sandbox/config.toml` to return paranoid to its default allowlist.
+
 ## 4. Custom-level smoke test
 
 Walk through creating a custom level following the customization story in the design doc.
@@ -281,6 +323,7 @@ Things that must STILL work after the change.
 - N-picker shows **"Claude Code"** once. It must NOT show "Claude Code", "Claude Code (nono)", and "Claude Code (sandboxed)" all at once.
 - `[agents.claude-unsandboxed]` is still spawnable. It is a separate entry, not a level.
 - Existing agents that have NOT been migrated yet — `codex`, `gemini`, `opencode`, `pi` — still spawn and work as before. They have no `sandbox_level` and fall back to the static command.
+- When `sandbox_level` is **not** paranoid (e.g. `permissive` or `normal`), the bwrap sandbox stays in the host network namespace — `--unshare-net` must NOT be set. Verify by running `ip route` from inside a permissive agent shell: it should show the host's default route, not just `lo`. Equivalently, no `socat` bridge process should be spawned for non-paranoid agents (`pgrep -af socat | grep lince-proxy` returns empty).
 - `install.sh` is idempotent. Re-running on an already-installed system prints no errors and overwrites profiles cleanly.
 - The WASM plugin builds clean:
   ```bash
@@ -300,5 +343,6 @@ Tester ticks each box that was actually run and passed. Cells skipped due to pla
 - [ ] 3.7 permissive x bwrap (linux)
 - [ ] 3.8 permissive x nono (linux)
 - [ ] 3.9 permissive x nono (macOS)
+- [ ] 3.10 paranoid + extra domain via `config.toml` override (linux, bwrap)
 - [ ] 4. Custom-level smoke test (including typo fallback)
 - [ ] 5. Regression checklist (all items)

--- a/docs/documentation/dashboard/sandbox-levels-testing.md
+++ b/docs/documentation/dashboard/sandbox-levels-testing.md
@@ -1,0 +1,304 @@
+# Sandbox Levels — Manual Test Plan
+
+See [`sandbox-levels.md`](./sandbox-levels.md) for the design and configuration reference.
+
+This is a pre-merge checklist for the LINCE three-level sandbox feature (`paranoid` / `normal` / `permissive`) on the Claude Code agent prototype. Each cell of `level x backend` has its own block of commands. Run the cells that apply to your platform, then walk the regression checklist, then sign off at the bottom.
+
+The Claude prototype is the only agent type wired to `sandbox_level` in this iteration. Other agent types (codex, gemini, opencode, pi) are explicitly part of the regression checklist below — they must keep working unchanged.
+
+## 1. Prerequisites
+
+- LINCE installed: `zd` alias works, dashboard launches via `zellij --layout dashboard`.
+- agent-sandbox (`bwrap` backend) installed and on `$PATH`. Verify:
+  ```bash
+  agent-sandbox --version
+  ```
+- nono installed and on `$PATH`. Verify:
+  ```bash
+  nono --version
+  ```
+- Anthropic API key exported in the env (used by `normal` and `permissive`):
+  ```bash
+  export ANTHROPIC_API_KEY="sk-ant-..."
+  ```
+- Anthropic API key stored in the nono keystore (used by `paranoid` on the nono backend). Run once per machine:
+  - Linux (libsecret / GNOME Keyring / KWallet):
+    ```bash
+    secret-tool store --label "nono anthropic" service nono account anthropic_api_key
+    ```
+  - macOS (Keychain):
+    ```bash
+    security add-generic-password -s "nono" -a "anthropic_api_key" -w "sk-ant-..."
+    ```
+- A clean test project directory:
+  ```bash
+  mkdir -p /tmp/lince-test && cd /tmp/lince-test && git init
+  ```
+- A GitHub token reachable from `~/.config/gh` (`gh auth login` once on the host) — required only for the `permissive` cells.
+
+## 2. Test matrix
+
+| Level x Backend | bwrap (linux)    | nono (linux)     | nono (macOS)              |
+|-----------------|------------------|------------------|---------------------------|
+| paranoid        | yes              | yes              | yes (if mac available)    |
+| normal          | smoke regression | smoke regression | smoke regression          |
+| permissive      | yes              | yes              | yes (if mac available)    |
+
+`bwrap` on macOS is **not applicable** — agent-sandbox is Linux-only. Skip those cells on macOS hosts.
+
+## 3. Test cells
+
+### 3.1 Cell: paranoid x bwrap (linux)
+
+#### Setup
+1. In `~/.config/lince-dashboard/config.toml`, set or override:
+   ```toml
+   [agents.claude]
+   sandbox_level = "paranoid"
+   sandbox_backend = "bwrap"
+   ```
+2. Restart Zellij so the plugin reloads the config.
+3. Spawn a Claude agent: press `n` in the dashboard, accept defaults.
+
+#### Inside the sandbox (run in claude's bash pane)
+- Command: `curl -s -o /dev/null -w "%{http_code}\n" https://example.com`
+  - Expected: non-200 / connection failure (DNS or TCP error). Network outside Anthropic must be blocked.
+- Command: send a chat message that triggers a real Anthropic API call.
+  - Expected: normal response. The credential proxy injects the API key on the host side.
+- Command: `ls -la ~/.claude/`
+  - Expected: a scratch copy of claude settings, NOT the real one. No personal history files outside what was rsync-seeded at spawn.
+- Command: `touch ~/.claude/MUTATED_BY_AGENT && ls ~/.claude/MUTATED_BY_AGENT`
+  - Expected: file exists inside the scratch copy.
+
+#### Outside the sandbox (host shell, after the previous step)
+- Command: `ls ~/.claude/MUTATED_BY_AGENT`
+  - Expected: `No such file or directory`. The real config is untouched.
+
+#### After agent stop
+- Command: `ls "$XDG_RUNTIME_DIR"/lince-* 2>/dev/null`
+  - Expected: no output. Cleanup ran and the scratch copy is gone.
+
+### 3.2 Cell: paranoid x nono (linux)
+
+#### Setup
+1. In `~/.config/lince-dashboard/config.toml`:
+   ```toml
+   [agents.claude]
+   sandbox_level = "paranoid"
+   sandbox_backend = "nono"
+   ```
+2. Restart Zellij.
+3. Spawn a Claude agent.
+
+#### Inside the sandbox
+- Command: `curl -s -o /dev/null -w "%{http_code}\n" https://example.com`
+  - Expected: connection failure. Under nono this is kernel-enforced via Landlock + nono's network policy.
+- Command: send a chat message that triggers a real Anthropic API call.
+  - Expected: normal response (credential proxy injects key).
+- Command: `ls -la ~/.claude/`
+  - Expected: scratch copy via the per-agent home, not the real `~/.claude`.
+- Command: `touch ~/.claude/MUTATED_BY_AGENT && ls ~/.claude/MUTATED_BY_AGENT`
+  - Expected: file present inside the scratch copy.
+
+#### Outside the sandbox
+- Command: `ls ~/.claude/MUTATED_BY_AGENT`
+  - Expected: `No such file or directory`.
+
+#### After agent stop
+- Command: `ls "$XDG_RUNTIME_DIR"/lince-* 2>/dev/null`
+  - Expected: no output.
+
+### 3.3 Cell: paranoid x nono (macOS)
+
+Run only if a macOS host is available.
+
+#### Setup
+1. Same config block as 3.2 in `~/.config/lince-dashboard/config.toml`.
+2. Restart Zellij.
+3. Spawn a Claude agent.
+
+#### Inside the sandbox
+- Command: `curl -s -o /dev/null -w "%{http_code}\n" https://example.com`
+  - Expected: connection failure. macOS uses Seatbelt for filesystem isolation plus nono's network policy.
+- Command: send a chat message that triggers a real Anthropic API call.
+  - Expected: normal response.
+- Command: `ls -la ~/.claude/`
+  - Expected: scratch copy, not the real one.
+- Command: `touch ~/.claude/MUTATED_BY_AGENT && ls ~/.claude/MUTATED_BY_AGENT`
+  - Expected: file inside scratch.
+
+#### Outside the sandbox
+- Command: `ls ~/.claude/MUTATED_BY_AGENT`
+  - Expected: `No such file or directory`.
+
+#### After agent stop
+- Command: `ls /tmp/lince-* 2>/dev/null` (macOS does not export `XDG_RUNTIME_DIR` by default)
+  - Expected: no output.
+
+### 3.4 Cell: normal x bwrap (linux) — smoke regression
+
+#### Setup
+1. In `~/.config/lince-dashboard/config.toml`:
+   ```toml
+   [agents.claude]
+   sandbox_level = "normal"
+   sandbox_backend = "bwrap"
+   ```
+2. Restart Zellij.
+3. Spawn a Claude agent.
+
+#### Inside the sandbox
+- Command: send a chat message that triggers a real Anthropic API call.
+  - Expected: normal response.
+- Command: `curl -s -o /dev/null -w "%{http_code}\n" https://example.com`
+  - Expected: failure — `normal` does not open arbitrary outbound HTTPS.
+- Command: `ls ~/.claude/`
+  - Expected: access works. `bwrap` uses an isolated copy via the default `use_real_config = false`; behavior is unchanged from pre-merge.
+
+Confirm nothing about pre-merge behavior changed.
+
+### 3.5 Cell: normal x nono (linux) — smoke regression
+
+#### Setup
+1. Same as 3.4 with `sandbox_backend = "nono"`.
+2. Restart Zellij.
+3. Spawn a Claude agent.
+
+#### Inside the sandbox
+- Command: send a chat message that triggers a real Anthropic API call.
+  - Expected: normal response.
+- Command: `curl -s -o /dev/null -w "%{http_code}\n" https://example.com`
+  - Expected: failure.
+- Command: `ls ~/.claude/`
+  - Expected: access works (inherited `claude-code` upstream nono preset).
+
+### 3.6 Cell: normal x nono (macOS) — smoke regression
+
+Run only if a macOS host is available. Same commands as 3.5.
+
+### 3.7 Cell: permissive x bwrap (linux)
+
+#### Setup
+1. In `~/.config/lince-dashboard/config.toml`:
+   ```toml
+   [agents.claude]
+   sandbox_level = "permissive"
+   sandbox_backend = "bwrap"
+   ```
+2. Restart Zellij.
+3. Spawn a Claude agent inside the test project (`/tmp/lince-test`).
+
+#### Inside the sandbox
+- Command: `gh auth status`
+  - Expected: `Logged in to github.com`. Token reachable via mounted `~/.config/gh`.
+- Command: `gh repo view RisorseArtificiali/lince`
+  - Expected: repo metadata returned. `api.github.com` is reachable.
+- Command: `curl -s -o /dev/null -w "%{http_code}\n" https://example.com`
+  - Expected: failure. Only allowlisted hosts (Anthropic + GitHub) reach out.
+- Command: `docker ps 2>&1`
+  - Expected: `command not found` or permission denied. Docker is deliberately excluded.
+- Command: `git push origin HEAD 2>&1`
+  - Expected: failure (`block_git_push = true` in the bwrap fragment, or no SSH agent in scope).
+
+#### Workflow check
+- Have the agent create a branch, commit a small change, and run `gh pr create --fill`.
+  - Expected: PR opened against the project's GitHub remote.
+
+### 3.8 Cell: permissive x nono (linux)
+
+#### Setup
+1. Same as 3.7 with `sandbox_backend = "nono"`.
+2. Restart Zellij.
+3. Spawn a Claude agent.
+
+#### Inside the sandbox
+- Command: `gh auth status`
+  - Expected: `Logged in to github.com`.
+- Command: `gh repo view RisorseArtificiali/lince`
+  - Expected: repo metadata returned.
+- Command: `curl -s -o /dev/null -w "%{http_code}\n" https://example.com`
+  - Expected: failure.
+- Command: `docker ps 2>&1`
+  - Expected: `command not found` / not reachable.
+- Command: `git push origin HEAD 2>&1`
+  - Expected: failure (no SSH agent reachable; HTTPS push blocked unless explicitly added to allowlist).
+
+#### Workflow check
+- Have the agent create a branch, commit, and run `gh pr create --fill`.
+  - Expected: PR opened.
+
+### 3.9 Cell: permissive x nono (macOS)
+
+Run only if a macOS host is available. Same commands as 3.8.
+
+## 4. Custom-level smoke test
+
+Walk through creating a custom level following the customization story in the design doc.
+
+1. Create the profile file `~/.config/nono/profiles/lince-claude-mytest.json`:
+   ```json
+   {
+     "extends": "lince-claude",
+     "meta": {
+       "name": "lince-claude-mytest",
+       "description": "Custom test level"
+     },
+     "filesystem": {
+       "allow": ["$WORKDIR"],
+       "read": ["$HOME/.local/share/test-data"]
+     },
+     "network": {
+       "credentials": ["anthropic"]
+     }
+   }
+   ```
+2. Create the matching read-source on the host:
+   ```bash
+   mkdir -p ~/.local/share/test-data && echo "hello" > ~/.local/share/test-data/marker
+   ```
+3. In `~/.config/lince-dashboard/agents-defaults.toml` (user override), set:
+   ```toml
+   [agents.claude]
+   sandbox_level = "mytest"
+   sandbox_backend = "nono"
+   ```
+4. Restart Zellij and spawn a Claude agent.
+5. Inside the sandbox:
+   - Command: `ls ~/.local/share/test-data/`
+     - Expected: `marker` is listed.
+   - Command: `cat ~/.local/share/test-data/marker`
+     - Expected: `hello`.
+
+#### Fallback for typos
+1. Set `sandbox_level = "doesnotexist"` in the same override file.
+2. Restart Zellij and try to spawn the agent.
+3. Expected: the plugin emits a clear error in the pane title or stderr (no profile resolved). The plugin must NOT hard-crash; the dashboard stays responsive.
+
+## 5. Regression checklist
+
+Things that must STILL work after the change.
+
+- N-picker shows **"Claude Code"** once. It must NOT show "Claude Code", "Claude Code (nono)", and "Claude Code (sandboxed)" all at once.
+- `[agents.claude-unsandboxed]` is still spawnable. It is a separate entry, not a level.
+- Existing agents that have NOT been migrated yet — `codex`, `gemini`, `opencode`, `pi` — still spawn and work as before. They have no `sandbox_level` and fall back to the static command.
+- `install.sh` is idempotent. Re-running on an already-installed system prints no errors and overwrites profiles cleanly.
+- The WASM plugin builds clean:
+  ```bash
+  cd lince-dashboard/plugin && PATH="$HOME/.cargo/bin:$PATH" $HOME/.cargo/bin/cargo build --release --target wasm32-wasip1
+  ```
+
+## 6. Sign-off
+
+Tester ticks each box that was actually run and passed. Cells skipped due to platform unavailability (e.g. macOS) should be left unchecked and noted in the merge description.
+
+- [ ] 3.1 paranoid x bwrap (linux)
+- [ ] 3.2 paranoid x nono (linux)
+- [ ] 3.3 paranoid x nono (macOS)
+- [ ] 3.4 normal x bwrap (linux) — smoke regression
+- [ ] 3.5 normal x nono (linux) — smoke regression
+- [ ] 3.6 normal x nono (macOS) — smoke regression
+- [ ] 3.7 permissive x bwrap (linux)
+- [ ] 3.8 permissive x nono (linux)
+- [ ] 3.9 permissive x nono (macOS)
+- [ ] 4. Custom-level smoke test (including typo fallback)
+- [ ] 5. Regression checklist (all items)

--- a/docs/documentation/dashboard/sandbox-levels.md
+++ b/docs/documentation/dashboard/sandbox-levels.md
@@ -163,6 +163,46 @@ block_git_push = true
 
 **Tools.** Adds the `gh` CLI. Direct `git push` is still blocked; the intended push path is `gh pr create` / `gh repo sync`. Docker and Podman are not in scope and are not made reachable — that is a much wider trust boundary and is tracked separately.
 
+**Recommended `gh` token: fine-grained PAT, scoped, non-destructive.** A prompt-injected agent at permissive level can read your `gh` token and act as you on GitHub. The default `gh auth login` token from a CLI device flow inherits broad `repo` scope and can do anything you can do — including delete branches, force-push, change repo settings, and read your other repos. Reduce the blast radius by giving the sandbox its own *fine-grained personal access token*, scoped to only the repository (or repositories) the agent is meant to work on, with permissions chosen so a leaked or coerced token cannot do destructive things.
+
+Create one at <https://github.com/settings/personal-access-tokens/new>:
+
+- **Token name**: pick something recognizable, e.g. `lince-permissive-<repo>` or `lince-sandbox-<project>`.
+- **Expiration**: 30–90 days. Rotation is part of the safety budget.
+- **Repository access**: select **Only select repositories** and choose the specific repo(s) you want the agent to operate on. Do not pick "All repositories".
+- **Account permissions** (left column): leave everything at *No access*. The agent does not need them.
+- **Repository permissions** (right column) — these are the sensible defaults for "agent that reads code, opens PRs, manages issues, does not destroy anything":
+
+  | Permission             | Setting        | Why                                                  |
+  | ---------------------- | -------------- | ---------------------------------------------------- |
+  | Metadata               | Read-only      | Required by all repo operations                      |
+  | Contents               | Read and write | Read code, push branches the agent created           |
+  | Pull requests          | Read and write | Open PRs, push review comments, update PR body       |
+  | Issues                 | Read and write | Read issue context, comment, label                   |
+  | Commit statuses        | Read-only      | Lets `gh pr checks` show CI state                    |
+  | Actions                | Read-only      | View workflow runs without re-triggering or editing  |
+  | Workflows              | **No access**  | Writing workflows from a sandbox is a clear escalation path — agents should not edit `.github/workflows/*` |
+  | Administration         | **No access**  | No settings changes, no protections relaxed          |
+  | Webhooks               | **No access**  | Webhook control is a back door to repo events        |
+  | Secrets / Variables    | **No access**  | Never hand the agent the keys to other tools         |
+  | Environments           | **No access**  | Same reasoning as Secrets                            |
+  | Codespaces / Pages     | **No access**  | Out of scope for typical agent work                  |
+
+  Anything not listed: leave at *No access*. The above set is enough for the workflows the permissive level was designed for (`gh pr create`, `gh issue comment`, branch push, PR review). Add more only when an agent task actually fails, and revisit this list when GitHub adds new permission scopes.
+
+- **Click "Generate token"** and copy the value somewhere safe (you cannot see it again).
+
+Then point `gh` inside the sandbox at that token instead of your daily one. The cleanest way is to keep the token out of `~/.config/gh/` (which is bind-mounted read-only) and pass it as an environment variable — `GH_TOKEN` is already in the permissive fragment's `[env].passthrough`:
+
+```bash
+export GH_TOKEN='github_pat_...'   # from "Generate token"
+zd                                  # launch the dashboard normally
+```
+
+`gh` inside the sandbox finds `GH_TOKEN` via the passthrough, ignores the broader OAuth token in `~/.config/gh/hosts.yml` (which the agent can still read but `gh` does not prefer when `GH_TOKEN` is set), and operates with the narrow permissions you granted. When you stop the dashboard, `unset GH_TOKEN` if you want the host shell to fall back to your daily token.
+
+If you would rather keep the token in a file: GitHub also accepts the fine-grained PAT through `gh auth login --with-token`, which writes it to `hosts.yml` instead of relying on the env var. Pick whichever fits your habits — the security gain comes from the token's scope, not from how it's stored.
+
 **What you'd see inside.**
 
 ```

--- a/docs/documentation/dashboard/sandbox-levels.md
+++ b/docs/documentation/dashboard/sandbox-levels.md
@@ -1,0 +1,273 @@
+# Sandbox Levels
+
+LINCE ships three sandbox levels — `paranoid`, `normal`, `permissive` — that let you dial network and filesystem exposure per agent without spawning a separate dashboard entry for every variant. This page documents what each level grants, how to pick one, how to switch backends, and how to ship your own custom level.
+
+## 1. Overview
+
+Sandboxing isolates an AI coding agent from the rest of your machine: the agent sees the project directory and a curated slice of your home, talks to a curated set of network endpoints, and cannot touch your SSH keys, AWS credentials, or arbitrary parts of the filesystem. The goal is to bound the blast radius of a prompt-injected, hallucinating, or simply over-eager agent.
+
+Until recently each combination of "agent type + isolation tightness" required its own entry in `agents-defaults.toml`. The three shipped levels collapse that: every agent type can be launched at any of the three levels through a single `sandbox_level` knob. `paranoid` keeps the agent on a strict diet (one API endpoint, scratch config), `normal` is the default daily-work setting, and `permissive` opens up GitHub and the `gh` CLI for users who need to push branches and open PRs from inside the sandbox.
+
+## 2. The three shipped levels
+
+The table below summarises the differences. Sections after it give the concrete config snippets and behavior for each level.
+
+| Aspect                | paranoid                                | normal                       | permissive                                                                   |
+|-----------------------|-----------------------------------------|------------------------------|------------------------------------------------------------------------------|
+| Network               | Anthropic API only (proxy)              | inherited base               | + GitHub + gh CLI domains                                                    |
+| Filesystem            | $WORKDIR + scratch ~/.claude            | as today                     | + ~/.config/gh, ~/.cache, ~/.ssh/known_hosts                                 |
+| `gh` CLI              | no                                      | no                           | yes                                                                          |
+| `docker` / `podman`   | no                                      | no                           | **no** (out of scope)                                                        |
+| direct `git push`     | no                                      | no                           | **no** (use `gh` instead)                                                    |
+
+### 2.1 Paranoid
+
+**Network.** Only the Anthropic API is reachable. All requests go through nono's credential proxy, which injects the API key on the host side; the key never enters the sandbox environment. Everything else — DNS for arbitrary hosts, plain HTTPS to other services, even `pip install` from PyPI — fails.
+
+nono profile (`~/.config/nono/profiles/lince-claude-paranoid.json`):
+
+```json
+{
+  "extends": "lince-claude",
+  "meta": {
+    "name": "lince-claude-paranoid",
+    "description": "Claude Code, paranoid sandbox"
+  },
+  "filesystem": {
+    "allow": ["$WORKDIR", "$HOME"],
+    "read": []
+  },
+  "network": {
+    "credentials": ["anthropic"]
+  }
+}
+```
+
+agent-sandbox (bwrap) fragment, loaded as `sandbox/profiles/claude-paranoid.toml`:
+
+```toml
+[claude]
+use_real_config = false
+
+[security]
+credential_proxy = true
+```
+
+**Filesystem.** The agent gets read/write on `$WORKDIR` (the project directory). `~/.claude` is **not** mounted from your real home — instead `use_real_config = false` (bwrap) and `allow: ["$HOME"]` over a per-agent home (nono) cause the agent to start with a fresh, scratch `~/.claude` that gets `rsync`-seeded from your real config at spawn and discarded when the agent stops. Anything the agent writes to its config dir stays inside that scratch copy.
+
+**Tools.** The agent has its own binary, `git` for local commits, and the standard core utilities. No `gh`, no `curl` to arbitrary hosts, no `docker`, no `podman`.
+
+**What you'd see inside.**
+
+```
+$ curl https://example.com
+curl: (6) Could not resolve host: example.com
+
+$ gh auth status
+gh: command not found  (or: no valid credential found)
+
+$ docker ps
+docker: command not found
+```
+
+### 2.2 Normal
+
+**Network.** Whatever the base profile of the agent type allows (for `lince-claude` that means the Anthropic API via the credential proxy, plus whatever the `claude-code` upstream nono preset opens up — typically just the Anthropic endpoint). No explicit GitHub allowlist.
+
+nono profile (`~/.config/nono/profiles/lince-claude.json`):
+
+```json
+{
+  "extends": "claude-code",
+  "meta": {
+    "name": "lince-claude",
+    "description": "LINCE sandbox profile for Claude Code"
+  },
+  "filesystem": {
+    "allow": ["$WORKDIR"],
+    "read": ["$HOME/.local/lib"]
+  },
+  "security": {
+    "signal_mode": "allow_same_sandbox"
+  }
+}
+```
+
+For agent-sandbox there is no extra fragment at the `normal` level — it is just the resolved config from `~/.agent-sandbox/config.toml` and the agent's `[claude]` section, with the credential proxy on. This is the level the dashboard ships with by default.
+
+**Filesystem.** Read/write on `$WORKDIR`, read on `$HOME/.local/lib` (so site-packages and similar are visible), the real `~/.claude` mounted read-only or read-write depending on backend defaults. SSH keys, AWS credentials, the rest of `$HOME` — invisible.
+
+**Tools.** Same as paranoid plus whatever the agent's base profile carries. No `gh` unless you opt in.
+
+**What you'd see inside.**
+
+```
+$ curl https://example.com         # fails — not in allowlist
+$ git commit -am 'wip'              # works (local)
+$ gh auth status                    # gh not present
+```
+
+### 2.3 Permissive
+
+**Network.** Anthropic API plus an explicit GitHub allowlist: `api.github.com`, `github.com`, `objects.githubusercontent.com`. Enough for `gh auth status`, `gh pr create`, `gh issue list`, and `git fetch`/`git clone` over HTTPS against those hosts.
+
+nono profile (`~/.config/nono/profiles/lince-claude-permissive.json`):
+
+```json
+{
+  "extends": "lince-claude",
+  "meta": {
+    "name": "lince-claude-permissive",
+    "description": "Claude Code, permissive sandbox"
+  },
+  "filesystem": {
+    "allow": ["$WORKDIR"],
+    "read": [
+      "$HOME/.config/gh",
+      "$HOME/.cache",
+      "$HOME/.ssh/known_hosts",
+      "$HOME/.local/lib"
+    ]
+  },
+  "network": {
+    "network_profile": "developer",
+    "credentials": ["anthropic"],
+    "allow_domain": [
+      "api.github.com",
+      "github.com",
+      "objects.githubusercontent.com"
+    ]
+  }
+}
+```
+
+agent-sandbox (bwrap) fragment, `sandbox/profiles/claude-permissive.toml`:
+
+```toml
+[sandbox]
+home_ro_dirs = [".config/gh", ".cache", ".ssh/known_hosts"]
+
+[security]
+credential_proxy = true
+block_git_push = true
+```
+
+**Filesystem.** Read/write on `$WORKDIR`. Read-only on `~/.config/gh` (so `gh` finds its token), `~/.cache` (general tool cache reuse), and `~/.ssh/known_hosts` (so SSH-style git remotes don't trip on host-key prompts — the private SSH keys themselves are still hidden).
+
+**Tools.** Adds the `gh` CLI. Direct `git push` is still blocked; the intended push path is `gh pr create` / `gh repo sync`. Docker and Podman are not in scope and are not made reachable — that is a much wider trust boundary and is tracked separately.
+
+**What you'd see inside.**
+
+```
+$ gh auth status
+github.com — Logged in to github.com as <user> (oauth_token)
+
+$ gh pr create --fill
+https://github.com/.../pull/123
+
+$ git push origin HEAD
+fatal: remote-helper exited (blocked by sandbox: use `gh` instead)
+
+$ docker ps
+docker: command not found
+```
+
+## 3. How to choose a level
+
+- **paranoid** when you are running an agent on an untrusted prompt, an unfamiliar repository, or any input you wouldn't paste into a root shell. The agent still does its job for the LLM API path; everything else is denied.
+- **normal** for daily work on your own code, where you want the agent to read/write the project, talk to its model, and not much else. This is the right default for most users most of the time.
+- **permissive** when you specifically need the agent to inspect or open PRs against GitHub and you accept that `~/.config/gh` is now visible inside the sandbox. The trade-off is real: a prompt-injected agent at this level can read your `gh` token and act as you on GitHub, scoped to whatever permissions that token holds.
+- **custom** (see below) when none of the three fit — for example if you need AWS Bedrock, a private Hugging Face mirror, or a corporate proxy.
+
+## 4. Selecting a sandbox backend
+
+The dashboard supports two backends, switched per agent via `sandbox_backend`:
+
+- `sandbox_backend = "bwrap"` — agent-sandbox, Linux only, isolation via Bubblewrap mount/PID namespaces and a host-side credential proxy.
+- `sandbox_backend = "nono"` — nono, Linux + macOS, isolation via Landlock (Linux) or Seatbelt (macOS) plus nono's own network policy engine.
+
+The default is per-OS: Linux picks `bwrap` (agent-sandbox), macOS picks `nono`. A Linux user who wants kernel-enforced filesystem isolation via Landlock can override that and pick `nono` explicitly.
+
+**Important asymmetry.** The two backends do not enforce paranoid the same way. Under nono, paranoid is **kernel-enforced**: Landlock restricts the filesystem and nono's native network policy restricts outbound connections. Under bwrap, paranoid is **proxy-enforced**: `use_real_config = false` keeps writes inside the scratch config copy and the credential proxy strips API keys from the sandbox environment, but the bwrap sandbox today does not run with `--unshare-net`. Adding `--unshare-net` would give the sandbox its own loopback and break the host-side credential proxy at `127.0.0.1:PORT`, which is what carries every LLM API call. Tightening this path requires a unix-socket proxy or an in-namespace proxy and is tracked as separate hardening work.
+
+In practice: if you want the strongest available network isolation under paranoid, run on a host where nono is available and set `sandbox_backend = "nono"`.
+
+## 5. Customization
+
+`sandbox_level` is a **free-form profile suffix, not a closed enum**. The three shipped levels are opinionated examples of how to use it. You are expected to ship your own when the defaults don't fit.
+
+The plugin synthesizes the launch command from `(agent_type, sandbox_backend, sandbox_level)` and resolves to a profile file by name. As long as a profile file exists at the expected path, any string works as a level.
+
+File-naming convention:
+
+- **nono**: `~/.config/nono/profiles/lince-<agent>-<level>.json`
+- **agent-sandbox**: `~/.agent-sandbox/profiles/<level>.toml` (or in-repo `sandbox/profiles/<level>.toml` for built-ins)
+
+### Worked example: a custom level for AWS Bedrock
+
+Suppose you want a Claude Code agent that can also reach AWS Bedrock. Create `~/.config/nono/profiles/lince-claude-with-aws.json`:
+
+```json
+{
+  "extends": "lince-claude",
+  "meta": {
+    "name": "lince-claude-with-aws",
+    "description": "claude + AWS Bedrock access"
+  },
+  "filesystem": {
+    "allow": ["$WORKDIR"],
+    "read": ["$HOME/.aws"]
+  },
+  "network": {
+    "credentials": ["anthropic"],
+    "allow_domain": ["bedrock-runtime.us-east-1.amazonaws.com"]
+  }
+}
+```
+
+What each field grants:
+
+- `extends: "lince-claude"` — start from the LINCE `normal` preset (which itself extends nono's built-in `claude-code` preset). The chain is: `claude-code` (nono built-in) → `lince-claude` (LINCE normal) → `lince-claude-with-aws` (your custom).
+- `filesystem.allow: ["$WORKDIR"]` — read/write on the project dir, as before.
+- `filesystem.read: ["$HOME/.aws"]` — read-only access to your AWS credentials and config. The agent can use them but cannot modify them.
+- `network.credentials: ["anthropic"]` — keeps the Anthropic credential proxy injection on.
+- `network.allow_domain: [...]` — opens exactly one extra outbound host: the Bedrock runtime endpoint for `us-east-1`. Other AWS endpoints, and the rest of the internet, remain blocked.
+
+Then in `~/.config/lince-dashboard/config.toml`:
+
+```toml
+[agents.claude]
+sandbox_level = "with-aws"
+```
+
+The next time you spawn a Claude Code agent it will launch with `lince-claude-with-aws` instead of `lince-claude`.
+
+For agent-sandbox (bwrap) users, the equivalent is a TOML fragment at `~/.agent-sandbox/profiles/with-aws.toml` deep-merged into the resolved config (lists appended, scalars overridden); flip the same `sandbox_level = "with-aws"` switch in `agents-defaults.toml` (or in the user `[agents.claude]` override block of `config.toml`) to activate it.
+
+## 6. Keystore setup for paranoid
+
+Paranoid relies on the Anthropic API key being in nono's credential keystore — **not** in `ANTHROPIC_API_KEY` in your environment. The point is that the key never enters the sandbox process tree; nono injects the `Authorization` header on the host side as the request flows through the credential proxy.
+
+Store the key once per machine:
+
+- **macOS** (Keychain):
+
+  ```bash
+  security add-generic-password -s "nono" -a "anthropic_api_key" -w "sk-ant-..."
+  ```
+
+- **Linux** (libsecret / GNOME Keyring / KWallet):
+
+  ```bash
+  secret-tool store --label "nono anthropic" service nono account anthropic_api_key
+  ```
+
+  `secret-tool` will prompt for the value on stdin.
+
+For 1Password, Apple Passwords, and other backends, see nono's credential injection docs: https://nono.sh/docs/cli/features/credential-injection.md.
+
+## 7. Future work
+
+The new `sandbox_level` model is what the upcoming wizard ('N' picker) UX changes are built on — the picker becomes a two-axis chooser (agent type x sandbox level) instead of needing a separate `agents.*` entry per variant. Progress is tracked in [GitHub issue #53](https://github.com/RisorseArtificiali/lince/issues/53).
+
+For the manual test plan used to validate this feature, see [`sandbox-levels-testing.md`](./sandbox-levels-testing.md).

--- a/docs/documentation/dashboard/sandbox-levels.md
+++ b/docs/documentation/dashboard/sandbox-levels.md
@@ -12,17 +12,24 @@ Until recently each combination of "agent type + isolation tightness" required i
 
 The table below summarises the differences. Sections after it give the concrete config snippets and behavior for each level.
 
-| Aspect                | paranoid                                | normal                       | permissive                                                                   |
-|-----------------------|-----------------------------------------|------------------------------|------------------------------------------------------------------------------|
-| Network               | Anthropic API only (proxy)              | inherited base               | + GitHub + gh CLI domains                                                    |
-| Filesystem            | $WORKDIR + scratch ~/.claude            | as today                     | + ~/.config/gh, ~/.cache, ~/.ssh/known_hosts                                 |
-| `gh` CLI              | no                                      | no                           | yes                                                                          |
-| `docker` / `podman`   | no                                      | no                           | **no** (out of scope)                                                        |
-| direct `git push`     | no                                      | no                           | **no** (use `gh` instead)                                                    |
+| Aspect                                  | paranoid (bwrap)              | paranoid (nono)        | normal             | permissive                                              |
+|-----------------------------------------|-------------------------------|------------------------|--------------------|---------------------------------------------------------|
+| Network (allowed destinations)          | Anthropic API only            | Anthropic API only     | inherited base     | + GitHub + gh CLI domains                               |
+| Network isolation enforcement           | kernel (netns) + proxy allowlist | kernel (Landlock + nono policy) | inherited       | proxy allowlist                                         |
+| Agent opens raw socket to exfiltrate    | blocked (no route in netns) ✓ | blocked (kernel policy) ✓ | depends on base | blocked for non-allowlisted hosts (proxy)               |
+| Filesystem                              | $WORKDIR + scratch ~/.claude  | $WORKDIR + scratch ~/.claude | as today      | + ~/.config/gh, ~/.cache, ~/.ssh/known_hosts            |
+| `gh` CLI                                | no                            | no                     | no                 | yes                                                     |
+| `docker` / `podman`                     | no                            | no                     | no                 | **no** (out of scope)                                   |
+| direct `git push`                       | no                            | no                     | no                 | **no** (use `gh` instead)                               |
 
 ### 2.1 Paranoid
 
-**Network.** Only the Anthropic API is reachable. All requests go through nono's credential proxy, which injects the API key on the host side; the key never enters the sandbox environment. Everything else — DNS for arbitrary hosts, plain HTTPS to other services, even `pip install` from PyPI — fails.
+**Network.** Only the Anthropic API is reachable, and isolation is **kernel-enforced** on both backends.
+
+- Under bwrap: the sandbox runs in a fresh network namespace (`bwrap --unshare-net`) with only its own loopback. There is no route to anywhere on the host or the internet — a raw TCP connect to `1.1.1.1:443` or a DNS lookup for `attacker.com` fails at the kernel. The host-side credential proxy is reached over a unix domain socket bind-mounted into the sandbox at `/run/lince-proxy.sock`; a small `socat` helper inside the sandbox listens on `127.0.0.1:8118` and forwards each TCP connection to that unix socket. The agent sees `HTTP_PROXY=http://127.0.0.1:8118` and uses TCP localhost as before — no SDK changes are required. On top of the kernel netns isolation, the credential proxy enforces an application-layer allowlist (`allow_domains`, default `["api.anthropic.com"]`); any HTTPS CONNECT or HTTP request to a destination outside the allowlist is rejected with a 403.
+- Under nono: kernel-level via Landlock LSM and nono's native network policy; application-level via the same credential proxy mechanism.
+
+The credential proxy injects the API key on the host side in both cases, so the key never enters the sandbox environment. Everything else — DNS for arbitrary hosts, plain HTTPS to other services, even `pip install` from PyPI — fails.
 
 nono profile (`~/.config/nono/profiles/lince-claude-paranoid.json`):
 
@@ -188,9 +195,9 @@ The dashboard supports two backends, switched per agent via `sandbox_backend`:
 
 The default is per-OS: Linux picks `bwrap` (agent-sandbox), macOS picks `nono`. A Linux user who wants kernel-enforced filesystem isolation via Landlock can override that and pick `nono` explicitly.
 
-**Important asymmetry.** The two backends do not enforce paranoid the same way. Under nono, paranoid is **kernel-enforced**: Landlock restricts the filesystem and nono's native network policy restricts outbound connections. Under bwrap, paranoid is **proxy-enforced**: `use_real_config = false` keeps writes inside the scratch config copy and the credential proxy strips API keys from the sandbox environment, but the bwrap sandbox today does not run with `--unshare-net`. Adding `--unshare-net` would give the sandbox its own loopback and break the host-side credential proxy at `127.0.0.1:PORT`, which is what carries every LLM API call. Tightening this path requires a unix-socket proxy or an in-namespace proxy and is tracked as separate hardening work.
+**Backend implementation note.** Both backends now achieve kernel-enforced network isolation under paranoid; the implementation paths differ. bwrap paranoid uses `--unshare-net` plus a socat unix-socket bridge to the credential proxy. nono paranoid uses Landlock LSM plus nono's native network policy. From a threat-model standpoint the two are equivalent for paranoid: an agent that opens a raw TCP socket to a non-allowlisted host fails at the kernel level on either backend.
 
-In practice: if you want the strongest available network isolation under paranoid, run on a host where nono is available and set `sandbox_backend = "nono"`.
+**Prerequisites for paranoid + bwrap.** `socat` must be available on the host's `$PATH` (most distros: install the `socat` package). `install.sh` warns when it is missing. If `unshare_net = true` is resolved at run time and `socat` is not found, `agent-sandbox` errors out with a clear message rather than silently degrading.
 
 ## 5. Customization
 
@@ -244,6 +251,32 @@ The next time you spawn a Claude Code agent it will launch with `lince-claude-wi
 
 For agent-sandbox (bwrap) users, the equivalent is a TOML fragment at `~/.agent-sandbox/profiles/with-aws.toml` deep-merged into the resolved config (lists appended, scalars overridden); flip the same `sandbox_level = "with-aws"` switch in `agents-defaults.toml` (or in the user `[agents.claude]` override block of `config.toml`) to activate it.
 
+### Extending the network allowlist with `allow_domains`
+
+`allow_domains` is the user-visible knob that controls which hosts the credential proxy lets through. It appears in the shipped fragments and can be extended by the user without writing a custom level.
+
+- **In paranoid (`unshare_net = true`)**: `allow_domains` is the **strict allowlist**. Any HTTPS CONNECT or HTTP request to a host not in the union of `credential_rules.domains` and `allow_domains` is rejected. The shipped paranoid fragment sets `allow_domains = ["api.anthropic.com"]`.
+- **In permissive (`unshare_net = false`)**: `allow_domains` lists the extra hosts the proxy passes through without credential injection. The shipped permissive fragment sets `allow_domains = ["api.github.com", "github.com", "objects.githubusercontent.com"]`.
+- **Append-merged, not replaced**: when the user adds `[security] allow_domains = [...]` in `~/.agent-sandbox/config.toml`, the entries are concatenated onto whatever the active fragment ships. Switching from paranoid to permissive (or vice versa) does not silently drop the user's additions, but it does change which fragment's defaults they extend.
+
+### Worked example: paranoid + pypi.org
+
+Suppose you want paranoid for an agent that occasionally needs `pip install` from PyPI. Rather than ship a new fragment file, extend `allow_domains` directly in `~/.agent-sandbox/config.toml`:
+
+```toml
+# ~/.agent-sandbox/config.toml
+[security]
+allow_domains = ["pypi.org", "files.pythonhosted.org"]
+```
+
+Then:
+
+```bash
+agent-sandbox run --sandbox-level paranoid <command>
+```
+
+The resolved config is paranoid + the two extra hosts: kernel netns isolation is unchanged, the proxy allowlist becomes `["api.anthropic.com", "pypi.org", "files.pythonhosted.org"]`, and `pip install` resolves through the proxy. This works because `allow_domains` is append-merged with the paranoid fragment's list, not overwritten.
+
 ## 6. Keystore setup for paranoid
 
 Paranoid relies on the Anthropic API key being in nono's credential keystore — **not** in `ANTHROPIC_API_KEY` in your environment. The point is that the key never enters the sandbox process tree; nono injects the `Authorization` header on the host side as the request flows through the credential proxy.
@@ -268,6 +301,6 @@ For 1Password, Apple Passwords, and other backends, see nono's credential inject
 
 ## 7. Future work
 
-The new `sandbox_level` model is what the upcoming wizard ('N' picker) UX changes are built on — the picker becomes a two-axis chooser (agent type x sandbox level) instead of needing a separate `agents.*` entry per variant. Progress is tracked in [GitHub issue #53](https://github.com/RisorseArtificiali/lince/issues/53).
+The new `sandbox_level` model is what the upcoming wizard ('N' picker) UX changes are built on — the picker becomes a two-axis chooser (agent type x sandbox level) instead of needing a separate `agents.*` entry per variant. Progress is tracked in [GitHub issue #53](https://github.com/RisorseArtificiali/lince/issues/53). [GitHub issue #54](https://github.com/RisorseArtificiali/lince/issues/54) tracks fragment-level `extends` inheritance so custom fragments can declare a parent level explicitly instead of relying on deep-merge order — a smaller, separate scope from the now-completed bwrap paranoid network hardening.
 
 For the manual test plan used to validate this feature, see [`sandbox-levels-testing.md`](./sandbox-levels-testing.md).

--- a/lince-dashboard/README.md
+++ b/lince-dashboard/README.md
@@ -77,7 +77,10 @@ Press `n` to spawn an agent (quick name prompt), or `N` for the full wizard (typ
 | **[Usage Guide](https://lince.sh/documentation/#/dashboard/usage-guide)** | Keybindings, wizard, features, voice relay |
 | **[Configuration Reference](https://lince.sh/documentation/#/dashboard/config-reference)** | Dashboard config.toml and agents-defaults.toml |
 | **[Agent Examples](https://lince.sh/documentation/#/dashboard/agent-examples)** | Default agents, custom agents, multi-provider setups |
+| **[Sandbox Levels](https://lince.sh/documentation/#/dashboard/sandbox-levels)** | Three shipped levels (paranoid/normal/permissive), how to choose, and how to ship a custom level |
 | **[Multi-Agent Guide](MULTI-AGENT-GUIDE.md)** | What changed for multi-agent support |
+
+Each agent can run at one of three sandbox levels — `paranoid`, `normal`, `permissive` — selected via `sandbox_level` in `agents-defaults.toml` or per-agent in `config.toml`. The level controls network reach (Anthropic-only vs. + GitHub) and filesystem exposure (scratch config vs. real `~/.claude` vs. `~/.config/gh` for `gh` CLI). The same knob accepts custom values pointing at your own profile files. See the [Sandbox Levels doc](https://lince.sh/documentation/#/dashboard/sandbox-levels) for the full reference.
 
 ## Architecture
 

--- a/lince-dashboard/agents-defaults.toml
+++ b/lince-dashboard/agents-defaults.toml
@@ -11,8 +11,20 @@
 #   {agent_id}    - unique agent identifier (e.g. "agent-1")
 #   {project_dir} - project directory path
 #   {profile}     - sandbox profile name
+#
+# Sandbox model (claude only for now; codex/gemini/opencode/pi land in
+# follow-up tasks lince-99..102):
+#   - sandbox_backend = "bwrap" | "nono"  (default per OS)
+#   - sandbox_level   = "paranoid" | "normal" | "permissive" | <custom>
+# When sandbox_level is set, the plugin synthesizes the launch command from
+# (agent_type, backend, level) — the `command` field below is then ignored
+# but kept for legacy/no-level fallback. See:
+#   docs/documentation/dashboard/sandbox-levels.md
+#   https://lince.sh/documentation/#/dashboard/sandbox-levels
 
 [agents.claude]
+# Legacy fallback command — ignored when sandbox_level is set (the plugin
+# synthesizes the actual command from sandbox_backend + sandbox_level).
 command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}"]
 pane_title_pattern = "agent-sandbox"
 status_pipe_name = "claude-status"
@@ -23,6 +35,43 @@ sandboxed = true
 has_native_hooks = true
 home_ro_dirs = ["~/.claude/"]
 profiles = ["__discover__"]
+sandbox_level = "normal"          # paranoid | normal | permissive (or custom; see docs)
+# sandbox_backend defaults to "agent-sandbox" (bwrap) on Linux, "nono" on macOS.
+# Uncomment to force a specific backend (overrides the OS default):
+# sandbox_backend = "nono"
+
+# Alternative levels — UNCOMMENT one of the blocks below to add a paranoid
+# or permissive variant of claude to the N-picker. They show up as separate
+# entries; the original [agents.claude] above stays as the "normal" default.
+# Both levels are kernel-enforced under nono and proxy-enforced under bwrap.
+# See docs/documentation/dashboard/sandbox-levels.md for what each level does
+# and how to ship a custom level.
+#
+# [agents.claude-paranoid]
+# command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}"]
+# pane_title_pattern = "agent-sandbox"
+# status_pipe_name = "claude-status"
+# display_name = "Claude Code (paranoid)"
+# short_label = "CLP"
+# color = "red"
+# sandboxed = true
+# has_native_hooks = true
+# home_ro_dirs = ["~/.claude/"]
+# profiles = ["__discover__"]
+# sandbox_level = "paranoid"
+#
+# [agents.claude-permissive]
+# command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}"]
+# pane_title_pattern = "agent-sandbox"
+# status_pipe_name = "claude-status"
+# display_name = "Claude Code (permissive)"
+# short_label = "CL+"
+# color = "green"
+# sandboxed = true
+# has_native_hooks = true
+# home_ro_dirs = ["~/.claude/"]
+# profiles = ["__discover__"]
+# sandbox_level = "permissive"
 
 [agents.claude-unsandboxed]
 command = ["claude"]
@@ -130,19 +179,11 @@ profiles = ["__discover__"]
 # ── nono-sandboxed variants ─────────────────────────────────────────
 # nono uses Landlock LSM on Linux and Seatbelt on macOS.
 # Profiles are named "lince-<agent>" and managed by `agent-sandbox nono-sync`.
-
-[agents.claude-nono]
-command = ["nono", "run", "--profile", "lince-claude", "--workdir", "{project_dir}", "--", "claude", "--dangerously-skip-permissions"]
-pane_title_pattern = "nono"
-status_pipe_name = "claude-status"
-display_name = "Claude Code (nono)"
-short_label = "CLA"
-color = "blue"
-sandboxed = true
-has_native_hooks = true
-sandbox_backend = "nono"
-home_ro_dirs = ["~/.claude/"]
-profiles = ["__discover__"]
+#
+# NOTE: claude no longer has a separate [agents.claude-nono] entry — it has
+# been collapsed into [agents.claude] above (use sandbox_backend = "nono" to
+# force the nono backend on Linux). The codex/gemini/opencode/pi entries
+# below will follow the same migration in lince-99..102.
 
 [agents.codex-nono]
 command = ["nono", "run", "--profile", "lince-codex", "--workdir", "{project_dir}", "--", "codex", "--full-auto"]

--- a/lince-dashboard/agents-defaults.toml
+++ b/lince-dashboard/agents-defaults.toml
@@ -30,6 +30,8 @@ pane_title_pattern = "agent-sandbox"
 status_pipe_name = "claude-status"
 display_name = "Claude Code"
 short_label = "CLA"
+# Color follows the sandbox-level gradient (basic ANSI palette):
+#   paranoid=green, normal=blue, permissive=yellow, unsandboxed=red
 color = "blue"
 sandboxed = true
 has_native_hooks = true
@@ -53,7 +55,7 @@ sandbox_level = "normal"          # paranoid | normal | permissive (or custom; s
 # status_pipe_name = "claude-status"
 # display_name = "Claude Code (paranoid)"
 # short_label = "CLP"
-# color = "red"
+# color = "green"
 # sandboxed = true
 # has_native_hooks = true
 # home_ro_dirs = ["~/.claude/"]
@@ -66,7 +68,7 @@ sandbox_level = "normal"          # paranoid | normal | permissive (or custom; s
 # status_pipe_name = "claude-status"
 # display_name = "Claude Code (permissive)"
 # short_label = "CL+"
-# color = "green"
+# color = "yellow"
 # sandboxed = true
 # has_native_hooks = true
 # home_ro_dirs = ["~/.claude/"]

--- a/lince-dashboard/install.sh
+++ b/lince-dashboard/install.sh
@@ -423,6 +423,19 @@ else
     [ "$HAS_NONO" = true ] && echo "  ✓ nono installed (alternative)"
 fi
 echo ""
+if [ "$HAS_NONO" = true ]; then
+    echo -e "${GREEN}Sandbox levels (paranoid/normal/permissive):${NC}"
+    echo "  Paranoid level needs the Anthropic API key in nono's keystore so"
+    echo "  the credential proxy can inject it at runtime. Populate it once:"
+    if [ "$OS_NAME" = "Darwin" ]; then
+        echo "    security add-generic-password -s nono -a anthropic_api_key -w 'sk-ant-...'"
+    else
+        echo "    secret-tool store --label 'nono anthropic' service nono account anthropic_api_key"
+    fi
+    echo "  See https://nono.sh/docs/cli/features/credential-injection.md for"
+    echo "  1Password / Apple Passwords integration."
+    echo ""
+fi
 echo -e "${GREEN}Usage:${NC}"
 echo "  source ~/.bashrc   # reload aliases"
 echo "  zd                 # launch dashboard layout"

--- a/lince-dashboard/nono-profiles/lince-claude-paranoid.json
+++ b/lince-dashboard/nono-profiles/lince-claude-paranoid.json
@@ -1,0 +1,14 @@
+{
+  "extends": "lince-claude",
+  "meta": {
+    "name": "lince-claude-paranoid",
+    "description": "Claude Code, paranoid sandbox: only Anthropic API reachable via nono credential proxy; ~/.claude isolated to a per-agent scratch dir (rsync'd at spawn, deleted on stop)."
+  },
+  "filesystem": {
+    "allow": ["$WORKDIR", "$HOME"],
+    "read": []
+  },
+  "network": {
+    "credentials": ["anthropic"]
+  }
+}

--- a/lince-dashboard/nono-profiles/lince-claude-permissive.json
+++ b/lince-dashboard/nono-profiles/lince-claude-permissive.json
@@ -1,0 +1,25 @@
+{
+  "extends": "lince-claude",
+  "meta": {
+    "name": "lince-claude-permissive",
+    "description": "Claude Code, permissive sandbox: Anthropic API + GitHub allowlist (api.github.com, github.com, objects.githubusercontent.com); reads ~/.config/gh, ~/.cache, ~/.ssh/known_hosts so gh CLI works (no docker, no podman, no direct git push)."
+  },
+  "filesystem": {
+    "allow": ["$WORKDIR"],
+    "read": [
+      "$HOME/.config/gh",
+      "$HOME/.cache",
+      "$HOME/.ssh/known_hosts",
+      "$HOME/.local/lib"
+    ]
+  },
+  "network": {
+    "network_profile": "developer",
+    "credentials": ["anthropic"],
+    "allow_domain": [
+      "api.github.com",
+      "github.com",
+      "objects.githubusercontent.com"
+    ]
+  }
+}

--- a/lince-dashboard/plugin/src/agent.rs
+++ b/lince-dashboard/plugin/src/agent.rs
@@ -3,7 +3,9 @@ use std::path::PathBuf;
 
 use zellij_tile::prelude::*;
 
-use crate::config::{AgentLayout, AgentTypeConfig, DashboardConfig, DEFAULT_SANDBOX_COMMAND};
+use crate::config::{
+    shell_escape, AgentLayout, AgentTypeConfig, DashboardConfig, DEFAULT_SANDBOX_COMMAND,
+};
 use crate::sandbox_backend::SandboxBackend;
 
 /// Name of the lifecycle wrapper script for agents without native hooks.
@@ -161,19 +163,24 @@ fn synthesize_sandboxed_command(
                     // follow-ups add codex/.codex, gemini/.gemini, etc.
                     _ => return None,
                 };
+                // Sentinels use `@@…@@` rather than bare uppercase words so
+                // accidental substring overlap is impossible (e.g. a
+                // hypothetical future `AGENT_IDENTITY` placeholder would
+                // collide with `AGENT_ID` if we used bare words). With the
+                // chosen format, replacement order is irrelevant.
                 let bash = String::from(
                     "set -e; \
-                     SCRATCH=\"${XDG_RUNTIME_DIR:-/tmp}/lince-AGENT_ID\"; \
+                     SCRATCH=\"${XDG_RUNTIME_DIR:-/tmp}/lince-@@AGENT_ID@@\"; \
                      mkdir -p -- \"$SCRATCH\"; \
                      trap 'rm -rf -- \"$SCRATCH\"' EXIT; \
-                     rsync -a --delete -- \"$HOME/AGENT_HOME_SUBDIR/\" \"$SCRATCH/AGENT_HOME_SUBDIR/\"; \
-                     HOME=\"$SCRATCH\" nono run --profile NONO_PROFILE --workdir PROJECT_DIR -- INNER_COMMAND",
+                     rsync -a --delete -- \"$HOME/@@HOME_SUBDIR@@/\" \"$SCRATCH/@@HOME_SUBDIR@@/\"; \
+                     HOME=\"$SCRATCH\" nono run --profile @@NONO_PROFILE@@ --workdir @@PROJECT_DIR@@ -- @@INNER_COMMAND@@",
                 )
-                .replace("AGENT_HOME_SUBDIR", agent_home_subdir)
-                .replace("AGENT_ID", &shell_quote(agent_id))
-                .replace("NONO_PROFILE", &shell_quote(&nono_profile))
-                .replace("PROJECT_DIR", &shell_quote(project_dir))
-                .replace("INNER_COMMAND", &inner_str);
+                .replace("@@HOME_SUBDIR@@", agent_home_subdir)
+                .replace("@@AGENT_ID@@", &shell_quote(agent_id))
+                .replace("@@NONO_PROFILE@@", &shell_quote(&nono_profile))
+                .replace("@@PROJECT_DIR@@", &shell_quote(project_dir))
+                .replace("@@INNER_COMMAND@@", &inner_str);
                 vec!["bash".to_string(), "-c".to_string(), bash]
             } else {
                 let mut cmd = vec![
@@ -193,17 +200,19 @@ fn synthesize_sandboxed_command(
     })
 }
 
-/// Minimal POSIX shell single-quote escaping for embedding strings inside
-/// `bash -c '...'` wrappers. We only use this on agent-internal values
-/// (profile names, binary paths from agents-defaults.toml), never on
-/// untrusted input.
+/// POSIX shell quoting for embedding strings inside `bash -c '...'`
+/// wrappers. Strings containing only alphanumerics and a few obviously
+/// safe punctuation chars pass through unchanged for readability;
+/// anything else is wrapped in single quotes, with embedded single
+/// quotes escaped via the standard `'\''` idiom that lives in
+/// `shell_escape`.
 fn shell_quote(s: &str) -> String {
     if s.chars()
         .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '/' | '.' | ':'))
     {
         s.to_string()
     } else {
-        format!("'{}'", s.replace('\'', "'\\''"))
+        format!("'{}'", shell_escape(s))
     }
 }
 
@@ -275,43 +284,38 @@ fn spawn_inner(
         // (agent_type, backend, level) instead of using the static template.
         // This is what enables the single-entry-per-agent model in
         // agents-defaults.toml.
-        let cmd_template_owned;
-        let cmd_template: &[String] = if let Some(level) = &type_config.sandbox_level {
-            match synthesize_sandboxed_command(
+        // Two paths produce the agent command: synthesize_sandboxed_command
+        // bakes agent_id/project_dir directly into argv (with shell_quote
+        // for values that end up inside a bash wrapper), so its output is
+        // final and skips expand_command_template. The legacy/static path
+        // (no sandbox_level set, or agent type not yet covered) goes
+        // through the placeholder-substitution helper as before.
+        let synthesized = type_config.sandbox_level.as_deref().and_then(|level| {
+            synthesize_sandboxed_command(
                 agent_type,
                 &type_config.sandbox_backend,
                 level,
                 &id,
                 &project_dir,
-            ) {
-                Some(t) => {
-                    // Synthesized argv is already final — agent_id and
-                    // project_dir baked in (shell-quoted where they end up
-                    // inside a bash wrapper). expand_command_template still
-                    // runs over it and is a no-op since there are no
-                    // placeholders left.
-                    cmd_template_owned = t;
-                    &cmd_template_owned
-                }
-                None => {
-                    // Agent doesn't yet support sandbox_level (follow-up task).
-                    // Fall back to the static command and surface a soft warning.
-                    eprintln!(
-                        "lince-dashboard: sandbox_level={} not yet supported for agent_type={} — using static command",
-                        level, agent_type
-                    );
-                    &type_config.command
-                }
-            }
+            )
+            .or_else(|| {
+                eprintln!(
+                    "lince-dashboard: sandbox_level={} not yet supported for agent_type={} — using static command",
+                    level, agent_type
+                );
+                None
+            })
+        });
+        if let Some(argv) = synthesized {
+            expanded.extend(argv);
         } else {
-            &type_config.command
-        };
-        expanded.extend(expand_command_template(
-            cmd_template,
-            &id,
-            &project_dir,
-            profile.as_deref(),
-        ));
+            expanded.extend(expand_command_template(
+                &type_config.command,
+                &id,
+                &project_dir,
+                profile.as_deref(),
+            ));
+        }
         // For agent-sandbox (bwrap) agents, pass the profile via -P flag so
         // agent-sandbox can resolve the profile's env vars internally.
         // Nono agents already have --profile baked into their command template.

--- a/lince-dashboard/plugin/src/agent.rs
+++ b/lince-dashboard/plugin/src/agent.rs
@@ -12,7 +12,13 @@ use crate::types::{AgentInfo, AgentStatus};
 
 /// Variant suffixes stripped by `agent_type_base_name()`.
 /// Add new suffixes here when new sandbox variants are introduced.
-const AGENT_TYPE_SUFFIXES: &[&str] = &["-unsandboxed", "-bwrap", "-nono"];
+const AGENT_TYPE_SUFFIXES: &[&str] = &[
+    "-unsandboxed",
+    "-bwrap",
+    "-nono",
+    "-paranoid",
+    "-permissive",
+];
 
 /// Extract base agent type name, stripping sandbox variant suffixes.
 /// e.g. "claude-unsandboxed" → "claude", "codex-bwrap" → "codex", "gemini" → "gemini".
@@ -62,6 +68,126 @@ fn expand_command_template(
                 .replace("{profile}", profile.unwrap_or(""))
         })
         .collect()
+}
+
+/// Resolve the nono profile filename for an agent at a given sandbox level.
+///
+/// `normal` maps to the base profile (`lince-<agent>`); any other value
+/// becomes a suffixed profile (`lince-<agent>-<level>`). This is intentionally
+/// a free-form mapping so users can drop a custom profile at
+/// `~/.config/nono/profiles/lince-<agent>-<custom>.json` and reference it via
+/// `sandbox_level = "<custom>"` without any plugin changes.
+pub fn resolve_nono_profile(agent_type: &str, level: &str) -> String {
+    if level == "normal" {
+        format!("lince-{}", agent_type)
+    } else {
+        format!("lince-{}-{}", agent_type, level)
+    }
+}
+
+/// Synthesize the command template for a sandboxed agent based on the
+/// (backend, level) pair. Returns `None` if the agent type doesn't yet have
+/// a known inner-command shape (follow-up tasks add agents incrementally).
+///
+/// The returned template still contains `{agent_id}` / `{project_dir}`
+/// placeholders — pass it through `expand_command_template` before exec.
+fn synthesize_sandboxed_command(
+    agent_type: &str,
+    backend: &SandboxBackend,
+    level: &str,
+) -> Option<Vec<String>> {
+    let base = agent_type_base_name(agent_type);
+    let inner_command: Vec<String> = match base {
+        "claude" => vec![
+            "claude".to_string(),
+            "--dangerously-skip-permissions".to_string(),
+        ],
+        // codex/gemini/opencode/pi land in follow-up tasks (lince-99..102).
+        _ => return None,
+    };
+
+    let nono_profile = resolve_nono_profile(base, level);
+
+    Some(match backend {
+        SandboxBackend::AgentSandbox => {
+            let mut cmd = vec![
+                "agent-sandbox".to_string(),
+                "run".to_string(),
+                "-p".to_string(),
+                "{project_dir}".to_string(),
+                "--id".to_string(),
+                "{agent_id}".to_string(),
+            ];
+            if level != "normal" {
+                cmd.push("--sandbox-level".to_string());
+                cmd.push(level.to_string());
+            }
+            cmd
+        }
+        SandboxBackend::Nono => {
+            let inner_str = inner_command
+                .iter()
+                .map(|s| shell_quote(s))
+                .collect::<Vec<_>>()
+                .join(" ");
+            if level == "paranoid" {
+                // Self-contained bash wrapper:
+                //   1. Make a per-agent scratch dir under $XDG_RUNTIME_DIR
+                //   2. rsync the real ~/.<agent>/ into the scratch dir so
+                //      modifications inside the sandbox stay isolated
+                //   3. Re-run nono with HOME pointed at the scratch dir
+                //   4. On exit (clean or trapped SIGINT/SIGTERM), rm -rf scratch
+                //
+                // No `exec` so the bash process stays alive to honor the EXIT
+                // trap; SIGKILL bypasses cleanup but that's acceptable for an
+                // ephemeral scratch dir.
+                let agent_home_subdir = match base {
+                    "claude" => ".claude",
+                    // follow-ups add codex/.codex, gemini/.gemini, etc.
+                    _ => return None,
+                };
+                let bash = String::from(
+                    "set -e; \
+                     SCRATCH=\"${XDG_RUNTIME_DIR:-/tmp}/lince-{agent_id}\"; \
+                     mkdir -p -- \"$SCRATCH\"; \
+                     trap 'rm -rf -- \"$SCRATCH\"' EXIT; \
+                     rsync -a --delete -- \"$HOME/AGENT_HOME_SUBDIR/\" \"$SCRATCH/AGENT_HOME_SUBDIR/\"; \
+                     HOME=\"$SCRATCH\" nono run --profile NONO_PROFILE --workdir \"{project_dir}\" -- INNER_COMMAND",
+                )
+                .replace("AGENT_HOME_SUBDIR", agent_home_subdir)
+                .replace("NONO_PROFILE", &shell_quote(&nono_profile))
+                .replace("INNER_COMMAND", &inner_str);
+                vec!["bash".to_string(), "-c".to_string(), bash]
+            } else {
+                let mut cmd = vec![
+                    "nono".to_string(),
+                    "run".to_string(),
+                    "--profile".to_string(),
+                    nono_profile,
+                    "--workdir".to_string(),
+                    "{project_dir}".to_string(),
+                    "--".to_string(),
+                ];
+                cmd.extend(inner_command);
+                cmd
+            }
+        }
+        SandboxBackend::None => inner_command,
+    })
+}
+
+/// Minimal POSIX shell single-quote escaping for embedding strings inside
+/// `bash -c '...'` wrappers. We only use this on agent-internal values
+/// (profile names, binary paths from agents-defaults.toml), never on
+/// untrusted input.
+fn shell_quote(s: &str) -> String {
+    if s.chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '/' | '.' | ':'))
+    {
+        s.to_string()
+    } else {
+        format!("'{}'", s.replace('\'', "'\\''"))
+    }
 }
 
 /// Internal helper that does the actual spawn work.
@@ -128,8 +254,32 @@ fn spawn_inner(
             expanded.push(id.clone());
             expanded.push(type_config.status_pipe_name.clone());
         }
+        // When `sandbox_level` is set, synthesize the command from
+        // (agent_type, backend, level) instead of using the static template.
+        // This is what enables the single-entry-per-agent model in
+        // agents-defaults.toml.
+        let cmd_template_owned;
+        let cmd_template: &[String] = if let Some(level) = &type_config.sandbox_level {
+            match synthesize_sandboxed_command(agent_type, &type_config.sandbox_backend, level) {
+                Some(t) => {
+                    cmd_template_owned = t;
+                    &cmd_template_owned
+                }
+                None => {
+                    // Agent doesn't yet support sandbox_level (follow-up task).
+                    // Fall back to the static command and surface a soft warning.
+                    eprintln!(
+                        "lince-dashboard: sandbox_level={} not yet supported for agent_type={} — using static command",
+                        level, agent_type
+                    );
+                    &type_config.command
+                }
+            }
+        } else {
+            &type_config.command
+        };
         expanded.extend(expand_command_template(
-            &type_config.command,
+            cmd_template,
             &id,
             &project_dir,
             profile.as_deref(),

--- a/lince-dashboard/plugin/src/agent.rs
+++ b/lince-dashboard/plugin/src/agent.rs
@@ -89,12 +89,22 @@ pub fn resolve_nono_profile(agent_type: &str, level: &str) -> String {
 /// (backend, level) pair. Returns `None` if the agent type doesn't yet have
 /// a known inner-command shape (follow-up tasks add agents incrementally).
 ///
-/// The returned template still contains `{agent_id}` / `{project_dir}`
-/// placeholders — pass it through `expand_command_template` before exec.
+/// `agent_id` and `project_dir` are baked in directly: the
+/// non-bash-wrapper branches (bwrap, normal nono) emit them as separate
+/// argv elements where shell parsing doesn't apply, and the paranoid
+/// nono bash wrapper substitutes them with `shell_quote()` so paths
+/// containing whitespace, `"`, or `$` can't break the wrapper or open a
+/// shell-injection surface (defense-in-depth: project_dir comes from
+/// local UI, but quoting costs nothing).
+///
+/// The returned argv is final — no more placeholder substitution needed
+/// downstream.
 fn synthesize_sandboxed_command(
     agent_type: &str,
     backend: &SandboxBackend,
     level: &str,
+    agent_id: &str,
+    project_dir: &str,
 ) -> Option<Vec<String>> {
     let base = agent_type_base_name(agent_type);
     let inner_command: Vec<String> = match base {
@@ -114,9 +124,9 @@ fn synthesize_sandboxed_command(
                 "agent-sandbox".to_string(),
                 "run".to_string(),
                 "-p".to_string(),
-                "{project_dir}".to_string(),
+                project_dir.to_string(),
                 "--id".to_string(),
-                "{agent_id}".to_string(),
+                agent_id.to_string(),
             ];
             if level != "normal" {
                 cmd.push("--sandbox-level".to_string());
@@ -141,6 +151,11 @@ fn synthesize_sandboxed_command(
                 // No `exec` so the bash process stays alive to honor the EXIT
                 // trap; SIGKILL bypasses cleanup but that's acceptable for an
                 // ephemeral scratch dir.
+                //
+                // All caller-supplied values (agent_id, project_dir, profile,
+                // inner command) are shell_quote'd before substitution, so the
+                // wrapper is safe even if any of them contain shell
+                // metacharacters.
                 let agent_home_subdir = match base {
                     "claude" => ".claude",
                     // follow-ups add codex/.codex, gemini/.gemini, etc.
@@ -148,14 +163,16 @@ fn synthesize_sandboxed_command(
                 };
                 let bash = String::from(
                     "set -e; \
-                     SCRATCH=\"${XDG_RUNTIME_DIR:-/tmp}/lince-{agent_id}\"; \
+                     SCRATCH=\"${XDG_RUNTIME_DIR:-/tmp}/lince-AGENT_ID\"; \
                      mkdir -p -- \"$SCRATCH\"; \
                      trap 'rm -rf -- \"$SCRATCH\"' EXIT; \
                      rsync -a --delete -- \"$HOME/AGENT_HOME_SUBDIR/\" \"$SCRATCH/AGENT_HOME_SUBDIR/\"; \
-                     HOME=\"$SCRATCH\" nono run --profile NONO_PROFILE --workdir \"{project_dir}\" -- INNER_COMMAND",
+                     HOME=\"$SCRATCH\" nono run --profile NONO_PROFILE --workdir PROJECT_DIR -- INNER_COMMAND",
                 )
                 .replace("AGENT_HOME_SUBDIR", agent_home_subdir)
+                .replace("AGENT_ID", &shell_quote(agent_id))
                 .replace("NONO_PROFILE", &shell_quote(&nono_profile))
+                .replace("PROJECT_DIR", &shell_quote(project_dir))
                 .replace("INNER_COMMAND", &inner_str);
                 vec!["bash".to_string(), "-c".to_string(), bash]
             } else {
@@ -165,7 +182,7 @@ fn synthesize_sandboxed_command(
                     "--profile".to_string(),
                     nono_profile,
                     "--workdir".to_string(),
-                    "{project_dir}".to_string(),
+                    project_dir.to_string(),
                     "--".to_string(),
                 ];
                 cmd.extend(inner_command);
@@ -260,8 +277,19 @@ fn spawn_inner(
         // agents-defaults.toml.
         let cmd_template_owned;
         let cmd_template: &[String] = if let Some(level) = &type_config.sandbox_level {
-            match synthesize_sandboxed_command(agent_type, &type_config.sandbox_backend, level) {
+            match synthesize_sandboxed_command(
+                agent_type,
+                &type_config.sandbox_backend,
+                level,
+                &id,
+                &project_dir,
+            ) {
                 Some(t) => {
+                    // Synthesized argv is already final — agent_id and
+                    // project_dir baked in (shell-quoted where they end up
+                    // inside a bash wrapper). expand_command_template still
+                    // runs over it and is a no-op since there are no
+                    // placeholders left.
                     cmd_template_owned = t;
                     &cmd_template_owned
                 }

--- a/lince-dashboard/plugin/src/config.rs
+++ b/lince-dashboard/plugin/src/config.rs
@@ -68,6 +68,19 @@ pub struct AgentTypeConfig {
     /// Defaults to `AgentSandbox` for backward compatibility.
     #[serde(default)]
     pub sandbox_backend: SandboxBackend,
+    /// Sandbox isolation level for this agent type.
+    ///
+    /// Free-form profile suffix, **not a closed enum**: `paranoid` / `normal`
+    /// / `permissive` are the shipped defaults; any other value resolves to a
+    /// user-supplied profile (`lince-<agent>-<value>.json` for nono,
+    /// `<agent>-<value>.toml` for agent-sandbox). See
+    /// `docs/documentation/dashboard/sandbox-levels.md`.
+    ///
+    /// When `None`, the legacy static `command` template is used as-is.
+    /// When `Some`, the plugin synthesizes the command from
+    /// `(agent_type, sandbox_backend, sandbox_level)`.
+    #[serde(default)]
+    pub sandbox_level: Option<String>,
 }
 
 /// Agent pane layout mode.

--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -2400,6 +2400,21 @@ def cmd_run(args, agent_extra: list[str]) -> None:
             "done\n"
             'exec "$@"\n'
         )
+        # `unshare -U -n -r` makes us UID 0 in a fresh user+net namespace
+        # (CAP_NET_ADMIN is only granted to the userns root, not to plain
+        # creators — verified empirically: --map-current-user fails ip link
+        # with EPERM). Then we re-map the inner UID back to the real user
+        # via bwrap's own --unshare-user / --uid / --gid, otherwise the
+        # agent inherits getuid()==0 and Claude Code refuses
+        # --dangerously-skip-permissions.
+        real_uid = os.getuid()
+        real_gid = os.getgid()
+        cmd = [
+            cmd[0], "--unshare-user",
+            "--uid", str(real_uid),
+            "--gid", str(real_gid),
+            *cmd[1:],
+        ]
         cmd = [
             "unshare", "-U", "-n", "-r",
             "bash", "-c", bash_setup, "lince-paranoid-netns",

--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -359,6 +359,13 @@ class _ProxyRequestHandler(BaseHTTPRequestHandler):
     # Set by CredentialProxy before the server starts serving.
     credential_rules: list[dict] = []
     blocked_hosts: set[str] = set()
+    # Extra domains the agent is allowed to reach via the proxy without
+    # credential injection (e.g. github.com, pypi.org). Empty by default —
+    # paranoid level keeps it minimal, custom levels can extend it.
+    # When enforce_allowlist is True, ANY destination not in
+    # credential_rules.domains ∪ allow_domains is rejected with 403.
+    allow_domains: set[str] = set()
+    enforce_allowlist: bool = False
     request_count: int = 0
     _count_lock: threading.Lock = threading.Lock()
 
@@ -381,6 +388,22 @@ class _ProxyRequestHandler(BaseHTTPRequestHandler):
                 return rule
         return None
 
+    def _is_allowed_host(self, host: str) -> bool:
+        """Return True if *host* is allowed to be reached through the proxy.
+
+        Checked when ``enforce_allowlist`` is True (paranoid mode). Allowed
+        hosts are: any domain that has a credential rule, plus everything in
+        ``allow_domains``. Hosts in ``blocked_hosts`` are always rejected,
+        regardless of allowlist state — that check happens earlier.
+        """
+        bare = host.split(":")[0]
+        if bare in self.allow_domains:
+            return True
+        for rule in self.credential_rules:
+            if rule["domain"] == bare:
+                return True
+        return False
+
     # --- Request counting -------------------------------------------------
 
     @classmethod
@@ -395,6 +418,13 @@ class _ProxyRequestHandler(BaseHTTPRequestHandler):
         if self._is_blocked(host):
             self.send_error(403, f"Blocked host: {host}")
             _proxy_logger.info("BLOCKED CONNECT to %s", host)
+            return
+
+        # Strict allowlist enforcement (paranoid mode). When off (default),
+        # CONNECT remains permissive — backward compatible behavior.
+        if self.enforce_allowlist and not self._is_allowed_host(host):
+            self.send_error(403, f"Host not in allowlist: {host}")
+            _proxy_logger.info("DENIED CONNECT to %s (not in allowlist)", host)
             return
 
         self._bump_count()
@@ -455,6 +485,24 @@ class _ProxyRequestHandler(BaseHTTPRequestHandler):
             _proxy_logger.info("BLOCKED %s to %s", method, host_header)
             return
 
+        # Resolve the actual destination host. In HTTP_PROXY mode `self.path`
+        # is an absolute URL (e.g. "http://pypi.org/foo"); in BASE_URL mode
+        # the Host header points at 127.0.0.1:PORT and the credential rule
+        # lookup falls back further down.
+        dest_host = ""
+        if self.path.startswith(("http://", "https://")):
+            parsed = urlparse(self.path)
+            dest_host = (parsed.hostname or "").lower()
+        elif host_header:
+            dest_host = host_header.split(":")[0].lower()
+
+        # Pass-through (no credential injection) for hosts in allow_domains.
+        # Used by permissive level (github.com, etc.) and by custom levels
+        # the user defines to extend paranoid with extra reachable domains.
+        if dest_host and dest_host in self.allow_domains:
+            self._forward_passthrough(method)
+            return
+
         rule = self._find_rule_for_host(host_header)
 
         # When the client SDK hits http://127.0.0.1:PORT/v1/messages the
@@ -469,6 +517,10 @@ class _ProxyRequestHandler(BaseHTTPRequestHandler):
                     rule = candidate
                     break
         if rule is None:
+            if self.enforce_allowlist:
+                self.send_error(403, f"Host not in allowlist: {dest_host or host_header}")
+                _proxy_logger.info("DENIED %s to %s (not in allowlist)", method, dest_host or host_header)
+                return
             self.send_error(502, "No credential rule matches this request")
             return
 
@@ -542,6 +594,57 @@ class _ProxyRequestHandler(BaseHTTPRequestHandler):
             _proxy_logger.error("Proxy forwarding error: %s", exc)
             self.send_error(502, f"Proxy error: {exc}")
 
+    # --- Pass-through forwarding (no credential injection) ---------------
+
+    def _forward_passthrough(self, method: str):
+        """Forward request as-is, no credential injection.
+
+        Used for hosts in ``allow_domains`` (e.g. permissive level allowing
+        github.com / pypi.org). HTTPS to those hosts goes through CONNECT;
+        plain HTTP arrives here when the agent uses HTTP_PROXY.
+        """
+        self._bump_count()
+
+        # In HTTP_PROXY mode the agent sends an absolute URL. Otherwise we
+        # reconstruct from Host header. We don't upgrade plain HTTP to HTTPS
+        # — pass the scheme the agent asked for.
+        if self.path.startswith(("http://", "https://")):
+            upstream_url = self.path
+        else:
+            host = self.headers.get("Host", "")
+            upstream_url = f"http://{host}{self.path}"
+
+        content_length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(content_length) if content_length > 0 else None
+
+        fwd_headers: dict[str, str] = {}
+        for hdr, val in self.headers.items():
+            if hdr.lower() not in _PROXY_SKIP_HEADERS:
+                fwd_headers[hdr] = val
+
+        _proxy_logger.info("PASS %s %s", method, upstream_url)
+
+        try:
+            resp = _upstream_pool.request(upstream_url, method, body, fwd_headers)
+            self.send_response(resp.status)
+            for hdr, val in resp.getheaders():
+                if hdr.lower() not in _PROXY_SKIP_HEADERS:
+                    self.send_header(hdr, val)
+            self.end_headers()
+            self.wfile.flush()
+            while True:
+                chunk = resp.read(4096)
+                if not chunk:
+                    break
+                self.wfile.write(chunk)
+                self.wfile.flush()
+        except http.client.HTTPException as exc:
+            _proxy_logger.warning("Pass-through error %s %s: %s", method, upstream_url, exc)
+            self.send_error(502, f"Pass-through error: {exc}")
+        except OSError as exc:
+            _proxy_logger.error("Pass-through socket error: %s", exc)
+            self.send_error(502, f"Pass-through error: {exc}")
+
     def do_GET(self):  # noqa: N802
         self._handle_forward("GET")
 
@@ -586,19 +689,29 @@ class CredentialProxy:
         self,
         credential_rules: list[dict],
         blocked_hosts: set[str] | None = None,
+        allow_domains: list[str] | None = None,
+        enforce_allowlist: bool = False,
     ):
         self._rules = credential_rules
         self._blocked = blocked_hosts or set(DEFAULT_BLOCKED_HOSTS)
+        self._allow_domains = {d.lower() for d in (allow_domains or [])}
+        self._enforce_allowlist = enforce_allowlist
         self._server: ThreadingTCPServer | None = None
         self._thread: threading.Thread | None = None
         self._port: int = 0
         self._start_time: float = 0.0
         self._pid_file = SANDBOX_DIR / "proxy.pid"
+        # Unix-socket bridge state (only set when start_unix_bridge is called).
+        self._unix_socket: socket.socket | None = None
+        self._unix_path: str = ""
+        self._unix_thread: threading.Thread | None = None
 
     def start(self) -> int:
         """Start the proxy server.  Returns the assigned port number."""
         _ProxyRequestHandler.credential_rules = list(self._rules)
         _ProxyRequestHandler.blocked_hosts = set(self._blocked)
+        _ProxyRequestHandler.allow_domains = set(self._allow_domains)
+        _ProxyRequestHandler.enforce_allowlist = self._enforce_allowlist
         _ProxyRequestHandler.request_count = 0
 
         ThreadingTCPServer.allow_reuse_address = True
@@ -645,6 +758,18 @@ class CredentialProxy:
 
     def stop(self):
         """Shut down the proxy server and clean up the PID file."""
+        if self._unix_socket is not None:
+            try:
+                self._unix_socket.close()
+            except OSError:
+                pass
+            self._unix_socket = None
+            if self._unix_path:
+                try:
+                    os.unlink(self._unix_path)
+                except OSError:
+                    pass
+                self._unix_path = ""
         if self._server is not None:
             self._server.shutdown()
             self._server.server_close()
@@ -655,6 +780,93 @@ class CredentialProxy:
                 self._pid_file.unlink()
             except OSError:
                 pass
+
+    def start_unix_bridge(self, path: str) -> str:
+        """Start a unix-domain-socket bridge that forwards into the TCP proxy.
+
+        Used by paranoid sandboxes with --unshare-net: the sandbox's network
+        namespace has no route to the host, but a unix socket file bind-mounted
+        from the host into the sandbox stays reachable. The sandbox runs a
+        TCP-to-unix bridge (e.g. socat) so the agent's HTTP_PROXY=http://...
+        client still sees a normal TCP localhost listener.
+
+        Each accepted unix connection is bridged to a fresh TCP connection
+        to the local proxy at 127.0.0.1:self._port.
+
+        Returns the unix-socket path (echoed back for caller convenience).
+        """
+        if self._port == 0:
+            raise RuntimeError("call start() before start_unix_bridge()")
+
+        path_str = str(path)
+        try:
+            os.unlink(path_str)
+        except FileNotFoundError:
+            pass
+
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.bind(path_str)
+        os.chmod(path_str, 0o600)
+        sock.listen(64)
+        self._unix_socket = sock
+        self._unix_path = path_str
+
+        proxy_port = self._port
+
+        def _bridge_pair(client: socket.socket) -> None:
+            try:
+                upstream = socket.create_connection(
+                    ("127.0.0.1", proxy_port), timeout=5
+                )
+            except OSError:
+                client.close()
+                return
+
+            def _forward(src: socket.socket, dst: socket.socket) -> None:
+                try:
+                    while True:
+                        data = src.recv(65536)
+                        if not data:
+                            break
+                        dst.sendall(data)
+                except OSError:
+                    pass
+                finally:
+                    try:
+                        dst.shutdown(socket.SHUT_WR)
+                    except OSError:
+                        pass
+
+            threading.Thread(
+                target=_forward, args=(client, upstream), daemon=True
+            ).start()
+            threading.Thread(
+                target=_forward, args=(upstream, client), daemon=True
+            ).start()
+
+        def _accept_loop() -> None:
+            while True:
+                try:
+                    client, _ = sock.accept()
+                except OSError:
+                    break
+                threading.Thread(
+                    target=_bridge_pair, args=(client,), daemon=True
+                ).start()
+
+        self._unix_thread = threading.Thread(target=_accept_loop, daemon=True)
+        self._unix_thread.start()
+
+        _proxy_logger.info(
+            "Credential proxy unix-socket bridge listening on %s "
+            "(forwards to 127.0.0.1:%d)",
+            path_str, self._port,
+        )
+        return path_str
+
+    def get_unix_path(self) -> str:
+        """Return the unix-socket path if the bridge is running, else ''."""
+        return self._unix_path
 
     def is_alive(self) -> bool:
         """Return True if the proxy server thread is running."""
@@ -759,7 +971,10 @@ def load_config() -> tuple[dict, Path]:
 # sandbox-policy fragment on top of the user's resolved config. New entries
 # are de-duplicated against what's already in the base list.
 _SANDBOX_LEVEL_LIST_APPEND_KEYS = frozenset({
-    "home_ro_dirs", "home_rw_dirs", "ro_dirs", "extra_rw"
+    "home_ro_dirs", "home_rw_dirs", "ro_dirs", "extra_rw",
+    # [security].allow_domains is also append-merged so a custom level can
+    # extend (e.g. "paranoid + pypi") without restating the base set.
+    "allow_domains",
 })
 
 
@@ -1429,7 +1644,9 @@ def build_bwrap_cmd(config: dict, project_dir: Path,
                     agent_config: dict | None = None,
                     agent_id: str | None = None,
                     agent_name: str = "claude",
-                    proxy_env: dict[str, str] | None = None) -> list[str]:
+                    proxy_env: dict[str, str] | None = None,
+                    unshare_net: bool = False,
+                    proxy_unix_socket: str = "") -> list[str]:
     home = str(Path.home())
     home_p = Path.home()
     sandbox = config.get("sandbox", {})
@@ -1608,6 +1825,19 @@ def build_bwrap_cmd(config: dict, project_dir: Path,
         cmd += ["--new-session"]
     cmd += ["--die-with-parent"]
 
+    # Paranoid network isolation: kernel-enforced via bwrap's own --unshare-net
+    # (separate netns with only its own loopback). The agent reaches the
+    # credential proxy through a unix socket bind-mounted from the host: a
+    # small socat helper inside the sandbox bridges TCP localhost -> that
+    # unix socket. See the wrapper assembled below at the agent-cmd append.
+    if unshare_net:
+        cmd += ["--unshare-net"]
+        if proxy_unix_socket:
+            cmd += [
+                "--bind", proxy_unix_socket,
+                "/run/lince-proxy.sock",
+            ]
+
     # --- 12. Environment: clearenv + explicit whitelist -----------------------
     cmd += ["--clearenv"]
     cmd += ["--setenv", "HOME", home]
@@ -1709,6 +1939,31 @@ def build_bwrap_cmd(config: dict, project_dir: Path,
                 args_source.append(da)
 
     agent_cmd = [agent_cfg["command"]] + args_source + list(agent_extra_args)
+
+    # Paranoid wrapper: bring up loopback inside the new netns, run a TCP
+    # listener that bridges to the bind-mounted unix socket, then exec the
+    # real agent. The agent's HTTP_PROXY env var points at this listener
+    # (set in cmd_run when unshare_net is True). PORT 8118 is fixed and
+    # internal — it never collides with anything because the netns is
+    # isolated.
+    if unshare_net and proxy_unix_socket:
+        bash_init = (
+            "set -e; "
+            "ip link set lo up; "
+            "socat TCP-LISTEN:8118,bind=127.0.0.1,reuseaddr,fork "
+            "UNIX-CONNECT:/run/lince-proxy.sock >/dev/null 2>&1 & "
+            # Wait briefly for the socat listener to be bound before
+            # handing control to the agent (otherwise the first request
+            # races against bind() and fails with ECONNREFUSED).
+            "for _ in 1 2 3 4 5 6 7 8 9 10; do "
+            "  if (exec 3<>/dev/tcp/127.0.0.1/8118) 2>/dev/null; then "
+            "    exec 3>&-; break; "
+            "  fi; "
+            "  sleep 0.05; "
+            "done; "
+            "exec \"$@\""
+        )
+        agent_cmd = ["/bin/bash", "-c", bash_init, "lince-paranoid-init"] + agent_cmd
 
     if log_file:
         # Use `script` to record the full terminal session.
@@ -2034,7 +2289,20 @@ def cmd_run(args, agent_extra: list[str]) -> None:
             blocked = set(
                 proxy_conf.get("blocked_hosts", DEFAULT_BLOCKED_HOSTS)
             )
-            proxy = CredentialProxy(rules, blocked_hosts=blocked)
+            # Paranoid level reads `unshare_net` + `allow_domains` from
+            # [security]. allow_domains extends what the proxy will forward
+            # without credential injection (e.g. ["pypi.org", "github.com"]
+            # in permissive). enforce_allowlist makes the proxy reject any
+            # destination that is neither a credential-rule domain nor in
+            # allow_domains — that's the application-layer half of paranoid.
+            allow_domains_cfg = list(sec.get("allow_domains", []))
+            enforce_allowlist = bool(sec.get("unshare_net", False))
+            proxy = CredentialProxy(
+                rules,
+                blocked_hosts=blocked,
+                allow_domains=allow_domains_cfg,
+                enforce_allowlist=enforce_allowlist,
+            )
             port = proxy.start()
 
             # Build env overrides: remove API keys, rewrite base URLs,
@@ -2051,13 +2319,54 @@ def cmd_run(args, agent_extra: list[str]) -> None:
             proxy_env["HTTP_PROXY"] = proxy_base
             proxy_env["http_proxy"] = proxy_base
 
+    # Paranoid (`unshare_net`) needs a unix-socket bridge so the network-
+    # isolated sandbox can still reach the proxy via a bind-mounted socket
+    # file. We start the bridge on the host side here and pass the path to
+    # build_bwrap_cmd so it can wire the bind mount + the in-sandbox socat.
+    unshare_net = bool(sec.get("unshare_net", False))
+    proxy_unix_socket: str = ""
+    if unshare_net:
+        if proxy is None:
+            print(
+                "Error: [security] unshare_net = true requires "
+                "credential_proxy = true (the sandbox has no other path "
+                "out and no credentials would be injectable).",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        if not shutil.which("socat"):
+            print(
+                "Error: paranoid sandbox needs 'socat' on the host (it is "
+                "bind-mounted into the sandbox to bridge TCP -> unix-socket). "
+                "Install via your package manager (e.g. `dnf install socat` "
+                "or `apt install socat`), or switch sandbox_backend to nono.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        SANDBOX_DIR.mkdir(parents=True, exist_ok=True)
+        proxy_unix_socket = str(
+            SANDBOX_DIR / f"proxy-{os.getpid()}.sock"
+        )
+        proxy.start_unix_bridge(proxy_unix_socket)
+        # Override HTTP_PROXY so the agent points at the in-sandbox socat
+        # listener (a fixed port we set up in the bash wrapper) rather than
+        # the host-side TCP port (unreachable inside --unshare-net).
+        sandbox_proxy_port = 8118
+        sandbox_proxy_base = f"http://127.0.0.1:{sandbox_proxy_port}"
+        proxy_env["HTTP_PROXY"] = sandbox_proxy_base
+        proxy_env["http_proxy"] = sandbox_proxy_base
+        for rule in rules:
+            proxy_env[rule["base_url_env"]] = sandbox_proxy_base
+
     # Build command
     cmd = build_bwrap_cmd(config, project_dir, agent_extra, log_file,
                           profile=profile, safe_mode=args.safe,
                           extra_rw_cli=args.rw, extra_ro_cli=args.ro,
                           agent_config=agent_cfg, agent_id=args.id,
                           agent_name=agent_name,
-                          proxy_env=proxy_env if proxy_env else None)
+                          proxy_env=proxy_env if proxy_env else None,
+                          unshare_net=unshare_net,
+                          proxy_unix_socket=proxy_unix_socket)
 
     if args.dry_run:
         print("# bwrap command that would be executed:\n")

--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -2343,12 +2343,27 @@ def cmd_run(args, agent_extra: list[str]) -> None:
     proxy_unix_socket: str = ""
     if unshare_net:
         if proxy is None:
-            print(
-                "Error: [security] unshare_net = true requires "
-                "credential_proxy = true (the sandbox has no other path "
-                "out and no credentials would be injectable).",
-                file=sys.stderr,
-            )
+            if not proxy_enabled:
+                print(
+                    "Error: [security] unshare_net = true requires "
+                    "[security] credential_proxy = true. Without the "
+                    "proxy the network-isolated sandbox has no path out.",
+                    file=sys.stderr,
+                )
+            else:
+                print(
+                    "Error: [security] unshare_net = true requires at "
+                    "least one credential rule (e.g. ANTHROPIC_API_KEY "
+                    "in [env.extra] or in the active provider profile), "
+                    "otherwise the proxy doesn't start and the sandbox "
+                    "has no path to any LLM API.\n"
+                    "Quick fix: export ANTHROPIC_API_KEY in your host "
+                    "shell — the paranoid fragment auto-maps it via "
+                    "[env.extra]. If you use a different provider, add "
+                    "its key to your [env.extra] in "
+                    f"{config_path} or pick a profile with `-P`.",
+                    file=sys.stderr,
+                )
             sys.exit(1)
         if not shutil.which("socat"):
             print(

--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -1656,9 +1656,7 @@ def build_bwrap_cmd(config: dict, project_dir: Path,
                     agent_config: dict | None = None,
                     agent_id: str | None = None,
                     agent_name: str = "claude",
-                    proxy_env: dict[str, str] | None = None,
-                    unshare_net: bool = False,
-                    proxy_unix_socket: str = "") -> list[str]:
+                    proxy_env: dict[str, str] | None = None) -> list[str]:
     home = str(Path.home())
     home_p = Path.home()
     sandbox = config.get("sandbox", {})
@@ -1837,22 +1835,12 @@ def build_bwrap_cmd(config: dict, project_dir: Path,
         cmd += ["--new-session"]
     cmd += ["--die-with-parent"]
 
-    # Paranoid network isolation: kernel-enforced via bwrap's own --unshare-net
-    # (separate netns with only its own loopback). The agent reaches the
-    # credential proxy through a unix socket bind-mounted from the host: a
-    # small socat helper inside the sandbox bridges TCP localhost -> that
-    # unix socket. See the wrapper assembled below at the agent-cmd append.
-    if unshare_net:
-        cmd += ["--unshare-net"]
-        if proxy_unix_socket:
-            # Bind the host-side socket file into a path that lives on the
-            # sandbox tmpfs (--tmpfs /tmp earlier in this command), since
-            # /run/ is mounted read-only via the --ro-bind / /. The socat
-            # wrapper below uses the same target path.
-            cmd += [
-                "--bind", proxy_unix_socket,
-                "/tmp/lince-proxy.sock",
-            ]
+    # Paranoid network isolation is set up OUTSIDE this function: the caller
+    # wraps the bwrap invocation in `unshare -U -n -r` (creating a userns
+    # where we have CAP_NET_ADMIN over the new netns), brings up loopback,
+    # starts socat to bridge in-netns TCP to the host-side proxy unix socket,
+    # then exec's bwrap. bwrap inherits that netns via the default
+    # --share-net behavior, so we do nothing here.
 
     # --- 12. Environment: clearenv + explicit whitelist -----------------------
     cmd += ["--clearenv"]
@@ -1955,31 +1943,6 @@ def build_bwrap_cmd(config: dict, project_dir: Path,
                 args_source.append(da)
 
     agent_cmd = [agent_cfg["command"]] + args_source + list(agent_extra_args)
-
-    # Paranoid wrapper: bring up loopback inside the new netns, run a TCP
-    # listener that bridges to the bind-mounted unix socket, then exec the
-    # real agent. The agent's HTTP_PROXY env var points at this listener
-    # (set in cmd_run when unshare_net is True). PORT 8118 is fixed and
-    # internal — it never collides with anything because the netns is
-    # isolated.
-    if unshare_net and proxy_unix_socket:
-        bash_init = (
-            "set -e; "
-            "ip link set lo up; "
-            "socat TCP-LISTEN:8118,bind=127.0.0.1,reuseaddr,fork "
-            "UNIX-CONNECT:/tmp/lince-proxy.sock >/dev/null 2>&1 & "
-            # Wait briefly for the socat listener to be bound before
-            # handing control to the agent (otherwise the first request
-            # races against bind() and fails with ECONNREFUSED).
-            "for _ in 1 2 3 4 5 6 7 8 9 10; do "
-            "  if (exec 3<>/dev/tcp/127.0.0.1/8118) 2>/dev/null; then "
-            "    exec 3>&-; break; "
-            "  fi; "
-            "  sleep 0.05; "
-            "done; "
-            "exec \"$@\""
-        )
-        agent_cmd = ["/bin/bash", "-c", bash_init, "lince-paranoid-init"] + agent_cmd
 
     if log_file:
         # Use `script` to record the full terminal session.
@@ -2399,9 +2362,49 @@ def cmd_run(args, agent_extra: list[str]) -> None:
                           extra_rw_cli=args.rw, extra_ro_cli=args.ro,
                           agent_config=agent_cfg, agent_id=args.id,
                           agent_name=agent_name,
-                          proxy_env=proxy_env if proxy_env else None,
-                          unshare_net=unshare_net,
-                          proxy_unix_socket=proxy_unix_socket)
+                          proxy_env=proxy_env if proxy_env else None)
+
+    # Paranoid wrap: create a userns + fresh netns OUTSIDE bwrap so we can
+    # bring up loopback (needs CAP_NET_ADMIN, which non-setuid bwrap drops
+    # before exec) and run socat as the TCP-localhost-to-unix-socket bridge.
+    # bwrap itself runs WITHOUT --unshare-net, inheriting our netns via
+    # default --share-net. Inside bwrap the agent sees 127.0.0.1:8118 as a
+    # working listener and the host filesystem (and the bridge) is
+    # unreachable except via the socket.
+    if unshare_net:
+        for tool in ("unshare", "ip", "socat"):
+            if not shutil.which(tool):
+                print(
+                    f"Error: paranoid sandbox needs '{tool}' on the host "
+                    f"(it's invoked outside bwrap to set up the isolated "
+                    f"network namespace and bridge to the credential "
+                    f"proxy). Install it via your package manager, or "
+                    f"switch sandbox_backend to nono.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+        bash_setup = (
+            "set -e\n"
+            "ip link set lo up\n"
+            f"socat TCP-LISTEN:8118,bind=127.0.0.1,reuseaddr,fork "
+            f"UNIX-CONNECT:{shlex.quote(proxy_unix_socket)} "
+            ">/dev/null 2>&1 &\n"
+            "SOCAT_PID=$!\n"
+            'trap "kill $SOCAT_PID 2>/dev/null" EXIT\n'
+            # Wait briefly for socat to bind before handing off to bwrap.
+            "for _ in 1 2 3 4 5 6 7 8 9 10; do\n"
+            "  if (exec 3<>/dev/tcp/127.0.0.1/8118) 2>/dev/null; then\n"
+            "    exec 3>&-; break\n"
+            "  fi\n"
+            "  sleep 0.05\n"
+            "done\n"
+            'exec "$@"\n'
+        )
+        cmd = [
+            "unshare", "-U", "-n", "-r",
+            "bash", "-c", bash_setup, "lince-paranoid-netns",
+            *cmd,
+        ]
 
     if args.dry_run:
         print("# bwrap command that would be executed:\n")

--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -284,8 +284,19 @@ DEFAULT_BLOCKED_HOSTS: set[str] = {
 _proxy_logger = logging.getLogger("agent-sandbox.proxy")
 
 # Headers to strip when forwarding through the credential proxy.
+# - host / connection / proxy-connection / transfer-encoding: hop-by-hop
+#   or otherwise meaningless once we re-frame the response.
+# - date / server: send_response() emits its own copies; forwarding the
+#   upstream values produces duplicate headers, which strict HTTP/1.1
+#   clients (some Anthropic SDKs included) treat as malformed and the
+#   socket gets closed mid-stream.
+# - content-length: when upstream uses Transfer-Encoding: chunked,
+#   http.client decodes it for us so the bytes we forward are no longer
+#   the wire length. Our response uses Connection: close instead so the
+#   client reads until EOF.
 _PROXY_SKIP_HEADERS = frozenset({
     "host", "transfer-encoding", "connection", "proxy-connection",
+    "date", "server", "content-length",
 })
 
 
@@ -575,6 +586,10 @@ class _ProxyRequestHandler(BaseHTTPRequestHandler):
             for hdr, val in resp.getheaders():
                 if hdr.lower() not in _PROXY_SKIP_HEADERS:
                     self.send_header(hdr, val)
+            # We strip Content-Length and Transfer-Encoding above; signal
+            # end-of-response via connection close so the client reads
+            # until EOF without depending on either framing.
+            self.send_header("Connection", "close")
             self.end_headers()
             self.wfile.flush()
             # Stream response: use small reads and flush after each
@@ -652,6 +667,7 @@ class _ProxyRequestHandler(BaseHTTPRequestHandler):
             for hdr, val in resp.getheaders():
                 if hdr.lower() not in _PROXY_SKIP_HEADERS:
                     self.send_header(hdr, val)
+            self.send_header("Connection", "close")
             self.end_headers()
             self.wfile.flush()
             while True:

--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -755,6 +755,72 @@ def load_config() -> tuple[dict, Path]:
         return tomllib.load(fh), config_path
 
 
+# Keys whose list values should be APPENDED (not replaced) when overlaying a
+# sandbox-policy fragment on top of the user's resolved config. New entries
+# are de-duplicated against what's already in the base list.
+_SANDBOX_LEVEL_LIST_APPEND_KEYS = frozenset({
+    "home_ro_dirs", "home_rw_dirs", "ro_dirs", "extra_rw"
+})
+
+
+def load_sandbox_level_fragment(level: str) -> dict | None:
+    """Locate and load a sandbox-policy fragment for the given level name.
+
+    Search order:
+      1. ./.agent-sandbox/profiles/<level>.toml   (project-local override)
+      2. ~/.agent-sandbox/profiles/<level>.toml   (user-installed)
+      3. <script-dir>/profiles/<level>.toml       (built-in, ships with the script)
+
+    Returns the fragment dict, or None if no file was found (caller surfaces
+    a user-visible error in that case so typos don't silently no-op).
+    """
+    if not level:
+        return None
+    script_dir = Path(__file__).resolve().parent
+    candidates = [
+        Path.cwd() / ".agent-sandbox" / "profiles" / f"{level}.toml",
+        SANDBOX_DIR / "profiles" / f"{level}.toml",
+        script_dir / "profiles" / f"{level}.toml",
+    ]
+    for p in candidates:
+        if p.is_file():
+            with open(p, "rb") as fh:
+                return tomllib.load(fh)
+    return None
+
+
+def merge_sandbox_level(base: dict, overlay: dict) -> dict:
+    """Deep-merge a sandbox-policy fragment into the loaded config.
+
+    Dict values are merged recursively. List values for keys in
+    ``_SANDBOX_LEVEL_LIST_APPEND_KEYS`` are appended (preserving order,
+    de-duplicating); other lists and scalars are replaced by the overlay.
+    Returns a new dict; does not mutate inputs.
+    """
+    result = dict(base)
+    for key, ov_value in overlay.items():
+        if (
+            key in result
+            and isinstance(result[key], dict)
+            and isinstance(ov_value, dict)
+        ):
+            result[key] = merge_sandbox_level(result[key], ov_value)
+        elif (
+            key in result
+            and isinstance(result[key], list)
+            and isinstance(ov_value, list)
+            and key in _SANDBOX_LEVEL_LIST_APPEND_KEYS
+        ):
+            merged = list(result[key])
+            for item in ov_value:
+                if item not in merged:
+                    merged.append(item)
+            result[key] = merged
+        else:
+            result[key] = ov_value
+    return result
+
+
 _agents_defaults_cache: dict[str, dict] | None = None
 
 
@@ -1815,6 +1881,24 @@ def cmd_init(args) -> None:
 
 def cmd_run(args, agent_extra: list[str]) -> None:
     config, config_path = load_config()
+
+    # Apply sandbox-policy fragment if --sandbox-level was passed. Levels are
+    # free-form: paranoid/normal/permissive ship as built-in fragments under
+    # <script-dir>/profiles/, and users can drop their own at
+    # ~/.agent-sandbox/profiles/<name>.toml.
+    sandbox_level = getattr(args, "sandbox_level", None)
+    if sandbox_level and sandbox_level != "normal":
+        fragment = load_sandbox_level_fragment(sandbox_level)
+        if fragment is None:
+            print(
+                f"Error: unknown sandbox level '{sandbox_level}' "
+                f"(no fragment file found in ./.agent-sandbox/profiles/, "
+                f"~/.agent-sandbox/profiles/, or alongside agent-sandbox).",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        config = merge_sandbox_level(config, fragment)
+
     backend = resolve_backend(config)
 
     project_dir = Path(args.project).resolve()
@@ -4292,6 +4376,13 @@ def main() -> None:
                        metavar="DIR", help="Extra read-only directory for this run (repeatable)")
     p_run.add_argument("--id", default=None, metavar="ID",
                        help="Agent ID (sets LINCE_AGENT_ID env var inside sandbox)")
+    p_run.add_argument("--sandbox-level", dest="sandbox_level", default=None,
+                       metavar="NAME",
+                       help="Sandbox isolation level: paranoid|normal|permissive "
+                            "(or any custom name). Loads the matching policy fragment "
+                            "from sandbox/profiles/<NAME>.toml (built-in) or "
+                            "~/.agent-sandbox/profiles/<NAME>.toml (user-supplied) and "
+                            "merges it into the config before running.")
 
     # diff
     sub.add_parser("diff",

--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -406,6 +406,13 @@ class _ProxyRequestHandler(BaseHTTPRequestHandler):
         hosts are: any domain that has a credential rule, plus everything in
         ``allow_domains``. Hosts in ``blocked_hosts`` are always rejected,
         regardless of allowlist state — that check happens earlier.
+
+        Case contract: ``host`` is a Host-header value (already lowercased
+        by the caller for the do_CONNECT/_handle_forward paths), and
+        ``allow_domains`` is lowercased once at construction
+        (``CredentialProxy.__init__``). Credential-rule domains in
+        ``CREDENTIAL_PROXY_RULES`` are also lowercase. Don't mix in
+        non-lowercased values without normalizing.
         """
         bare = host.split(":")[0]
         if bare in self.allow_domains:
@@ -642,14 +649,14 @@ class _ProxyRequestHandler(BaseHTTPRequestHandler):
         """
         self._bump_count()
 
-        # In HTTP_PROXY mode the agent sends an absolute URL. Otherwise we
-        # reconstruct from Host header. We don't upgrade plain HTTP to HTTPS
-        # — pass the scheme the agent asked for.
-        if self.path.startswith(("http://", "https://")):
-            upstream_url = self.path
-        else:
-            host = self.headers.get("Host", "")
-            upstream_url = f"http://{host}{self.path}"
+        # _forward_passthrough is only reachable from _handle_forward AFTER
+        # an allow_domains match, and that match only succeeds in HTTP_PROXY
+        # mode (where self.path is an absolute URL like
+        # "http://github.com/foo"). In BASE_URL mode the Host header is
+        # 127.0.0.1:PORT and never matches an external allow_domain entry,
+        # so the relative-URL fallback would be unreachable — drop it
+        # rather than carry dead code.
+        upstream_url = self.path
 
         content_length = int(self.headers.get("Content-Length", 0))
         body = self.rfile.read(content_length) if content_length > 0 else None
@@ -2382,6 +2389,10 @@ def cmd_run(args, agent_extra: list[str]) -> None:
             )
             sys.exit(1)
         SANDBOX_DIR.mkdir(parents=True, exist_ok=True)
+        # Per-pid socket path: agent-sandbox doesn't fork or daemonize, so
+        # the pid is stable for the lifetime of one `run` invocation and
+        # collisions are not a concern. If we ever introduce a long-lived
+        # daemon that forks, switch to a uuid or include the agent_id.
         proxy_unix_socket = str(
             SANDBOX_DIR / f"proxy-{os.getpid()}.sock"
         )
@@ -2431,13 +2442,22 @@ def cmd_run(args, agent_extra: list[str]) -> None:
             ">/dev/null 2>&1 &\n"
             "SOCAT_PID=$!\n"
             'trap "kill $SOCAT_PID 2>/dev/null" EXIT\n'
-            # Wait briefly for socat to bind before handing off to bwrap.
+            # Wait for socat to bind, then verify before handing off to
+            # bwrap. Without this fail-fast, a socat that never binds (e.g.
+            # binary missing inside the netns or address-in-use) would
+            # leave the agent running with a dead proxy — every API call
+            # would silently fail with ECONNREFUSED.
+            "READY=0\n"
             "for _ in 1 2 3 4 5 6 7 8 9 10; do\n"
             "  if (exec 3<>/dev/tcp/127.0.0.1/8118) 2>/dev/null; then\n"
-            "    exec 3>&-; break\n"
+            "    exec 3>&-; READY=1; break\n"
             "  fi\n"
             "  sleep 0.05\n"
             "done\n"
+            "if [ \"$READY\" != 1 ]; then\n"
+            "  echo \"agent-sandbox paranoid: socat failed to bind 127.0.0.1:8118 inside the sandbox netns; aborting\" >&2\n"
+            "  exit 1\n"
+            "fi\n"
             'exec "$@"\n'
         )
         # `unshare -U -n -r` makes us UID 0 in a fresh user+net namespace

--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -386,14 +386,18 @@ class _ProxyRequestHandler(BaseHTTPRequestHandler):
 
     # --- Metadata / blocked host guard ------------------------------------
 
+    @staticmethod
+    def _bare_host(host: str) -> str:
+        """Strip the optional ``:port`` suffix from a Host-header value."""
+        return host.split(":", 1)[0]
+
     def _is_blocked(self, host: str) -> bool:
         """Return True if *host* is in the blocked set."""
-        bare = host.split(":")[0]
-        return bare in self.blocked_hosts
+        return self._bare_host(host) in self.blocked_hosts
 
     def _find_rule_for_host(self, host: str) -> dict | None:
         """Return the credential rule matching *host*, or None."""
-        bare = host.split(":")[0]
+        bare = self._bare_host(host)
         for rule in self.credential_rules:
             if rule["domain"] == bare:
                 return rule
@@ -414,13 +418,10 @@ class _ProxyRequestHandler(BaseHTTPRequestHandler):
         ``CREDENTIAL_PROXY_RULES`` are also lowercase. Don't mix in
         non-lowercased values without normalizing.
         """
-        bare = host.split(":")[0]
+        bare = self._bare_host(host)
         if bare in self.allow_domains:
             return True
-        for rule in self.credential_rules:
-            if rule["domain"] == bare:
-                return True
-        return False
+        return self._find_rule_for_host(host) is not None
 
     # --- Request counting -------------------------------------------------
 
@@ -2389,6 +2390,27 @@ def cmd_run(args, agent_extra: list[str]) -> None:
             )
             sys.exit(1)
         SANDBOX_DIR.mkdir(parents=True, exist_ok=True)
+        # Sweep socket files left over by previous paranoid runs that
+        # exited via SIGKILL or crash (the normal cleanup is in
+        # CredentialProxy.stop, which doesn't fire on SIGKILL). Each file
+        # is a few bytes but they accumulate over time. We unlink any
+        # `proxy-PID.sock` whose pid is no longer alive.
+        for stale in SANDBOX_DIR.glob("proxy-*.sock"):
+            try:
+                stale_pid = int(stale.stem.removeprefix("proxy-"))
+            except ValueError:
+                continue
+            try:
+                os.kill(stale_pid, 0)  # raises if pid is gone
+            except ProcessLookupError:
+                try:
+                    stale.unlink()
+                except OSError:
+                    pass
+            except PermissionError:
+                # PID exists but is owned by someone else — leave alone.
+                pass
+
         # Per-pid socket path: agent-sandbox doesn't fork or daemonize, so
         # the pid is stable for the lifetime of one `run` invocation and
         # collisions are not a concern. If we ever introduce a long-lived

--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -975,6 +975,10 @@ _SANDBOX_LEVEL_LIST_APPEND_KEYS = frozenset({
     # [security].allow_domains is also append-merged so a custom level can
     # extend (e.g. "paranoid + pypi") without restating the base set.
     "allow_domains",
+    # [env].passthrough extends host-env vars exposed in the sandbox so
+    # fragments can add tool-specific tokens (e.g. permissive ships
+    # GH_TOKEN / GITHUB_TOKEN so `gh` keeps its env-based auth working).
+    "passthrough",
 })
 
 

--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -1845,9 +1845,13 @@ def build_bwrap_cmd(config: dict, project_dir: Path,
     if unshare_net:
         cmd += ["--unshare-net"]
         if proxy_unix_socket:
+            # Bind the host-side socket file into a path that lives on the
+            # sandbox tmpfs (--tmpfs /tmp earlier in this command), since
+            # /run/ is mounted read-only via the --ro-bind / /. The socat
+            # wrapper below uses the same target path.
             cmd += [
                 "--bind", proxy_unix_socket,
-                "/run/lince-proxy.sock",
+                "/tmp/lince-proxy.sock",
             ]
 
     # --- 12. Environment: clearenv + explicit whitelist -----------------------
@@ -1963,7 +1967,7 @@ def build_bwrap_cmd(config: dict, project_dir: Path,
             "set -e; "
             "ip link set lo up; "
             "socat TCP-LISTEN:8118,bind=127.0.0.1,reuseaddr,fork "
-            "UNIX-CONNECT:/run/lince-proxy.sock >/dev/null 2>&1 & "
+            "UNIX-CONNECT:/tmp/lince-proxy.sock >/dev/null 2>&1 & "
             # Wait briefly for the socat listener to be bound before
             # handing control to the agent (otherwise the first request
             # races against bind() and fails with ECONNREFUSED).

--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -589,10 +589,32 @@ class _ProxyRequestHandler(BaseHTTPRequestHandler):
             _proxy_logger.warning(
                 "Upstream error %s %s: %s", method, upstream_url, exc
             )
-            self.send_error(502, f"Upstream error: {exc}")
+            self._safe_send_error(502, f"Upstream error: {exc}")
+        except BrokenPipeError:
+            # Client closed the connection mid-stream (normal end-of-SSE
+            # behavior for some SDKs). Don't try to write anything else;
+            # the socket is already gone.
+            _proxy_logger.debug("client closed during %s %s", method, upstream_url)
         except OSError as exc:
             _proxy_logger.error("Proxy forwarding error: %s", exc)
-            self.send_error(502, f"Proxy error: {exc}")
+            self._safe_send_error(502, f"Proxy error: {exc}")
+
+    # --- Helper: send_error that swallows write-side failures ------------
+
+    def _safe_send_error(self, code: int, message: str) -> None:
+        """``send_error`` wrapped so a broken client connection doesn't
+        cascade into a second uncaught OSError.
+
+        The default ``BaseHTTPRequestHandler.send_error`` writes status +
+        headers + body to ``self.wfile``; if the underlying socket is
+        already gone (because the *first* error was a write failure), the
+        secondary write raises another exception that surfaces as
+        "Exception occurred during processing of request" in stderr.
+        """
+        try:
+            self.send_error(code, message)
+        except (BrokenPipeError, ConnectionResetError, OSError):
+            pass
 
     # --- Pass-through forwarding (no credential injection) ---------------
 
@@ -640,10 +662,12 @@ class _ProxyRequestHandler(BaseHTTPRequestHandler):
                 self.wfile.flush()
         except http.client.HTTPException as exc:
             _proxy_logger.warning("Pass-through error %s %s: %s", method, upstream_url, exc)
-            self.send_error(502, f"Pass-through error: {exc}")
+            self._safe_send_error(502, f"Pass-through error: {exc}")
+        except BrokenPipeError:
+            _proxy_logger.debug("client closed during pass-through %s %s", method, upstream_url)
         except OSError as exc:
             _proxy_logger.error("Pass-through socket error: %s", exc)
-            self.send_error(502, f"Pass-through error: {exc}")
+            self._safe_send_error(502, f"Pass-through error: {exc}")
 
     def do_GET(self):  # noqa: N802
         self._handle_forward("GET")

--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -978,29 +978,37 @@ _SANDBOX_LEVEL_LIST_APPEND_KEYS = frozenset({
 })
 
 
-def load_sandbox_level_fragment(level: str) -> dict | None:
+def load_sandbox_level_fragment(level: str, agent: str = "claude") -> dict | None:
     """Locate and load a sandbox-policy fragment for the given level name.
 
-    Search order:
-      1. ./.agent-sandbox/profiles/<level>.toml   (project-local override)
-      2. ~/.agent-sandbox/profiles/<level>.toml   (user-installed)
-      3. <script-dir>/profiles/<level>.toml       (built-in, ships with the script)
+    Tries the agent-specific name first (``<agent>-<level>.toml``) so the
+    shipped fragments like ``claude-paranoid.toml`` are picked up, then
+    falls back to the bare level name (``<level>.toml``) so users can
+    write a single cross-agent fragment when they want one.
 
-    Returns the fragment dict, or None if no file was found (caller surfaces
-    a user-visible error in that case so typos don't silently no-op).
+    Search order, each tried as <agent>-<level>.toml then <level>.toml:
+      1. ./.agent-sandbox/profiles/   (project-local override)
+      2. ~/.agent-sandbox/profiles/   (user-installed)
+      3. <script-dir>/profiles/       (built-in, ships with the script)
+
+    Returns the fragment dict, or None if no file was found (caller
+    surfaces a user-visible error so typos don't silently no-op).
     """
     if not level:
         return None
     script_dir = Path(__file__).resolve().parent
-    candidates = [
-        Path.cwd() / ".agent-sandbox" / "profiles" / f"{level}.toml",
-        SANDBOX_DIR / "profiles" / f"{level}.toml",
-        script_dir / "profiles" / f"{level}.toml",
+    base_dirs = [
+        Path.cwd() / ".agent-sandbox" / "profiles",
+        SANDBOX_DIR / "profiles",
+        script_dir / "profiles",
     ]
-    for p in candidates:
-        if p.is_file():
-            with open(p, "rb") as fh:
-                return tomllib.load(fh)
+    name_candidates = [f"{agent}-{level}.toml", f"{level}.toml"]
+    for d in base_dirs:
+        for name in name_candidates:
+            p = d / name
+            if p.is_file():
+                with open(p, "rb") as fh:
+                    return tomllib.load(fh)
     return None
 
 
@@ -2140,15 +2148,19 @@ def cmd_run(args, agent_extra: list[str]) -> None:
     # Apply sandbox-policy fragment if --sandbox-level was passed. Levels are
     # free-form: paranoid/normal/permissive ship as built-in fragments under
     # <script-dir>/profiles/, and users can drop their own at
-    # ~/.agent-sandbox/profiles/<name>.toml.
+    # ~/.agent-sandbox/profiles/<name>.toml. Lookup tries
+    # <agent>-<level>.toml first (shipped as e.g. claude-paranoid.toml),
+    # then falls back to the bare <level>.toml.
     sandbox_level = getattr(args, "sandbox_level", None)
     if sandbox_level and sandbox_level != "normal":
-        fragment = load_sandbox_level_fragment(sandbox_level)
+        fragment = load_sandbox_level_fragment(sandbox_level, agent=args.agent)
         if fragment is None:
             print(
-                f"Error: unknown sandbox level '{sandbox_level}' "
-                f"(no fragment file found in ./.agent-sandbox/profiles/, "
-                f"~/.agent-sandbox/profiles/, or alongside agent-sandbox).",
+                f"Error: unknown sandbox level '{sandbox_level}' for "
+                f"agent '{args.agent}' (looked for "
+                f"{args.agent}-{sandbox_level}.toml then "
+                f"{sandbox_level}.toml in ./.agent-sandbox/profiles/, "
+                f"~/.agent-sandbox/profiles/, and alongside agent-sandbox).",
                 file=sys.stderr,
             )
             sys.exit(1)

--- a/sandbox/install.sh
+++ b/sandbox/install.sh
@@ -51,6 +51,19 @@ if command -v nono >/dev/null 2>&1; then
     echo -e "${GREEN}  ✓ nono $(nono --version 2>/dev/null | head -1)${NC}"
 fi
 
+# socat is required for paranoid sandbox level on bwrap (it bridges
+# TCP-localhost-in-sandbox -> bind-mounted unix socket -> host proxy).
+# Not a hard prerequisite — paranoid is opt-in — but warn early so users
+# don't hit it at run time.
+if [ "$OS_NAME" != "Darwin" ] && [ "$HAS_BWRAP" = true ]; then
+    if command -v socat >/dev/null 2>&1; then
+        echo -e "${GREEN}  ✓ socat $(socat -V 2>&1 | head -1 | awk '{print $3}') (needed for paranoid sandbox level)${NC}"
+    else
+        echo -e "${YELLOW}  ⚠ socat not found — needed only if you use sandbox_level=\"paranoid\" with bwrap${NC}"
+        echo -e "${YELLOW}    Install: dnf install socat   |   apt install socat   |   pacman -S socat${NC}"
+    fi
+fi
+
 # Platform-specific checks
 if [ "$OS_NAME" = "Darwin" ]; then
     # macOS: bwrap is not available, nono is required

--- a/sandbox/install.sh
+++ b/sandbox/install.sh
@@ -98,6 +98,24 @@ if [ -f "$DEFAULTS_SRC" ]; then
     cp "$DEFAULTS_SRC" "$HOME/.local/bin/agents-defaults.toml"
     echo -e "${GREEN}  ✓ Installed: ~/.local/bin/agents-defaults.toml${NC}"
 fi
+
+# Install built-in sandbox-policy fragments (paranoid/normal/permissive +
+# any custom-shipped ones). agent-sandbox loads these via --sandbox-level.
+# Fragment search order in the script: ./.agent-sandbox/profiles → ~/.agent-sandbox/profiles → <script-dir>/profiles.
+PROFILES_SRC="$SCRIPT_DIR/profiles"
+PROFILES_DST="$CONFIG_DIR/profiles"
+if [ -d "$PROFILES_SRC" ]; then
+    mkdir -p "$PROFILES_DST"
+    count=0
+    for fragment in "$PROFILES_SRC"/*.toml; do
+        [ -f "$fragment" ] || continue
+        cp "$fragment" "$PROFILES_DST/"
+        count=$((count + 1))
+    done
+    if [ "$count" -gt 0 ]; then
+        echo -e "${GREEN}  ✓ Installed $count sandbox-policy fragment(s) to $PROFILES_DST${NC}"
+    fi
+fi
 echo ""
 
 # ── Step 3: Initialize config ──────────────────────────────────────────

--- a/sandbox/profiles/claude-paranoid.toml
+++ b/sandbox/profiles/claude-paranoid.toml
@@ -1,0 +1,23 @@
+# Sandbox-policy fragment: claude — paranoid level.
+#
+# Loaded by `agent-sandbox run --sandbox-level paranoid` and merged on top of
+# the user's resolved config (deep merge; lists are appended). See lince-98
+# for the design rationale.
+#
+# Paranoid intent on bwrap:
+#   - Force isolated copy of ~/.claude (use_real_config = false), so anything
+#     the agent writes stays inside ~/.agent-sandbox/claude-config/, not the
+#     real config dir.
+#   - Ensure the credential proxy is on so API keys never enter the sandbox.
+#
+# NOTE: kernel-level network isolation (--unshare-net) is intentionally NOT
+# enabled here. With --unshare-net the sandbox gets its own loopback and can
+# no longer reach the host-side credential proxy at 127.0.0.1:PORT, breaking
+# all LLM API calls. Tightening this path requires a unix-socket proxy or an
+# in-namespace proxy — tracked as a follow-up issue.
+
+[claude]
+use_real_config = false
+
+[security]
+credential_proxy = true

--- a/sandbox/profiles/claude-paranoid.toml
+++ b/sandbox/profiles/claude-paranoid.toml
@@ -31,6 +31,15 @@
 [claude]
 use_real_config = false
 
+[env.extra]
+# Auto-pick the user's host Anthropic credential so the credential proxy
+# has something to inject without requiring `-P someprofile` or a manual
+# entry in the user's [env.extra]. Both forms are recognized — whichever
+# is set in the host env wins; the unset one expands to empty and is
+# silently dropped by the proxy rule collector.
+ANTHROPIC_API_KEY = "$ANTHROPIC_API_KEY"
+ANTHROPIC_AUTH_TOKEN = "$ANTHROPIC_AUTH_TOKEN"
+
 [security]
 credential_proxy = true
 unshare_net = true

--- a/sandbox/profiles/claude-paranoid.toml
+++ b/sandbox/profiles/claude-paranoid.toml
@@ -43,4 +43,12 @@ ANTHROPIC_AUTH_TOKEN = "$ANTHROPIC_AUTH_TOKEN"
 [security]
 credential_proxy = true
 unshare_net = true
-allow_domains = ["api.anthropic.com"]
+# allow_domains lists EXTRA hosts the agent can reach via the proxy, on
+# top of the domains already covered by credential rules
+# (api.anthropic.com is auto-included because we have an Anthropic
+# credential rule — no need to repeat it here). Empty by default.
+# Extend in your own ~/.agent-sandbox/config.toml — the lists are
+# append-merged:
+#   [security]
+#   allow_domains = ["pypi.org", "files.pythonhosted.org"]
+allow_domains = []

--- a/sandbox/profiles/claude-paranoid.toml
+++ b/sandbox/profiles/claude-paranoid.toml
@@ -1,23 +1,37 @@
 # Sandbox-policy fragment: claude — paranoid level.
 #
-# Loaded by `agent-sandbox run --sandbox-level paranoid` and merged on top of
-# the user's resolved config (deep merge; lists are appended). See lince-98
-# for the design rationale.
+# Loaded by `agent-sandbox run --sandbox-level paranoid` and deep-merged on
+# top of the user's resolved config. Lists like home_ro_dirs and
+# allow_domains are appended (not replaced).
 #
-# Paranoid intent on bwrap:
-#   - Force isolated copy of ~/.claude (use_real_config = false), so anything
-#     the agent writes stays inside ~/.agent-sandbox/claude-config/, not the
-#     real config dir.
-#   - Ensure the credential proxy is on so API keys never enter the sandbox.
+# Paranoid means kernel-enforced isolation:
+#   - use_real_config = false: agent writes to ~/.agent-sandbox/claude-config/,
+#     real ~/.claude is untouched.
+#   - credential_proxy = true: API keys live on the host keystore/env, never
+#     in the sandbox; the proxy injects them at request time.
+#   - unshare_net = true: the agent runs in a fresh network namespace
+#     (bwrap --unshare-net) with only its own loopback. No route to
+#     anywhere — kernel rejects raw socket connections to attacker.com or
+#     anywhere else. The credential proxy is reached via a unix socket
+#     bind-mounted into the sandbox + an in-sandbox socat bridge that the
+#     agent talks to as plain TCP localhost.
+#   - allow_domains: hosts the proxy is allowed to forward to (whether by
+#     credential injection for known providers, or by pass-through for
+#     extras like pypi.org). Anything else gets 403 from the proxy.
 #
-# NOTE: kernel-level network isolation (--unshare-net) is intentionally NOT
-# enabled here. With --unshare-net the sandbox gets its own loopback and can
-# no longer reach the host-side credential proxy at 127.0.0.1:PORT, breaking
-# all LLM API calls. Tightening this path requires a unix-socket proxy or an
-# in-namespace proxy — tracked as a follow-up issue.
+# To extend paranoid (e.g. paranoid + pypi.org), don't fork this file —
+# just add to your ~/.agent-sandbox/config.toml:
+#
+#   [security]
+#   allow_domains = ["pypi.org", "files.pythonhosted.org"]
+#
+# The lists are append-merged, so the final allowlist is the base
+# (api.anthropic.com) plus your extras.
 
 [claude]
 use_real_config = false
 
 [security]
 credential_proxy = true
+unshare_net = true
+allow_domains = ["api.anthropic.com"]

--- a/sandbox/profiles/claude-permissive.toml
+++ b/sandbox/profiles/claude-permissive.toml
@@ -1,0 +1,21 @@
+# Sandbox-policy fragment: claude — permissive level.
+#
+# Loaded by `agent-sandbox run --sandbox-level permissive` and merged on top
+# of the user's resolved config (deep merge; lists are appended).
+#
+# Permissive intent on bwrap:
+#   - Read access to gh CLI's config and SSH known_hosts so `gh auth status`
+#     and `gh pr create` work inside the sandbox.
+#   - Read access to ~/.cache for general tool cache reuse.
+#   - Anthropic API and github.com reachable (the credential proxy already
+#     allows the LLM API; bwrap shares the host network so github is reachable
+#     unless explicitly blocked).
+#
+# Out of scope: docker, podman, direct `git push` (use `gh` instead).
+
+[sandbox]
+home_ro_dirs = [".config/gh", ".cache", ".ssh/known_hosts"]
+
+[security]
+credential_proxy = true
+block_git_push = true

--- a/sandbox/profiles/claude-permissive.toml
+++ b/sandbox/profiles/claude-permissive.toml
@@ -1,17 +1,20 @@
 # Sandbox-policy fragment: claude — permissive level.
 #
-# Loaded by `agent-sandbox run --sandbox-level permissive` and merged on top
-# of the user's resolved config (deep merge; lists are appended).
+# Loaded by `agent-sandbox run --sandbox-level permissive` and deep-merged
+# on top of the user's resolved config. Lists like home_ro_dirs and
+# allow_domains are appended (not replaced).
 #
-# Permissive intent on bwrap:
-#   - Read access to gh CLI's config and SSH known_hosts so `gh auth status`
-#     and `gh pr create` work inside the sandbox.
-#   - Read access to ~/.cache for general tool cache reuse.
-#   - Anthropic API and github.com reachable (the credential proxy already
-#     allows the LLM API; bwrap shares the host network so github is reachable
-#     unless explicitly blocked).
+# Permissive opens up github + the gh CLI's filesystem footprint while
+# keeping the credential proxy on. Network is NOT kernel-isolated here
+# (unshare_net is left at its default, off) — the threat model is "trusted
+# agent that needs broader access, not adversarial".
 #
-# Out of scope: docker, podman, direct `git push` (use `gh` instead).
+# To narrow what the proxy is allowed to forward (without going to the
+# stricter paranoid level), keep this fragment but tighten allow_domains
+# in your own config:
+#
+#   [security]
+#   allow_domains = []   # block everything except credential-rule hosts
 
 [sandbox]
 home_ro_dirs = [".config/gh", ".cache", ".ssh/known_hosts"]
@@ -19,3 +22,8 @@ home_ro_dirs = [".config/gh", ".cache", ".ssh/known_hosts"]
 [security]
 credential_proxy = true
 block_git_push = true
+allow_domains = [
+    "api.github.com",
+    "github.com",
+    "objects.githubusercontent.com",
+]

--- a/sandbox/profiles/claude-permissive.toml
+++ b/sandbox/profiles/claude-permissive.toml
@@ -19,6 +19,15 @@
 [sandbox]
 home_ro_dirs = [".config/gh", ".cache", ".ssh/known_hosts"]
 
+[env]
+# Pass host-env GitHub tokens through. gh CLI authenticated via
+# `gh auth login --with-token` reads from ~/.config/gh/hosts.yml (mounted
+# above), but users authenticated via the system keyring rely on
+# GH_TOKEN / GITHUB_TOKEN being exported in their shell — the sandbox's
+# default --clearenv would otherwise wipe them. Append-merged with the
+# user's [env].passthrough.
+passthrough = ["GH_TOKEN", "GITHUB_TOKEN"]
+
 [security]
 credential_proxy = true
 block_git_push = true

--- a/sandbox/update.sh
+++ b/sandbox/update.sh
@@ -39,6 +39,24 @@ if [ -f "$DEFAULTS_SRC" ]; then
     cp "$DEFAULTS_SRC" "$HOME/.local/bin/agents-defaults.toml"
     echo -e "${GREEN}  ✓ Agent defaults updated: ~/.local/bin/agents-defaults.toml${NC}"
 fi
+
+# Update built-in sandbox-policy fragments. New fragments shipped with this
+# release land in ~/.agent-sandbox/profiles/ where agent-sandbox finds them
+# via its --sandbox-level flag.
+PROFILES_SRC="$SCRIPT_DIR/profiles"
+PROFILES_DST="$HOME/.agent-sandbox/profiles"
+if [ -d "$PROFILES_SRC" ]; then
+    mkdir -p "$PROFILES_DST"
+    count=0
+    for fragment in "$PROFILES_SRC"/*.toml; do
+        [ -f "$fragment" ] || continue
+        cp "$fragment" "$PROFILES_DST/"
+        count=$((count + 1))
+    done
+    if [ "$count" -gt 0 ]; then
+        echo -e "${GREEN}  ✓ Sandbox-policy fragments updated: $count file(s) in $PROFILES_DST${NC}"
+    fi
+fi
 echo ""
 
 # ── Step 2: Ensure env passthrough ─────────────────────────────────────


### PR DESCRIPTION
Closes #48. Tracked in backlog as `lince-98`. Umbrella: #47.

## What this PR does

Collapses the multiple `[agents.claude]` / `claude-bwrap` / `claude-nono` entries in `lince-dashboard/agents-defaults.toml` into a **single** entry driven by two new attributes:

- `sandbox_level = "paranoid" | "normal" | "permissive"` — default `"normal"`. **Free-form**, not a closed enum: any string resolves to a profile file by name, so users can ship custom levels without plugin changes.
- `sandbox_backend = "bwrap" | "nono"` — default per OS (linux=bwrap, mac=nono); explicit override allowed.

The N-picker now shows `Claude Code` once, not three times. Alternative levels live as commented templates in `agents-defaults.toml` so they're discoverable without cluttering the picker.

## The three levels — final threat model

| Scenario | bwrap normal | bwrap paranoid | bwrap permissive | nono paranoid |
|---|---|---|---|---|
| Leak `ANTHROPIC_API_KEY` via env dump | ❌ | ✅ proxy strips | ✅ proxy strips | ✅ keystore |
| Modify real `~/.claude` | ❌ | ✅ `use_real_config=false` | ✅ default | ✅ scratch copy |
| Open raw socket to `attacker.com` | ❌ | **✅ netns has no route** | ❌ (intentional) | ✅ Landlock |
| `curl https://attacker.com` via HTTP_PROXY | ❌ | **✅ proxy 403** | ❌ (intentional) | ✅ nono allowlist |
| `gh auth status` works | ❌ no `~/.config/gh` mounted | n/a (only Anthropic API allowed) | ✅ via mount + `GH_TOKEN` | n/a |
| `docker ps` works | depends | ❌ | ❌ (out of scope) | ❌ |

Both paranoid backends are now **kernel-enforced**:
- nono: Landlock LSM + native nono network policy
- bwrap: `--unshare-net` (fresh netns, no route) + unix-socket bridge to the credential proxy via in-sandbox `socat`. Agents see plain TCP localhost — no SDK changes needed.

## Architectural decisions worth highlighting

1. **`sandbox_level` is free-form on purpose.** Drop a `~/.config/nono/profiles/lince-claude-with-aws.json` (nono) or `~/.agent-sandbox/profiles/with-aws.toml` (bwrap), set `sandbox_level = "with-aws"`, done. No plugin recompile.

2. **`[security] allow_domains` is the per-level allowlist knob.** Append-merged, so users extend without forking fragments:

   ```toml
   # ~/.agent-sandbox/config.toml
   [security]
   allow_domains = ["pypi.org", "files.pythonhosted.org"]
   ```

   …combined with `sandbox_level = "paranoid"` gives paranoid + the two extra domains. The proxy's strict-allowlist mode auto-activates when `unshare_net = true`.

3. **bwrap paranoid path: `bwrap --unshare-net` + bind-mount unix socket + `socat` bridge.** Considered pasta initially; the deep-research-agent revealed pasta isn't a firewall by default (forwards outbound to anywhere). The unix-socket approach is simpler, kernel-enforced, and keeps TCP-localhost compatibility for all HTTP clients.

4. **MCP-on-internet for permissive is opt-in.** Users who run MCP servers reaching internet inside the sandbox extend `allow_domains` with the MCP endpoints. Out of scope for shipped defaults.

## Files

**New:**
- `lince-dashboard/nono-profiles/lince-claude-{paranoid,permissive}.json`
- `sandbox/profiles/claude-{paranoid,permissive}.toml`
- `docs/documentation/dashboard/sandbox-levels.md` (reference)
- `docs/documentation/dashboard/sandbox-levels-testing.md` (manual test plan)
- `backlog/tasks/lince-{98,99,100,101,102}*.md`

**Modified (selected):**
- `lince-dashboard/plugin/src/{config.rs,agent.rs}` — `sandbox_level` field + dispatch
- `lince-dashboard/agents-defaults.toml` — collapse claude entries
- `lince-dashboard/install.sh` — keystore setup reminder when nono is detected
- `sandbox/agent-sandbox` — `--sandbox-level` flag, fragment loader, `CredentialProxy` allow_domains + unix-socket bridge, `--unshare-net` wiring with socat wrapper, GH_TOKEN/GITHUB_TOKEN passthrough
- `sandbox/install.sh` / `sandbox/update.sh` — copy fragments, detect socat
- `lince-dashboard/README.md` — cross-link to the new docs

## Manual verification

Acceptance criteria #2–#6 require a running dashboard and are covered by the manual test plan in `docs/documentation/dashboard/sandbox-levels-testing.md`. Reviewer should run each (level × backend) cell before merging. Static AC (#1, #7–#12) verified at code-review time (parse, build, smoke tests).

## Test plan checklist

- [ ] N-picker shows `Claude Code` once
- [ ] `sandbox_level=normal` (default): existing behavior unchanged
- [ ] `sandbox_level=paranoid` on nono: arbitrary network blocked, Anthropic API works via proxy, `~/.claude` isolated
- [ ] `sandbox_level=paranoid` on bwrap: `curl https://attacker.com` fails at netns level (DNS or route error), `pgrep socat` shows one helper per running agent, Anthropic API works
- [ ] `sandbox_level=permissive` on bwrap: `gh auth status` works (file or env-token auth), `gh pr create` works, `docker ps` fails, direct `git push` fails
- [ ] Custom level via `~/.agent-sandbox/config.toml` `[security] allow_domains = [...]` extends paranoid (paranoid + pypi.org workflow)
- [ ] `install.sh` is idempotent

## Follow-ups (already filed)

- #49 #50 #51 #52 — apply the same pattern to codex / gemini / opencode / pi (depend on this PR; backlog tasks lince-99..102 carry the design context so no re-brainstorm)
- #53 — wizard 'N' picker UX changes that the single-entry-per-agent model enables
- #54 — fragment-level `extends` inheritance (so `paranoid-with-pypi.toml` can `extends = "paranoid"` instead of relying on config.toml-overlay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)