### PR TITLE
sandbox: three-level model for codex + generic ephemeral scratch_home_dirs

### DIFF
--- a/backlog/tasks/lince-100 - Three-sandbox-levels-—-gemini-follow-up.md
+++ b/backlog/tasks/lince-100 - Three-sandbox-levels-—-gemini-follow-up.md
@@ -4,7 +4,7 @@ title: Three sandbox levels — gemini follow-up
 status: To Do
 assignee: []
 created_date: '2026-05-04 20:32'
-updated_date: '2026-05-05 18:11'
+updated_date: '2026-05-05 19:02'
 labels:
   - sandbox
   - lince-dashboard
@@ -12,6 +12,7 @@ labels:
 milestone: m-13
 dependencies:
   - LINCE-98
+  - LINCE-104
 references:
   - 'https://github.com/RisorseArtificiali/lince/issues/50'
   - 'https://github.com/RisorseArtificiali/lince/issues/47'
@@ -183,4 +184,19 @@ No other code change needed for the bwrap-paranoid scratch — agent-sandbox han
 **For the nono path** (synthesized by `lince-dashboard/plugin/src/agent.rs::synthesize_sandboxed_command`), the existing bash-wrapper logic (rsync into `$XDG_RUNTIME_DIR` HOME, trap-on-EXIT cleanup) stays — just add the gemini match arm with `agent_home_subdir = ".gemini"`. Both backends now give the same user-facing guarantee: ephemeral, per-run, fresh snapshot of `~/.gemini`, discarded on exit.
 
 **Reference.** See `sandbox/profiles/codex-paranoid.toml` (commit c60cadfc on `feature/lince-99-sandbox-levels-codex`) for the working pattern.
+
+## 2026-05-05 — organisation change: variants go in agents-template.toml (LINCE-104)
+
+LINCE-104 splits `lince-dashboard/agents-defaults.toml` (loaded) from a new `lince-dashboard/agents-template.toml` (reference-only, not loaded). After LINCE-104 lands:
+
+- `agents-defaults.toml` carries only the **active** gemini entry: a single `[agents.gemini]` with `sandbox_level = "normal"` + `sandbox_backend`, plus `[agents.gemini-unsandboxed]` if kept separate. **No commented variant blocks.**
+- `agents-template.toml` carries the **alternative variants** as fully uncommented TOML: `[agents.gemini-paranoid]` and `[agents.gemini-permissive]`. Users copy what they want into their own `~/.config/lince-dashboard/config.toml`.
+
+This task is updated to:
+
+1. Depend on LINCE-104 (so the file split exists before gemini variants are written).
+2. Add `[agents.gemini-paranoid]` and `[agents.gemini-permissive]` to `agents-template.toml` (not as commented blocks anywhere).
+3. The new `[agents.gemini]` entry in `agents-defaults.toml` is the only loaded gemini entry; it carries `sandbox_level = "normal"`.
+
+Nothing else in the existing plan changes — the nono profiles, bwrap fragments, plugin match arm, OAuth decision, and `scratch_home_dirs` opt-in are all unchanged. Only the destination file for the alternative-variant agent entries shifts.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/lince-100 - Three-sandbox-levels-—-gemini-follow-up.md
+++ b/backlog/tasks/lince-100 - Three-sandbox-levels-—-gemini-follow-up.md
@@ -4,7 +4,7 @@ title: Three sandbox levels — gemini follow-up
 status: To Do
 assignee: []
 created_date: '2026-05-04 20:32'
-updated_date: '2026-05-05 13:40'
+updated_date: '2026-05-05 18:11'
 labels:
   - sandbox
   - lince-dashboard
@@ -166,4 +166,21 @@ ls ~/.agent-sandbox/proxy-*.sock 2>/dev/null
 
 - `077b37d3` (fragment lookup), `9b214451` (auto-map API key), `9142c367` (UID remap), `a7933b48` (unshare wrapper), `9e62cf12` (proxy framing), `7f5898c4` (BrokenPipe), `858fe521` (GH_TOKEN passthrough), `405c3a11`/`5f987859` (review fixes).
 Reading those diffs is faster than re-discovering the same problems.
+
+## 2026-05-05 — helper available since LINCE-99: `scratch_home_dirs`
+
+LINCE-99 introduced a generic, agent-agnostic ephemeral scratch mechanism in `sandbox/agent-sandbox`. Use it instead of hand-rolling per-agent scratch logic on the bwrap path.
+
+**What it does.** `agent_cfg.scratch_home_dirs` (list[str], default `[]`). When non-empty, `cmd_run` (bwrap path) creates a `tempfile.mkdtemp` per entry under `$XDG_RUNTIME_DIR` (or `/tmp`), `rsync -a`-seeds it from the real `~/<subdir>` if it exists, bind-mounts it over `$HOME/<subdir>` inside bwrap, and `shutil.rmtree`s it in the run's `finally` block. `build_bwrap_cmd` filters those subdirs out of `home_ro_dirs`/`home_rw_dirs` so the real dir is never bound — even briefly. Requires `rsync` on the host; agent-sandbox errors out with a clear install hint if it's missing.
+
+**For gemini.** Add to `sandbox/profiles/gemini-paranoid.toml`:
+```toml
+[agents.gemini]
+scratch_home_dirs = [".gemini"]
+```
+No other code change needed for the bwrap-paranoid scratch — agent-sandbox handles the rsync, bind, and cleanup.
+
+**For the nono path** (synthesized by `lince-dashboard/plugin/src/agent.rs::synthesize_sandboxed_command`), the existing bash-wrapper logic (rsync into `$XDG_RUNTIME_DIR` HOME, trap-on-EXIT cleanup) stays — just add the gemini match arm with `agent_home_subdir = ".gemini"`. Both backends now give the same user-facing guarantee: ephemeral, per-run, fresh snapshot of `~/.gemini`, discarded on exit.
+
+**Reference.** See `sandbox/profiles/codex-paranoid.toml` (commit c60cadfc on `feature/lince-99-sandbox-levels-codex`) for the working pattern.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/lince-101 - Three-sandbox-levels-—-opencode-follow-up.md
+++ b/backlog/tasks/lince-101 - Three-sandbox-levels-—-opencode-follow-up.md
@@ -4,7 +4,7 @@ title: Three sandbox levels — opencode follow-up
 status: To Do
 assignee: []
 created_date: '2026-05-04 20:33'
-updated_date: '2026-05-05 13:42'
+updated_date: '2026-05-05 18:11'
 labels:
   - sandbox
   - lince-dashboard
@@ -171,4 +171,23 @@ curl -s https://attacker.com 2>&1   # netns-level fail
 - `077b37d3` (fragment lookup), `9b214451` (auto-map API key), `9142c367` (UID remap), `a7933b48` (unshare wrapper), `9e62cf12` (proxy framing), `858fe521` (GH_TOKEN passthrough), `405c3a11`/`5f987859` (review fixes).
 
 For the Bun/Landlock workaround specifically, the existing `[agents.opencode-nono]` entry in `agents-defaults.toml` is the canonical reference.
+
+## 2026-05-05 — helper available since LINCE-99: `scratch_home_dirs`
+
+LINCE-99 introduced a generic, agent-agnostic ephemeral scratch mechanism in `sandbox/agent-sandbox`. Use it instead of hand-rolling per-agent scratch logic on the bwrap path.
+
+**What it does.** `agent_cfg.scratch_home_dirs` (list[str], default `[]`). When non-empty, `cmd_run` (bwrap path) creates a `tempfile.mkdtemp` per entry under `$XDG_RUNTIME_DIR` (or `/tmp`), `rsync -a`-seeds it from the real `~/<subdir>` if it exists, bind-mounts it over `$HOME/<subdir>` inside bwrap, and `shutil.rmtree`s it in the run's `finally` block. `build_bwrap_cmd` filters those subdirs out of `home_ro_dirs`/`home_rw_dirs` so the real dir is never bound — even briefly. Requires `rsync` on the host; agent-sandbox errors out with a clear install hint if it's missing.
+
+**Nested subdirs supported.** The implementation matches by absolute target path (`home_p / sub_clean`), so `.config/opencode` works as well as a flat name like `.codex`. rsync `-a` on a destination with a trailing slash creates the parent dir (`.config/`) automatically when seeding from source.
+
+**For opencode.** Add to `sandbox/profiles/opencode-paranoid.toml`:
+```toml
+[agents.opencode]
+scratch_home_dirs = [".config/opencode"]
+```
+No other code change needed for the bwrap-paranoid scratch — agent-sandbox handles rsync, bind, and cleanup.
+
+**For the nono path** (synthesized by `lince-dashboard/plugin/src/agent.rs::synthesize_sandboxed_command`), the existing bash-wrapper logic stays — add the opencode match arm with `agent_home_subdir = ".config/opencode"`. Note that the **Bun/Landlock workaround** must still compose with the paranoid bash wrapper: pick option (a) or (b) from the existing notes §2 — the scratch_home_dirs helper is orthogonal to the inner-command shape.
+
+**Reference.** See `sandbox/profiles/codex-paranoid.toml` (commit c60cadfc on `feature/lince-99-sandbox-levels-codex`) for the working pattern.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/lince-101 - Three-sandbox-levels-—-opencode-follow-up.md
+++ b/backlog/tasks/lince-101 - Three-sandbox-levels-—-opencode-follow-up.md
@@ -4,7 +4,7 @@ title: Three sandbox levels — opencode follow-up
 status: To Do
 assignee: []
 created_date: '2026-05-04 20:33'
-updated_date: '2026-05-05 18:11'
+updated_date: '2026-05-05 19:02'
 labels:
   - sandbox
   - lince-dashboard
@@ -12,6 +12,7 @@ labels:
 milestone: m-13
 dependencies:
   - LINCE-98
+  - LINCE-104
 references:
   - 'https://github.com/RisorseArtificiali/lince/issues/51'
   - 'https://github.com/RisorseArtificiali/lince/issues/47'
@@ -190,4 +191,19 @@ No other code change needed for the bwrap-paranoid scratch — agent-sandbox han
 **For the nono path** (synthesized by `lince-dashboard/plugin/src/agent.rs::synthesize_sandboxed_command`), the existing bash-wrapper logic stays — add the opencode match arm with `agent_home_subdir = ".config/opencode"`. Note that the **Bun/Landlock workaround** must still compose with the paranoid bash wrapper: pick option (a) or (b) from the existing notes §2 — the scratch_home_dirs helper is orthogonal to the inner-command shape.
 
 **Reference.** See `sandbox/profiles/codex-paranoid.toml` (commit c60cadfc on `feature/lince-99-sandbox-levels-codex`) for the working pattern.
+
+## 2026-05-05 — organisation change: variants go in agents-template.toml (LINCE-104)
+
+LINCE-104 splits `lince-dashboard/agents-defaults.toml` (loaded) from a new `lince-dashboard/agents-template.toml` (reference-only, not loaded). After LINCE-104 lands:
+
+- `agents-defaults.toml` carries only the **active** opencode entry: a single `[agents.opencode]` with `sandbox_level = "normal"` + `sandbox_backend`, plus `[agents.opencode-unsandboxed]` if kept separate. **No commented variant blocks.**
+- `agents-template.toml` carries the **alternative variants** as fully uncommented TOML: `[agents.opencode-paranoid]` and `[agents.opencode-permissive]`. Users copy what they want into their own `~/.config/lince-dashboard/config.toml`.
+
+This task is updated to:
+
+1. Depend on LINCE-104 (so the file split exists before opencode variants are written).
+2. Add `[agents.opencode-paranoid]` and `[agents.opencode-permissive]` to `agents-template.toml` (not as commented blocks anywhere).
+3. The new `[agents.opencode]` entry in `agents-defaults.toml` is the only loaded opencode entry; it carries `sandbox_level = "normal"`.
+
+Nothing else in the existing plan changes — the Bun/Landlock workaround, LLM-endpoint allowlist decision, plugin match arm, and `scratch_home_dirs = [".config/opencode"]` opt-in are all unchanged. Only the destination file for the alternative-variant agent entries shifts.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/lince-102 - Three-sandbox-levels-—-pi-follow-up.md
+++ b/backlog/tasks/lince-102 - Three-sandbox-levels-—-pi-follow-up.md
@@ -4,7 +4,7 @@ title: Three sandbox levels — pi follow-up
 status: To Do
 assignee: []
 created_date: '2026-05-04 20:33'
-updated_date: '2026-05-05 13:41'
+updated_date: '2026-05-05 18:11'
 labels:
   - sandbox
   - lince-dashboard
@@ -165,4 +165,23 @@ printenv OPENAI_API_KEY    # empty
 
 - `077b37d3` (fragment lookup), `9b214451` (auto-map API key), `9142c367` (UID remap), `a7933b48` (unshare wrapper), `9e62cf12` (proxy framing), `7f5898c4` (BrokenPipe), `858fe521` (GH_TOKEN passthrough), `405c3a11`/`5f987859` (review fixes).
 For pi's multi-provider model specifically, see the original PR #40 commit history (when the 18-var passthrough was added) and the `[agents.pi.env_vars]` block in `lince-dashboard/agents-defaults.toml`.
+
+## 2026-05-05 — helper available since LINCE-99: `scratch_home_dirs`
+
+LINCE-99 introduced a generic, agent-agnostic ephemeral scratch mechanism in `sandbox/agent-sandbox`. Use it instead of hand-rolling per-agent scratch logic on the bwrap path.
+
+**What it does.** `agent_cfg.scratch_home_dirs` (list[str], default `[]`). When non-empty, `cmd_run` (bwrap path) creates a `tempfile.mkdtemp` per entry under `$XDG_RUNTIME_DIR` (or `/tmp`), `rsync -a`-seeds it from the real `~/<subdir>` if it exists, bind-mounts it over `$HOME/<subdir>` inside bwrap, and `shutil.rmtree`s it in the run's `finally` block. `build_bwrap_cmd` filters those subdirs out of `home_ro_dirs`/`home_rw_dirs` so the real dir is never bound — even briefly. Requires `rsync` on the host; agent-sandbox errors out with a clear install hint if it's missing.
+
+**For pi.** Add to `sandbox/profiles/pi-paranoid.toml`:
+```toml
+[agents.pi]
+scratch_home_dirs = [".pi"]
+```
+No other code change needed for the bwrap-paranoid scratch — agent-sandbox handles rsync, bind, and cleanup.
+
+**Note on `pi_providers` filtering.** The `scratch_home_dirs` mechanism is purely about filesystem isolation of `~/.pi`. It does NOT affect env-var passthrough or proxy rule selection — those are still the architectural call this task has to make (option a/b/c in §2 of the existing notes). The two are orthogonal: scratch the config dir AND filter the env vars.
+
+**For the nono path** (synthesized by `lince-dashboard/plugin/src/agent.rs::synthesize_sandboxed_command`), the existing bash-wrapper logic stays — add the pi match arm with `agent_home_subdir = ".pi"`. Both backends now give the same user-facing guarantee: ephemeral, per-run, fresh snapshot of `~/.pi`, discarded on exit.
+
+**Reference.** See `sandbox/profiles/codex-paranoid.toml` (commit c60cadfc on `feature/lince-99-sandbox-levels-codex`) for the working pattern.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/lince-102 - Three-sandbox-levels-—-pi-follow-up.md
+++ b/backlog/tasks/lince-102 - Three-sandbox-levels-—-pi-follow-up.md
@@ -4,7 +4,7 @@ title: Three sandbox levels — pi follow-up
 status: To Do
 assignee: []
 created_date: '2026-05-04 20:33'
-updated_date: '2026-05-05 18:11'
+updated_date: '2026-05-05 19:02'
 labels:
   - sandbox
   - lince-dashboard
@@ -12,6 +12,7 @@ labels:
 milestone: m-13
 dependencies:
   - LINCE-98
+  - LINCE-104
 references:
   - 'https://github.com/RisorseArtificiali/lince/issues/52'
   - 'https://github.com/RisorseArtificiali/lince/issues/47'
@@ -184,4 +185,19 @@ No other code change needed for the bwrap-paranoid scratch — agent-sandbox han
 **For the nono path** (synthesized by `lince-dashboard/plugin/src/agent.rs::synthesize_sandboxed_command`), the existing bash-wrapper logic stays — add the pi match arm with `agent_home_subdir = ".pi"`. Both backends now give the same user-facing guarantee: ephemeral, per-run, fresh snapshot of `~/.pi`, discarded on exit.
 
 **Reference.** See `sandbox/profiles/codex-paranoid.toml` (commit c60cadfc on `feature/lince-99-sandbox-levels-codex`) for the working pattern.
+
+## 2026-05-05 — organisation change: variants go in agents-template.toml (LINCE-104)
+
+LINCE-104 splits `lince-dashboard/agents-defaults.toml` (loaded) from a new `lince-dashboard/agents-template.toml` (reference-only, not loaded). After LINCE-104 lands:
+
+- `agents-defaults.toml` carries only the **active** pi entry: a single `[agents.pi]` with `sandbox_level = "normal"` + `sandbox_backend` + `pi_providers` (per the multi-provider design call this task makes), plus `[agents.pi-unsandboxed]` if kept separate. **No commented variant blocks.**
+- `agents-template.toml` carries the **alternative variants** as fully uncommented TOML: `[agents.pi-paranoid]` and `[agents.pi-permissive]`, each with its own `pi_providers` example values. Users copy what they want into their own `~/.config/lince-dashboard/config.toml` and edit the providers list.
+
+This task is updated to:
+
+1. Depend on LINCE-104 (so the file split exists before pi variants are written).
+2. Add `[agents.pi-paranoid]` and `[agents.pi-permissive]` to `agents-template.toml` (not as commented blocks anywhere).
+3. The new `[agents.pi]` entry in `agents-defaults.toml` is the only loaded pi entry; it carries `sandbox_level = "normal"`.
+
+Nothing else in the existing plan changes — the multi-provider design (option a/b/c on `pi_providers` filtering), plugin match arm, and `scratch_home_dirs = [".pi"]` opt-in are all unchanged. Only the destination file for the alternative-variant agent entries shifts.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/lince-103 - claude-migrate-to-scratch_home_dirs-and-retire-use_real_config.md
+++ b/backlog/tasks/lince-103 - claude-migrate-to-scratch_home_dirs-and-retire-use_real_config.md
@@ -1,0 +1,91 @@
+---
+id: LINCE-103
+title: 'claude: migrate to scratch_home_dirs and retire use_real_config'
+status: To Do
+assignee: []
+created_date: '2026-05-05 18:13'
+labels:
+  - sandbox
+  - refactor
+  - follow-up
+milestone: m-13
+dependencies:
+  - LINCE-99
+references:
+  - 'https://github.com/RisorseArtificiali/lince/issues/58'
+  - sandbox/agent-sandbox
+  - sandbox/profiles/claude-paranoid.toml
+  - sandbox/profiles/codex-paranoid.toml
+documentation:
+  - docs/documentation/dashboard/sandbox-levels.md
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Scope
+
+Migrate the claude agent off its bespoke `[claude] use_real_config` mechanism onto the generic `scratch_home_dirs` mechanism introduced in LINCE-99. Two phases — Phase 1 is low-risk and self-contained; Phase 2 is a behavior change that wants an RFC first.
+
+Tracks GH issue [#58](https://github.com/RisorseArtificiali/lince/issues/58).
+
+## Background — what LINCE-99 shipped
+
+LINCE-99 introduced a **generic ephemeral scratch mechanism** in `sandbox/agent-sandbox`: an agent-config field `scratch_home_dirs = [".codex"]` that makes `cmd_run` (bwrap path):
+
+1. `tempfile.mkdtemp` per entry under `$XDG_RUNTIME_DIR` (or `/tmp`)
+2. `rsync -a`-seed it from real `~/<subdir>` if present
+3. `--bind` it over `$HOME/<subdir>` inside bwrap
+4. `shutil.rmtree` it in the run's `finally` block
+
+`build_bwrap_cmd` filters those subdirs out of `home_ro_dirs` / `home_rw_dirs` so the real dir is never bound — even briefly. Requires `rsync` on the host; agent-sandbox errors out at startup with a clear install hint if it's missing.
+
+Currently only **codex paranoid** (`sandbox/profiles/codex-paranoid.toml`) opts in. Claude still uses the older claude-specific machinery (`[claude] use_real_config = false` → persistent `~/.agent-sandbox/claude-config/`).
+
+## Why this is non-trivial
+
+1. **Behavior change for existing claude users.** Today's normal/permissive levels read/write the real `~/.claude` (when `use_real_config = true`) or the persistent `~/.agent-sandbox/claude-config/` (when `false`). Switching all three levels to ephemeral would mean every claude run starts from scratch — losing learned tool permissions, MCP project configs, recent project list, etc. Acceptable for paranoid, **not** acceptable as the default for normal/permissive.
+2. **`~/.claude.json` is a sibling file, not a directory.** It lives at `$HOME/.claude.json` (not inside `~/.claude/`). The current `scratch_home_dirs` mechanism handles directories only — `claude.json` is mounted from `SANDBOX_DIR / "claude.json"` by a separate code branch in `build_bwrap_cmd` (~lines 1798–1815). A full migration needs either a companion `scratch_home_files` field (preferred), or repackaging `~/.claude.json` inside `~/.claude/` (upstream change, not under our control).
+3. **`agent-sandbox init` / `merge` / `diff` / `_auto_snapshot`.** These commands assume the persistent `claude-config/` exists and is syncable with real `~/.claude`. They have to be deprecated, gated behind a flag, or rewired (e.g. `init` becomes a no-op for ephemeral; `merge` becomes an explicit copy-back the user invokes from inside the sandbox).
+4. **Existing user installs.** Anyone running LINCE today has a populated `~/.agent-sandbox/claude-config/`. The migration must not nuke it; either keep it as the default for normal/permissive, or provide a one-shot `agent-sandbox migrate-claude-config` that rsyncs it back to real `~/.claude`.
+
+## Phase 1 — opt-in for paranoid only (low risk)
+
+- Add `scratch_home_dirs = [".claude"]` to `sandbox/profiles/claude-paranoid.toml`.
+- Add a companion `scratch_home_files` mechanism in `agent-sandbox` for `~/.claude.json` (rsync real file into a temp file at spawn, `--bind` over `$HOME/.claude.json`, remove on exit). This is a small, isolated change to `cmd_run` and `build_bwrap_cmd` mirroring the existing `scratch_home_dirs` plumbing.
+- Update `claude-paranoid.toml` to use the new mechanism for `.claude.json` too. The result: claude paranoid matches codex paranoid — kernel network isolation **and** ephemeral filesystem on both backends (nono paranoid already does this via the bash wrapper).
+- **Do not touch normal/permissive.** `[claude] use_real_config` keeps its current semantics there.
+- Update `docs/documentation/dashboard/sandbox-levels.md`: claude paranoid now ephemeral; cross-link to the codex example; `use_real_config` is now a normal/permissive concern only.
+
+## Phase 2 — retire `use_real_config` for normal/permissive (RFC first)
+
+This phase is a behavior change for everyday users. Do **not** start coding without a design doc.
+
+- RFC: how do normal/permissive look without `use_real_config`? Options:
+  - Persistent variant of `scratch_home_dirs` (new field, e.g. `persistent_home_dirs = [".claude"]` with destination `~/.agent-sandbox/claude-config/`).
+  - Overlayfs copy-on-write — bigger change, portability concerns.
+  - Deprecate `claude-config/` and just bind real `~/.claude` rw (matches `use_real_config = true`).
+- Refactor or remove `cmd_init` / `cmd_merge` / `cmd_diff` / `_auto_snapshot` accordingly.
+- Migration tool (`agent-sandbox migrate-claude-config`) for users with a populated persistent dir.
+- Deprecate `[claude] use_real_config` with a warning; eventually remove.
+- Remove the claude-specific code path in `build_bwrap_cmd` (lines ~1798–1815).
+
+## Out of scope
+
+- Other agents (gemini/opencode/pi) — they get `scratch_home_dirs` opt-in via LINCE-100/101/102 directly; they never had the `use_real_config` legacy.
+- Any change to the nono path (it already uses an equivalent ephemeral wrapper synthesized by the lince-dashboard plugin).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Phase 1: sandbox/profiles/claude-paranoid.toml opts in via [agents.claude] scratch_home_dirs = [".claude"]
+- [ ] #2 Phase 1: ~/.claude.json is also ephemeral under paranoid (via new scratch_home_files field or equivalent)
+- [ ] #3 Phase 1: 'agent-sandbox run -a claude --sandbox-level paranoid' banner shows the scratch line listing both ~/.claude and ~/.claude.json
+- [ ] #4 Phase 1: Inside paranoid, modifications to ~/.claude/ and ~/.claude.json do not persist across runs
+- [ ] #5 Phase 1: Normal/permissive behavior unchanged; no regression in init/merge/diff/snapshot-diff
+- [ ] #6 Phase 1: docs/documentation/dashboard/sandbox-levels.md updated — claude paranoid filesystem now matches codex paranoid; use_real_config is normal/permissive only
+- [ ] #7 Phase 2 (separate sub-task): RFC produced and approved before any code changes
+- [ ] #8 Phase 2: agent-sandbox migrate-claude-config tool for existing users
+- [ ] #9 Phase 2: [claude] use_real_config removed; build_bwrap_cmd's claude-specific branch removed/refactored
+<!-- AC:END -->

--- a/backlog/tasks/lince-104 - agents-defaults.toml-split-active-entries-from-variants-into-agents-template.toml.md
+++ b/backlog/tasks/lince-104 - agents-defaults.toml-split-active-entries-from-variants-into-agents-template.toml.md
@@ -1,0 +1,106 @@
+---
+id: LINCE-104
+title: >-
+  agents-defaults.toml: split active entries from variants into
+  agents-template.toml
+status: To Do
+assignee: []
+created_date: '2026-05-05 19:01'
+labels:
+  - lince-dashboard
+  - refactor
+  - follow-up
+milestone: m-13
+dependencies:
+  - LINCE-99
+references:
+  - 'https://github.com/RisorseArtificiali/lince/issues/59'
+  - lince-dashboard/agents-defaults.toml
+  - lince-dashboard/install.sh
+  - docs/documentation/dashboard/sandbox-levels.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Scope
+
+Split the variant entries out of `lince-dashboard/agents-defaults.toml` into a new sibling file `agents-template.toml` that is **not** loaded by the dashboard. The defaults file then contains only active entries (one per agent + `-unsandboxed` variants). Apply to both claude and codex — the only agents with variants today.
+
+Tracks GH issue [#59](https://github.com/RisorseArtificiali/lince/issues/59). Land after LINCE-99 merges, before LINCE-100/101/102 start (so gemini/opencode/pi adopt the new layout from day one).
+
+## Why
+
+After LINCE-98 (claude) and LINCE-99 (codex), `agents-defaults.toml` carries long commented blocks (`# [agents.claude-paranoid]`, `# [agents.codex-permissive]`, ...) so users can uncomment to add a variant to the N-picker. The file is hard to skim and gets worse as more agents land — gemini/opencode/pi would each add ~2 commented blocks, ballooning the file by 6 sections of disabled config.
+
+The cleaner model is symmetric with how the plugin already handles user overrides: the user's `~/.config/lince-dashboard/config.toml` can carry its own `[agents.<name>]` blocks that the loader merges on top of `agents-defaults.toml`. Today users have to either uncomment-in-place inside `agents-defaults.toml` or copy-paste from a comment. Making the template a real TOML file in its own right is just better ergonomics for the same mechanism.
+
+## File layout after this task
+
+### `lince-dashboard/agents-defaults.toml` (loaded)
+
+Only active entries:
+- `[agents.claude]` (normal)
+- `[agents.claude-unsandboxed]`
+- `[agents.codex]` (normal)
+- `[agents.codex-unsandboxed]`
+- `[agents.gemini]`, `[agents.gemini-bwrap]`, `[agents.gemini-nono]` (until LINCE-100 collapses them)
+- `[agents.opencode]`, `[agents.opencode-bwrap]`, `[agents.opencode-nono]` (until LINCE-101)
+- `[agents.pi]`, `[agents.pi-bwrap]`, `[agents.pi-nono]` (until LINCE-102)
+
+No commented `[agents.*]` blocks. A header comment at the top points to `agents-template.toml` and explains the override mechanism.
+
+### `lince-dashboard/agents-template.toml` (NOT loaded — reference only)
+
+Fully uncommented alternative variants:
+- `[agents.claude-paranoid]`
+- `[agents.claude-permissive]`
+- `[agents.codex-paranoid]`
+- `[agents.codex-permissive]`
+
+Header explains:
+- This file is **not** read by the dashboard.
+- It is a copy-paste source for users who want to add a variant to their N-picker.
+- The user copies the desired block into their own `~/.config/lince-dashboard/config.toml`. The plugin's loader then merges it on top of `agents-defaults.toml` and the variant appears in the N-picker.
+
+`install.sh` copies the file into `~/.config/lince-dashboard/` alongside `agents-defaults.toml` so users can find it locally without browsing the repo.
+
+LINCE-100/101/102 add their own variants to this same file (paranoid/permissive for gemini, opencode, pi) once they land — never as commented blocks in `agents-defaults.toml`.
+
+## Implementation steps
+
+1. Create `lince-dashboard/agents-template.toml` with the four variants for claude and codex (move them out of `agents-defaults.toml`, uncomment, polish).
+2. Strip the commented variant blocks from `lince-dashboard/agents-defaults.toml`. Add a header pointer to `agents-template.toml` and a one-line explanation of how to enable a variant via `config.toml`.
+3. Update `lince-dashboard/install.sh`:
+   - Step 9 (or wherever) copies `agents-template.toml` to `~/.config/lince-dashboard/agents-template.toml`.
+   - Update the printed summary to mention the new file.
+4. Verify the plugin loader does **not** read `agents-template.toml`. Today the loader reads `agents-defaults.toml` (built-in) and `config.toml` (user overrides). No code change should be needed if we name the new file `agents-template.toml` (i.e. not matching either expected filename).
+5. Update `docs/documentation/dashboard/sandbox-levels.md` with a new short section: *\"How to enable a paranoid/permissive variant in the N-picker\"*. Worked example: copy `[agents.claude-paranoid]` from `~/.config/lince-dashboard/agents-template.toml` into `~/.config/lince-dashboard/config.toml`, restart the dashboard, the entry shows up.
+6. Update the LINCE-setup skill (`lince-dashboard/skills/lince-setup/`) if it references the commented-variant pattern.
+7. Re-test: claude (normal) and codex (normal) still spawn from the N-picker as today; copying a variant block from the template file into a fresh `config.toml` and restarting the dashboard adds the variant to the picker.
+
+## Out of scope
+
+- Plugin loader changes (none needed — we just don't add a third source file).
+- Changes to how user overrides in `config.toml` are merged (existing mechanism already does what we need).
+- Other agents (gemini/opencode/pi). Their tasks (LINCE-100/101/102) are updated to depend on this one and to add their variants directly to `agents-template.toml`.
+
+## Risks
+
+- Users who already uncommented variants in `agents-defaults.toml` lose them on the next `install.sh --update` run. **Mitigation**: install.sh's existing backup behavior (`*.bak.<timestamp>`) preserves the prior file; the migration note in the install summary tells users to re-add their variants by copying from `agents-template.toml` into their `config.toml`.
+- Copy-paste workflow vs. uncomment-in-place is one extra step. Acceptable trade for a cleaner defaults file and proper TOML for the templates.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 lince-dashboard/agents-defaults.toml contains no commented [agents.*] blocks; only active entries
+- [ ] #2 lince-dashboard/agents-defaults.toml has a header comment pointing to agents-template.toml and explaining the override-via-config.toml mechanism
+- [ ] #3 lince-dashboard/agents-template.toml exists with fully uncommented [agents.claude-paranoid], [agents.claude-permissive], [agents.codex-paranoid], [agents.codex-permissive]
+- [ ] #4 agents-template.toml has a prominent header making clear it is NOT loaded by the dashboard and is a copy-paste source
+- [ ] #5 lince-dashboard/install.sh copies agents-template.toml into ~/.config/lince-dashboard/ alongside agents-defaults.toml; install summary mentions it
+- [ ] #6 Plugin loader is unchanged — it does not read agents-template.toml (verify by inspecting config.rs and any TOML lookup paths)
+- [ ] #7 docs/documentation/dashboard/sandbox-levels.md has a 'How to enable a paranoid/permissive variant' section with a worked copy-from-template example
+- [ ] #8 Re-test: claude (normal) and codex (normal) still spawn from the N-picker; copying [agents.claude-paranoid] from the template into a user's config.toml adds it to the picker after dashboard restart
+- [ ] #9 LINCE-100, LINCE-101, LINCE-102 are updated to depend on this task and to add their variants to agents-template.toml directly (no commented blocks)
+<!-- AC:END -->

--- a/backlog/tasks/lince-99 - Three-sandbox-levels-—-codex-follow-up.md
+++ b/backlog/tasks/lince-99 - Three-sandbox-levels-—-codex-follow-up.md
@@ -1,10 +1,11 @@
 ---
 id: LINCE-99
 title: Three sandbox levels — codex follow-up
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - claude
 created_date: '2026-05-04 20:32'
-updated_date: '2026-05-05 13:42'
+updated_date: '2026-05-05 17:19'
 labels:
   - sandbox
   - lince-dashboard
@@ -82,14 +83,63 @@ LLM provider for proxy/credential injection: **openai** (nono keystore account: 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 agents-defaults.toml has a single [agents.codex] with sandbox_level/sandbox_backend; codex-nono removed
-- [ ] #2 Codex internal sandbox conflict preserved across all three levels (no regression in disable_inner_sandbox_args = ['--sandbox', 'danger-full-access'])
-- [ ] #3 OPENAI_API_KEY: passthrough in normal/permissive, proxy-injected in paranoid (no env var leak)
+- [x] #1 agents-defaults.toml has a single [agents.codex] with sandbox_level/sandbox_backend; codex-nono removed
+- [x] #2 Codex internal sandbox conflict preserved across all three levels (no regression in disable_inner_sandbox_args = ['--sandbox', 'danger-full-access'])
+- [x] #3 OPENAI_API_KEY: passthrough in normal/permissive, proxy-injected in paranoid (no env var leak)
 - [ ] #4 sandbox_level=paranoid on nono: only api.openai.com reachable; arbitrary outbound fails
 - [ ] #5 sandbox_level=permissive: gh auth + gh pr work; docker ps fails
-- [ ] #6 N-picker shows 'OpenAI Codex' once
-- [ ] #7 Master doc page (sandbox-levels.md) extended with codex-specific rows: per-level behavior, codex quirks (inner-sandbox conflict, bwrap_conflict), OPENAI_API_KEY handling per level
+- [x] #6 N-picker shows 'OpenAI Codex' once
+- [x] #7 Master doc page (sandbox-levels.md) extended with codex-specific rows: per-level behavior, codex quirks (inner-sandbox conflict, bwrap_conflict), OPENAI_API_KEY handling per level
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+## Implementation plan
+
+Branch: `feature/lince-99-sandbox-levels-codex` (off main).
+
+### 1. New files
+
+**Nono profiles** (`lince-dashboard/nono-profiles/`):
+- `lince-codex-paranoid.json` — extends `lince-codex`; `network.credentials = ["openai"]`; `filesystem.allow = ["$WORKDIR", "$HOME"]` (per-agent scratch HOME, real home not mounted; bash wrapper supplies the per-agent scratch); no `allow_domain` (auto-included from credential rule, mirroring claude-paranoid).
+- `lince-codex-permissive.json` — extends `lince-codex`; `network.credentials = ["openai"]` + `allow_domain: [api.github.com, github.com, objects.githubusercontent.com]` + `network_profile: "developer"`; `filesystem.read` adds `$HOME/.config/gh`, `$HOME/.cache`, `$HOME/.ssh/known_hosts`.
+
+**Bwrap fragments** (`sandbox/profiles/`):
+- `codex-paranoid.toml` — `[env.extra] OPENAI_API_KEY = "$OPENAI_API_KEY"` (auto-rule); `[security] credential_proxy = true`, `unshare_net = true`, `allow_domains = []` (api.openai.com auto-included). NO `[claude]` block (codex has its own state in `~/.codex` — see "scratch limitation" below).
+- `codex-permissive.toml` — `[sandbox] home_ro_dirs = [".config/gh", ".cache", ".ssh/known_hosts"]`; `[env] passthrough = ["GH_TOKEN", "GITHUB_TOKEN"]`; `[security] credential_proxy = true`, `block_git_push = true`, `allow_domains = ["api.github.com", "github.com", "objects.githubusercontent.com"]`.
+
+### 2. Modified files
+
+**`lince-dashboard/agents-defaults.toml`**:
+- Rename `[agents.codex]` (current, unsandboxed) → `[agents.codex-unsandboxed]` to match claude pattern.
+- Remove `[agents.codex-bwrap]` and `[agents.codex-nono]`.
+- Add a single new `[agents.codex]` entry: `sandboxed = true`, `sandbox_level = "normal"`, `bwrap_conflict = true`, `disable_inner_sandbox_args = ["--sandbox", "danger-full-access"]`, `home_ro_dirs = ["~/.codex/"]`, `ignore_wrapper_start = true`, `env_vars.OPENAI_API_KEY = "$OPENAI_API_KEY"`, color `cyan`. Mirror claude's commented `-paranoid` / `-permissive` example blocks.
+
+**`lince-dashboard/plugin/src/agent.rs`** — `synthesize_sandboxed_command`:
+- Add `"codex"` match arm: `inner_command = ["codex", "--full-auto", "--sandbox", "danger-full-access"]` (hardcode disable_inner_sandbox_args for nono path; bwrap path goes through agent-sandbox which reads `agent_cfg.disable_inner_sandbox_args` from sandbox/agents-defaults.toml as today).
+- Add `agent_home_subdir = ".codex"` for paranoid bash wrapper.
+- For **AgentSandbox** (bwrap) backend: always emit `--agent <base>` so codex (and future gemini/opencode/pi) lands in agent-sandbox's per-agent dispatch. Claude's case is unchanged in behavior because `--agent claude` matches the script default.
+
+**`docs/documentation/dashboard/sandbox-levels.md`**:
+- Append a "### 8. Per-agent specifics — codex" section: per-level table row(s), inner-sandbox conflict (`--sandbox danger-full-access`) note, OPENAI_API_KEY proxy injection, brief note on common custom levels (e.g. `lince-codex-with-azure` for Azure OpenAI).
+- Brief footnote: under bwrap paranoid, real `~/.codex` is still bind-mounted RW (no codex-side `use_real_config` mechanism today); under nono paranoid, the bash wrapper rsyncs to a scratch HOME and discards on stop. nono is the strongest paranoid backend for codex.
+
+### 3. install.sh
+No change — `lince-dashboard/install.sh` already copies every `lince-*.json` and the bwrap fragment files are picked up by agent-sandbox from its profiles dir on a fresh install.
+
+### 4. Manual verification (per AC)
+1. `agent-sandbox run -a codex --sandbox-level paranoid --dry-run -p .` → bwrap argv contains `--unshare-user --uid <real_uid>`, no OPENAI_API_KEY, HTTP_PROXY set, codex receives `--sandbox danger-full-access`.
+2. nono paranoid sandbox: `curl https://attacker.com` fails kernel-side, `curl -x http://127.0.0.1:8118 https://api.openai.com/v1/models` returns 200.
+3. permissive: `gh auth status` works, `docker ps` fails (binary not present).
+4. N-picker: only one entry labeled "OpenAI Codex" (the new `[agents.codex]`); `codex-unsandboxed` shows separately.
+
+### 5. Out of scope (explicit)
+- Bwrap-paranoid scratch `~/.codex` (would need a codex analog of `[claude] use_real_config = false`; not blocking ACs since #4 specifies nono for paranoid network isolation).
+- docker / podman in permissive.
+- direct `git push` (gh-only).
+- gemini / opencode / pi (separate tasks).
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
@@ -177,4 +227,27 @@ ls ~/.agent-sandbox/proxy-*.sock 2>/dev/null
 - `405c3a11` / `5f987859` — review fixes (fail-fast socat, drop redundant `allow_domains`, dedupe shell_quote, stale-socket sweep)
 
 Reading the diffs of those commits is faster than re-discovering the same problem from a stack trace.
+
+## 2026-05-05 — implementation landed on branch `feature/lince-99-sandbox-levels-codex` (uncommitted, awaiting user manual test before push)
+
+### Files
+New:
+- `lince-dashboard/nono-profiles/lince-codex-paranoid.json`
+- `lince-dashboard/nono-profiles/lince-codex-permissive.json`
+- `sandbox/profiles/codex-paranoid.toml`
+- `sandbox/profiles/codex-permissive.toml`
+
+Modified:
+- `lince-dashboard/agents-defaults.toml` — collapsed `[agents.codex]` (legacy unsandboxed) + `[agents.codex-bwrap]` + `[agents.codex-nono]` into a single `[agents.codex]` with `sandbox_level="normal"` + `bwrap_conflict=true` + `disable_inner_sandbox_args=["--sandbox","danger-full-access"]`. Renamed legacy unsandboxed entry to `[agents.codex-unsandboxed]` (mirrors `claude-unsandboxed`). Removed the `[agents.codex-nono]` block from the nono-variants comment block. Added commented `[agents.codex-paranoid]` / `[agents.codex-permissive]` example blocks.
+- `lince-dashboard/plugin/src/agent.rs::synthesize_sandboxed_command` — added `"codex"` arm to `inner_command` (with `--sandbox danger-full-access` baked in for the nono path), added `"codex" => ".codex"` to the `agent_home_subdir` match, and made the AgentSandbox branch always emit `--agent <base>` so codex/future-agents dispatch correctly (claude default is unchanged).
+- `docs/documentation/dashboard/sandbox-levels.md` — new §7 “Per-agent specifics — codex” with per-level table, inner-sandbox-conflict note, OPENAI_API_KEY-per-level note, and bwrap-paranoid scratch-`~/.codex` limitation. Added OpenAI keystore commands to §6.
+
+### Build / static checks
+- `cargo build --target wasm32-wasip1` succeeds.
+- All four new TOML/JSON files parse cleanly with python `tomllib`/`json`.
+- agent-sandbox dry-run not exercised — no `~/.agent-sandbox/config.toml` on this host. AC #4 / #5 need runtime validation by the user.
+
+### Notes / deviations from plan
+- For bwrap paranoid, real `~/.codex` is still bind-mounted RW (no codex analog of `[claude] use_real_config = false`). Documented as a limitation in §7; recommendation is to use nono paranoid for the strongest codex isolation. The `home_rw_dirs` append-merge semantics of `merge_sandbox_level` make subtracting from the `[agents.codex]` `home_ro_dirs` impractical from a fragment.
+- `_collect_proxy_rules` already handles unset `OPENAI_API_KEY` (silent drop), so the auto-mapping in `codex-paranoid.toml`'s `[env.extra]` is safe even without the host var set.
 <!-- SECTION:NOTES:END -->

--- a/docs/documentation/dashboard/sandbox-levels.md
+++ b/docs/documentation/dashboard/sandbox-levels.md
@@ -357,7 +357,7 @@ Codex's level mappings follow the same shape as Claude's, with a few codex-speci
 | Network (allowed destinations)          | OpenAI API only                        | OpenAI API only              | inherited base                 | + GitHub + gh CLI domains                               |
 | Network isolation enforcement           | kernel (netns) + proxy allowlist       | kernel (Landlock + nono policy) | inherited                  | proxy allowlist                                         |
 | `OPENAI_API_KEY` handling               | proxy-injected, **stripped** from env  | proxy-injected, stripped     | passthrough                    | passthrough (codex usually picks token from `~/.codex`) |
-| Filesystem (~/.codex)                   | bind-mounted RW (real)                 | per-agent scratch HOME       | as today                       | as today + read on `~/.config/gh`, `~/.cache`, `~/.ssh/known_hosts` |
+| Filesystem (~/.codex)                   | per-run ephemeral scratch (rsync-seeded, discarded on exit) | per-agent scratch HOME       | as today                       | as today + read on `~/.config/gh`, `~/.cache`, `~/.ssh/known_hosts` |
 | `gh` CLI                                | no                                     | no                           | no                             | yes                                                     |
 | `disable_inner_sandbox_args`            | preserved (`--sandbox danger-full-access`) | preserved                | preserved                      | preserved                                               |
 
@@ -370,7 +370,14 @@ Both paths must keep `--sandbox danger-full-access` on the codex argv across all
 
 **`OPENAI_API_KEY` handling per level.** Normal and permissive pass `OPENAI_API_KEY` through to the codex process unchanged. Paranoid strips it from the sandbox environment entirely and lets the host-side credential proxy inject the `Authorization: Bearer <key>` header on outbound HTTPS — same model as Claude's `ANTHROPIC_API_KEY` in paranoid. The shipped `sandbox/profiles/codex-paranoid.toml` auto-maps `OPENAI_API_KEY = "$OPENAI_API_KEY"` in `[env.extra]` so the proxy has something to inject without requiring a manual entry in the user's config; if the host env var is unset the rule is silently dropped (same as Claude).
 
-**Scratch ~/.codex on bwrap paranoid.** Unlike Claude (`[claude] use_real_config = false` redirects to `~/.agent-sandbox/claude-config/`), codex has no equivalent host-side scratch mechanism in `agent-sandbox` today. Under bwrap paranoid, the real `~/.codex` is still bind-mounted read-write inside the sandbox. Under nono paranoid, the `lince-dashboard` plugin synthesizes a per-agent bash wrapper that rsyncs `~/.codex` into a scratch HOME under `$XDG_RUNTIME_DIR` and discards it on exit — the agent sees a fresh, isolated config dir. **For threat models that require codex's persistent state to be untouchable, prefer nono paranoid over bwrap paranoid.**
+**Scratch ~/.codex (both backends).** Unlike Claude — whose `[claude] use_real_config = false` mechanism redirects writes to a *persistent* `~/.agent-sandbox/claude-config/` shared across runs — codex paranoid uses a *per-run ephemeral* scratch:
+
+- **bwrap paranoid**: `sandbox/profiles/codex-paranoid.toml` ships `[agents.codex] scratch_home_dirs = [".codex"]`. `agent-sandbox` (run-side, before launching bwrap) creates a temp dir under `$XDG_RUNTIME_DIR`, rsyncs `~/.codex/` into it, bind-mounts the scratch on top of `~/.codex` inside the sandbox, and `rm -rf`s the scratch in the run's `finally` block. Real `~/.codex` is never bound RW into the sandbox.
+- **nono paranoid**: the `lince-dashboard` plugin synthesizes a per-agent bash wrapper that rsyncs `~/.codex` into a scratch `HOME` under `$XDG_RUNTIME_DIR` and discards it on exit — same outcome, different code path.
+
+The result is identical to the user: the agent sees its own auth/state at startup, can write to its config dir freely during the run, and those writes are gone when the run ends. No cross-run state leakage; no risk of a paranoid run mutating your real codex config. The mechanism is generic — `scratch_home_dirs` is read from the resolved `agent_cfg`, so any other agent (or any other home subdir) can opt in via a fragment without touching `agent-sandbox` itself.
+
+`rsync` is required on the host for `scratch_home_dirs` to function; `agent-sandbox` errors out at startup with a clear message if it's missing.
 
 **Common custom levels for codex.** The same `sandbox_level` knob accepts arbitrary suffixes — drop a profile at `~/.config/nono/profiles/lince-codex-<name>.json` (or a TOML fragment under `~/.agent-sandbox/profiles/`) and reference it via `sandbox_level = "<name>"`. Two common patterns:
 

--- a/docs/documentation/dashboard/sandbox-levels.md
+++ b/docs/documentation/dashboard/sandbox-levels.md
@@ -339,7 +339,47 @@ Store the key once per machine:
 
 For 1Password, Apple Passwords, and other backends, see nono's credential injection docs: https://nono.sh/docs/cli/features/credential-injection.md.
 
-## 7. Future work
+The same mechanism applies to OpenAI Codex, with the keystore account name `openai_api_key`:
+
+- **macOS**: `security add-generic-password -s "nono" -a "openai_api_key" -w "sk-..."`
+- **Linux**: `secret-tool store --label "nono openai" service nono account openai_api_key`
+
+## 7. Per-agent specifics
+
+The shipped levels apply across all sandboxed agents, but each agent has quirks worth calling out. The general mechanics are documented above; this section is for the per-agent deltas.
+
+### 7.1 Codex (OpenAI)
+
+Codex's level mappings follow the same shape as Claude's, with a few codex-specific knobs.
+
+| Aspect                                  | paranoid (bwrap)                       | paranoid (nono)              | normal                         | permissive                                              |
+|-----------------------------------------|----------------------------------------|------------------------------|--------------------------------|---------------------------------------------------------|
+| Network (allowed destinations)          | OpenAI API only                        | OpenAI API only              | inherited base                 | + GitHub + gh CLI domains                               |
+| Network isolation enforcement           | kernel (netns) + proxy allowlist       | kernel (Landlock + nono policy) | inherited                  | proxy allowlist                                         |
+| `OPENAI_API_KEY` handling               | proxy-injected, **stripped** from env  | proxy-injected, stripped     | passthrough                    | passthrough (codex usually picks token from `~/.codex`) |
+| Filesystem (~/.codex)                   | bind-mounted RW (real)                 | per-agent scratch HOME       | as today                       | as today + read on `~/.config/gh`, `~/.cache`, `~/.ssh/known_hosts` |
+| `gh` CLI                                | no                                     | no                           | no                             | yes                                                     |
+| `disable_inner_sandbox_args`            | preserved (`--sandbox danger-full-access`) | preserved                | preserved                      | preserved                                               |
+
+**Inner-sandbox conflict.** Codex applies its own filesystem sandbox by default. When running under our outer sandbox the two sandboxes fight: codex's seccomp/landlock layer collides with bwrap's PID/mount namespaces, and Landlock-on-Landlock under nono is a non-starter. We disable codex's inner sandbox by passing `--sandbox danger-full-access` on its argv. The wiring lives in two places:
+
+- **bwrap path**: `[agents.codex] disable_inner_sandbox_args = ["--sandbox", "danger-full-access"]` in `agent-sandbox`'s `agents-defaults.toml`. `build_bwrap_cmd` appends these args when `bwrap_conflict = true`.
+- **nono path**: hardcoded into the synthesized `inner_command` in `lince-dashboard/plugin/src/agent.rs` (the nono path bypasses agent-sandbox).
+
+Both paths must keep `--sandbox danger-full-access` on the codex argv across all three levels — it is unrelated to network/filesystem isolation; it just turns off the redundant inner layer.
+
+**`OPENAI_API_KEY` handling per level.** Normal and permissive pass `OPENAI_API_KEY` through to the codex process unchanged. Paranoid strips it from the sandbox environment entirely and lets the host-side credential proxy inject the `Authorization: Bearer <key>` header on outbound HTTPS — same model as Claude's `ANTHROPIC_API_KEY` in paranoid. The shipped `sandbox/profiles/codex-paranoid.toml` auto-maps `OPENAI_API_KEY = "$OPENAI_API_KEY"` in `[env.extra]` so the proxy has something to inject without requiring a manual entry in the user's config; if the host env var is unset the rule is silently dropped (same as Claude).
+
+**Scratch ~/.codex on bwrap paranoid.** Unlike Claude (`[claude] use_real_config = false` redirects to `~/.agent-sandbox/claude-config/`), codex has no equivalent host-side scratch mechanism in `agent-sandbox` today. Under bwrap paranoid, the real `~/.codex` is still bind-mounted read-write inside the sandbox. Under nono paranoid, the `lince-dashboard` plugin synthesizes a per-agent bash wrapper that rsyncs `~/.codex` into a scratch HOME under `$XDG_RUNTIME_DIR` and discards it on exit — the agent sees a fresh, isolated config dir. **For threat models that require codex's persistent state to be untouchable, prefer nono paranoid over bwrap paranoid.**
+
+**Common custom levels for codex.** The same `sandbox_level` knob accepts arbitrary suffixes — drop a profile at `~/.config/nono/profiles/lince-codex-<name>.json` (or a TOML fragment under `~/.agent-sandbox/profiles/`) and reference it via `sandbox_level = "<name>"`. Two common patterns:
+
+- **`lince-codex-with-azure`** — adds an `allow_domain` for `<your-resource>.openai.azure.com` so Codex can hit Azure OpenAI. Keep `credentials: ["openai"]` and set `OPENAI_BASE_URL` to your Azure endpoint via `[env.extra]` in the matching agent-sandbox fragment.
+- **`lince-codex-with-aws`** — same pattern as the Claude + Bedrock example in §5; replace the `credentials` entry with whatever Bedrock auth scheme your codex setup uses, and grant read access to `~/.aws` for the SDK.
+
+For the master mechanics (file-naming convention, append-merge semantics, choosing a backend), see §4 and §5 above — those rules apply unchanged to codex.
+
+## 8. Future work
 
 The new `sandbox_level` model is what the upcoming wizard ('N' picker) UX changes are built on — the picker becomes a two-axis chooser (agent type x sandbox level) instead of needing a separate `agents.*` entry per variant. Progress is tracked in [GitHub issue #53](https://github.com/RisorseArtificiali/lince/issues/53). [GitHub issue #54](https://github.com/RisorseArtificiali/lince/issues/54) tracks fragment-level `extends` inheritance so custom fragments can declare a parent level explicitly instead of relying on deep-merge order — a smaller, separate scope from the now-completed bwrap paranoid network hardening.
 

--- a/lince-dashboard/agents-defaults.toml
+++ b/lince-dashboard/agents-defaults.toml
@@ -12,8 +12,8 @@
 #   {project_dir} - project directory path
 #   {profile}     - sandbox profile name
 #
-# Sandbox model (claude only for now; codex/gemini/opencode/pi land in
-# follow-up tasks lince-99..102):
+# Sandbox model (claude + codex; gemini/opencode/pi land in follow-up
+# tasks lince-100..102):
 #   - sandbox_backend = "bwrap" | "nono"  (default per OS)
 #   - sandbox_level   = "paranoid" | "normal" | "permissive" | <custom>
 # When sandbox_level is set, the plugin synthesizes the launch command from
@@ -87,37 +87,94 @@ has_native_hooks = true
 profiles = ["__discover__"]
 
 [agents.codex]
+# Legacy fallback command — ignored when sandbox_level is set (the plugin
+# synthesizes the actual command from sandbox_backend + sandbox_level).
+command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}", "--agent", "codex"]
+pane_title_pattern = "agent-sandbox"
+status_pipe_name = "lince-status"
+display_name = "OpenAI Codex"
+short_label = "CDX"
+# Color follows the sandbox-level gradient (basic ANSI palette):
+#   paranoid=green, normal=cyan, permissive=yellow, unsandboxed=red
+color = "cyan"
+sandboxed = true
+has_native_hooks = false
+ignore_wrapper_start = true
+# codex applies its own filesystem sandbox; disable it under our outer
+# sandbox via --sandbox danger-full-access. The flag is read by
+# agent-sandbox (bwrap path) from this entry; the nono path hardcodes
+# it into the synthesized inner_command in plugin/src/agent.rs.
+bwrap_conflict = true
+disable_inner_sandbox_args = ["--sandbox", "danger-full-access"]
+home_ro_dirs = ["~/.codex/"]
+profiles = ["__discover__"]
+sandbox_level = "normal"          # paranoid | normal | permissive (or custom; see docs)
+# sandbox_backend defaults to "agent-sandbox" (bwrap) on Linux, "nono" on macOS.
+# Uncomment to force a specific backend (overrides the OS default):
+# sandbox_backend = "nono"
+
+[agents.codex.env_vars]
+OPENAI_API_KEY = "$OPENAI_API_KEY"
+
+# Alternative levels — UNCOMMENT one of the blocks below to add a paranoid
+# or permissive variant of codex to the N-picker. They show up as separate
+# entries; the original [agents.codex] above stays as the "normal" default.
+# Both levels are kernel-enforced under nono and proxy-enforced under bwrap.
+# See docs/documentation/dashboard/sandbox-levels.md for what each level does
+# and how to ship a custom level.
+#
+# [agents.codex-paranoid]
+# command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}", "--agent", "codex"]
+# pane_title_pattern = "agent-sandbox"
+# status_pipe_name = "lince-status"
+# display_name = "OpenAI Codex (paranoid)"
+# short_label = "CDP"
+# color = "green"
+# sandboxed = true
+# has_native_hooks = false
+# ignore_wrapper_start = true
+# bwrap_conflict = true
+# disable_inner_sandbox_args = ["--sandbox", "danger-full-access"]
+# home_ro_dirs = ["~/.codex/"]
+# profiles = ["__discover__"]
+# sandbox_level = "paranoid"
+#
+# [agents.codex-paranoid.env_vars]
+# OPENAI_API_KEY = "$OPENAI_API_KEY"
+#
+# [agents.codex-permissive]
+# command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}", "--agent", "codex"]
+# pane_title_pattern = "agent-sandbox"
+# status_pipe_name = "lince-status"
+# display_name = "OpenAI Codex (permissive)"
+# short_label = "CD+"
+# color = "yellow"
+# sandboxed = true
+# has_native_hooks = false
+# ignore_wrapper_start = true
+# bwrap_conflict = true
+# disable_inner_sandbox_args = ["--sandbox", "danger-full-access"]
+# home_ro_dirs = ["~/.codex/"]
+# profiles = ["__discover__"]
+# sandbox_level = "permissive"
+#
+# [agents.codex-permissive.env_vars]
+# OPENAI_API_KEY = "$OPENAI_API_KEY"
+
+[agents.codex-unsandboxed]
 command = ["codex", "--full-auto"]
 pane_title_pattern = "codex"
 status_pipe_name = "lince-status"
 display_name = "OpenAI Codex (unsandboxed)"
-short_label = "CDX"
-color = "cyan"
+short_label = "CDU"
+color = "red"
 sandboxed = false
 has_native_hooks = false
 ignore_wrapper_start = true
 bwrap_conflict = false
 profiles = ["__discover__"]
 
-[agents.codex.env_vars]
-OPENAI_API_KEY = "$OPENAI_API_KEY"
-
-[agents.codex-bwrap]
-command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}", "--agent", "codex"]
-pane_title_pattern = "agent-sandbox"
-status_pipe_name = "lince-status"
-display_name = "OpenAI Codex (sandboxed)"
-short_label = "CDX"
-color = "cyan"
-sandboxed = true
-has_native_hooks = false
-ignore_wrapper_start = true
-bwrap_conflict = true
-disable_inner_sandbox_args = ["--sandbox", "danger-full-access"]
-home_ro_dirs = ["~/.codex/"]
-profiles = ["__discover__"]
-
-[agents.codex-bwrap.env_vars]
+[agents.codex-unsandboxed.env_vars]
 OPENAI_API_KEY = "$OPENAI_API_KEY"
 
 [agents.gemini]
@@ -182,29 +239,11 @@ profiles = ["__discover__"]
 # nono uses Landlock LSM on Linux and Seatbelt on macOS.
 # Profiles are named "lince-<agent>" and managed by `agent-sandbox nono-sync`.
 #
-# NOTE: claude no longer has a separate [agents.claude-nono] entry — it has
-# been collapsed into [agents.claude] above (use sandbox_backend = "nono" to
-# force the nono backend on Linux). The codex/gemini/opencode/pi entries
-# below will follow the same migration in lince-99..102.
-
-[agents.codex-nono]
-command = ["nono", "run", "--profile", "lince-codex", "--workdir", "{project_dir}", "--", "codex", "--full-auto"]
-pane_title_pattern = "nono"
-status_pipe_name = "lince-status"
-display_name = "OpenAI Codex (nono)"
-short_label = "CDX"
-color = "cyan"
-sandboxed = true
-has_native_hooks = false
-ignore_wrapper_start = true
-sandbox_backend = "nono"
-bwrap_conflict = false
-disable_inner_sandbox_args = ["--sandbox", "danger-full-access"]
-home_ro_dirs = ["~/.codex/"]
-profiles = ["__discover__"]
-
-[agents.codex-nono.env_vars]
-OPENAI_API_KEY = "$OPENAI_API_KEY"
+# NOTE: claude and codex no longer have separate `*-nono` entries — they
+# have been collapsed into [agents.claude] / [agents.codex] above (use
+# `sandbox_backend = "nono"` to force the nono backend on Linux). The
+# gemini/opencode/pi entries below will follow the same migration in
+# lince-100..102.
 
 [agents.gemini-nono]
 command = ["nono", "run", "--profile", "lince-gemini", "--workdir", "{project_dir}", "--", "gemini"]

--- a/lince-dashboard/agents-defaults.toml
+++ b/lince-dashboard/agents-defaults.toml
@@ -87,30 +87,23 @@ has_native_hooks = true
 profiles = ["__discover__"]
 
 [agents.codex]
-# Legacy fallback command — ignored when sandbox_level is set (the plugin
-# synthesizes the actual command from sandbox_backend + sandbox_level).
+# Legacy fallback command — ignored when sandbox_level is set.
 command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}", "--agent", "codex"]
 pane_title_pattern = "agent-sandbox"
 status_pipe_name = "lince-status"
 display_name = "OpenAI Codex"
 short_label = "CDX"
-# Color follows the sandbox-level gradient (basic ANSI palette):
-#   paranoid=green, normal=cyan, permissive=yellow, unsandboxed=red
 color = "cyan"
 sandboxed = true
 has_native_hooks = false
 ignore_wrapper_start = true
-# codex applies its own filesystem sandbox; disable it under our outer
-# sandbox via --sandbox danger-full-access. The flag is read by
-# agent-sandbox (bwrap path) from this entry; the nono path hardcodes
-# it into the synthesized inner_command in plugin/src/agent.rs.
+# Disables codex's own --sandbox so it doesn't fight ours.
 bwrap_conflict = true
 disable_inner_sandbox_args = ["--sandbox", "danger-full-access"]
 home_ro_dirs = ["~/.codex/"]
 profiles = ["__discover__"]
 sandbox_level = "normal"          # paranoid | normal | permissive (or custom; see docs)
-# sandbox_backend defaults to "agent-sandbox" (bwrap) on Linux, "nono" on macOS.
-# Uncomment to force a specific backend (overrides the OS default):
+# sandbox_backend defaults to bwrap on Linux, nono on macOS. Uncomment to override:
 # sandbox_backend = "nono"
 
 [agents.codex.env_vars]

--- a/lince-dashboard/nono-profiles/lince-codex-paranoid.json
+++ b/lince-dashboard/nono-profiles/lince-codex-paranoid.json
@@ -1,0 +1,14 @@
+{
+  "extends": "lince-codex",
+  "meta": {
+    "name": "lince-codex-paranoid",
+    "description": "OpenAI Codex, paranoid sandbox: only api.openai.com reachable via nono credential proxy; ~/.codex isolated to a per-agent scratch HOME (rsync'd at spawn, deleted on stop). Codex's own --sandbox is disabled (danger-full-access) since the outer sandbox is doing the isolating."
+  },
+  "filesystem": {
+    "allow": ["$WORKDIR", "$HOME"],
+    "read": []
+  },
+  "network": {
+    "credentials": ["openai"]
+  }
+}

--- a/lince-dashboard/nono-profiles/lince-codex-paranoid.json
+++ b/lince-dashboard/nono-profiles/lince-codex-paranoid.json
@@ -2,7 +2,7 @@
   "extends": "lince-codex",
   "meta": {
     "name": "lince-codex-paranoid",
-    "description": "OpenAI Codex, paranoid sandbox: only api.openai.com reachable via nono credential proxy; ~/.codex isolated to a per-agent scratch HOME (rsync'd at spawn, deleted on stop). Codex's own --sandbox is disabled (danger-full-access) since the outer sandbox is doing the isolating."
+    "description": "Codex paranoid: only api.openai.com via nono credential proxy; ~/.codex on a per-agent scratch HOME."
   },
   "filesystem": {
     "allow": ["$WORKDIR", "$HOME"],

--- a/lince-dashboard/nono-profiles/lince-codex-permissive.json
+++ b/lince-dashboard/nono-profiles/lince-codex-permissive.json
@@ -2,7 +2,7 @@
   "extends": "lince-codex",
   "meta": {
     "name": "lince-codex-permissive",
-    "description": "OpenAI Codex, permissive sandbox: OpenAI API + GitHub allowlist (api.github.com, github.com, objects.githubusercontent.com); reads ~/.config/gh, ~/.cache, ~/.ssh/known_hosts so gh CLI works (no docker, no podman, no direct git push). Codex's own --sandbox is disabled (danger-full-access)."
+    "description": "Codex permissive: OpenAI API + GitHub allowlist; reads ~/.config/gh, ~/.cache, ~/.ssh/known_hosts so gh CLI works. No docker, no direct git push."
   },
   "filesystem": {
     "allow": ["$WORKDIR"],

--- a/lince-dashboard/nono-profiles/lince-codex-permissive.json
+++ b/lince-dashboard/nono-profiles/lince-codex-permissive.json
@@ -1,0 +1,25 @@
+{
+  "extends": "lince-codex",
+  "meta": {
+    "name": "lince-codex-permissive",
+    "description": "OpenAI Codex, permissive sandbox: OpenAI API + GitHub allowlist (api.github.com, github.com, objects.githubusercontent.com); reads ~/.config/gh, ~/.cache, ~/.ssh/known_hosts so gh CLI works (no docker, no podman, no direct git push). Codex's own --sandbox is disabled (danger-full-access)."
+  },
+  "filesystem": {
+    "allow": ["$WORKDIR"],
+    "read": [
+      "$HOME/.config/gh",
+      "$HOME/.cache",
+      "$HOME/.ssh/known_hosts",
+      "$HOME/.local/lib"
+    ]
+  },
+  "network": {
+    "network_profile": "developer",
+    "credentials": ["openai"],
+    "allow_domain": [
+      "api.github.com",
+      "github.com",
+      "objects.githubusercontent.com"
+    ]
+  }
+}

--- a/lince-dashboard/plugin/src/agent.rs
+++ b/lince-dashboard/plugin/src/agent.rs
@@ -114,7 +114,19 @@ fn synthesize_sandboxed_command(
             "claude".to_string(),
             "--dangerously-skip-permissions".to_string(),
         ],
-        // codex/gemini/opencode/pi land in follow-up tasks (lince-99..102).
+        // codex applies its own filesystem sandbox; disable it under our
+        // outer sandbox via --sandbox danger-full-access. The bwrap path
+        // applies this through agent-sandbox (which reads
+        // disable_inner_sandbox_args from agents-defaults.toml); the nono
+        // path bypasses agent-sandbox so we hardcode it into argv here.
+        // Pattern reused for gemini/opencode/pi in follow-ups (lince-100..102).
+        "codex" => vec![
+            "codex".to_string(),
+            "--full-auto".to_string(),
+            "--sandbox".to_string(),
+            "danger-full-access".to_string(),
+        ],
+        // gemini/opencode/pi land in follow-up tasks (lince-100..102).
         _ => return None,
     };
 
@@ -122,6 +134,9 @@ fn synthesize_sandboxed_command(
 
     Some(match backend {
         SandboxBackend::AgentSandbox => {
+            // Always pass --agent <base>: agent-sandbox defaults to claude,
+            // so claude is unchanged in behavior, but codex/gemini/opencode/pi
+            // need the explicit dispatch.
             let mut cmd = vec![
                 "agent-sandbox".to_string(),
                 "run".to_string(),
@@ -129,6 +144,8 @@ fn synthesize_sandboxed_command(
                 project_dir.to_string(),
                 "--id".to_string(),
                 agent_id.to_string(),
+                "--agent".to_string(),
+                base.to_string(),
             ];
             if level != "normal" {
                 cmd.push("--sandbox-level".to_string());
@@ -160,7 +177,8 @@ fn synthesize_sandboxed_command(
                 // metacharacters.
                 let agent_home_subdir = match base {
                     "claude" => ".claude",
-                    // follow-ups add codex/.codex, gemini/.gemini, etc.
+                    "codex" => ".codex",
+                    // follow-ups add gemini/.gemini, etc.
                     _ => return None,
                 };
                 // Sentinels use `@@…@@` rather than bare uppercase words so

--- a/lince-dashboard/plugin/src/agent.rs
+++ b/lince-dashboard/plugin/src/agent.rs
@@ -109,24 +109,27 @@ fn synthesize_sandboxed_command(
     project_dir: &str,
 ) -> Option<Vec<String>> {
     let base = agent_type_base_name(agent_type);
-    let inner_command: Vec<String> = match base {
-        "claude" => vec![
-            "claude".to_string(),
-            "--dangerously-skip-permissions".to_string(),
-        ],
-        // codex applies its own filesystem sandbox; disable it under our
-        // outer sandbox via --sandbox danger-full-access. The bwrap path
-        // applies this through agent-sandbox (which reads
-        // disable_inner_sandbox_args from agents-defaults.toml); the nono
-        // path bypasses agent-sandbox so we hardcode it into argv here.
-        // Pattern reused for gemini/opencode/pi in follow-ups (lince-100..102).
-        "codex" => vec![
-            "codex".to_string(),
-            "--full-auto".to_string(),
-            "--sandbox".to_string(),
-            "danger-full-access".to_string(),
-        ],
-        // gemini/opencode/pi land in follow-up tasks (lince-100..102).
+    // Per-agent dispatch: (inner argv, $HOME subdir for the paranoid scratch).
+    // codex's `--sandbox danger-full-access` disables its own filesystem
+    // sandbox so it doesn't fight ours; the bwrap path also reads
+    // disable_inner_sandbox_args from agents-defaults.toml.
+    let (inner_command, agent_home_subdir): (Vec<String>, &str) = match base {
+        "claude" => (
+            vec![
+                "claude".to_string(),
+                "--dangerously-skip-permissions".to_string(),
+            ],
+            ".claude",
+        ),
+        "codex" => (
+            vec![
+                "codex".to_string(),
+                "--full-auto".to_string(),
+                "--sandbox".to_string(),
+                "danger-full-access".to_string(),
+            ],
+            ".codex",
+        ),
         _ => return None,
     };
 
@@ -134,9 +137,6 @@ fn synthesize_sandboxed_command(
 
     Some(match backend {
         SandboxBackend::AgentSandbox => {
-            // Always pass --agent <base>: agent-sandbox defaults to claude,
-            // so claude is unchanged in behavior, but codex/gemini/opencode/pi
-            // need the explicit dispatch.
             let mut cmd = vec![
                 "agent-sandbox".to_string(),
                 "run".to_string(),
@@ -160,32 +160,11 @@ fn synthesize_sandboxed_command(
                 .collect::<Vec<_>>()
                 .join(" ");
             if level == "paranoid" {
-                // Self-contained bash wrapper:
-                //   1. Make a per-agent scratch dir under $XDG_RUNTIME_DIR
-                //   2. rsync the real ~/.<agent>/ into the scratch dir so
-                //      modifications inside the sandbox stay isolated
-                //   3. Re-run nono with HOME pointed at the scratch dir
-                //   4. On exit (clean or trapped SIGINT/SIGTERM), rm -rf scratch
-                //
-                // No `exec` so the bash process stays alive to honor the EXIT
-                // trap; SIGKILL bypasses cleanup but that's acceptable for an
-                // ephemeral scratch dir.
-                //
-                // All caller-supplied values (agent_id, project_dir, profile,
-                // inner command) are shell_quote'd before substitution, so the
-                // wrapper is safe even if any of them contain shell
-                // metacharacters.
-                let agent_home_subdir = match base {
-                    "claude" => ".claude",
-                    "codex" => ".codex",
-                    // follow-ups add gemini/.gemini, etc.
-                    _ => return None,
-                };
-                // Sentinels use `@@…@@` rather than bare uppercase words so
-                // accidental substring overlap is impossible (e.g. a
-                // hypothetical future `AGENT_IDENTITY` placeholder would
-                // collide with `AGENT_ID` if we used bare words). With the
-                // chosen format, replacement order is irrelevant.
+                // Bash wrapper: mkdir scratch under $XDG_RUNTIME_DIR, rsync
+                // ~/.<agent>/ into it, run nono with HOME=scratch, rm scratch
+                // on EXIT. No `exec` so the trap fires. Caller-supplied values
+                // are shell_quote'd before substitution. `@@…@@` sentinels
+                // can't accidentally substring-overlap each other.
                 let bash = String::from(
                     "set -e; \
                      SCRATCH=\"${XDG_RUNTIME_DIR:-/tmp}/lince-@@AGENT_ID@@\"; \

--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -1172,12 +1172,7 @@ def resolve_agent_config(config: dict, agent_name: str) -> dict:
         "home_rw_dirs": [],
         "bwrap_conflict": False,
         "disable_inner_sandbox_args": [],
-        # Subdirs of $HOME that are bound to per-run ephemeral scratch
-        # directories: the real ~/<subdir> is rsync-seeded into a scratch
-        # path under $XDG_RUNTIME_DIR (or /tmp) at spawn, bind-mounted
-        # over the agent's $HOME/<subdir>, and removed on exit. Activated
-        # by sandbox-policy fragments (e.g. codex-paranoid.toml) so the
-        # agent's writes to its own config dir don't touch the real one.
+        # Subdirs bound to per-run ephemeral scratch dirs (see cmd_run §5c).
         "scratch_home_dirs": [],
     }
 
@@ -1791,11 +1786,8 @@ def build_bwrap_cmd(config: dict, project_dir: Path,
             cmd += ["--ro-bind", str(full), str(full)]
 
     # --- 5b. Agent-specific home dirs ----------------------------------------
-    # Subdirs that will be replaced by ephemeral scratch dirs (see §5c) are
-    # filtered out here so the real home dir is never exposed in the same
-    # run — even momentarily — and so we don't emit a redundant bind that
-    # bwrap would just shadow. Match by absolute target path so nested
-    # subdirs (e.g. ".config/gh") work too.
+    # Subdirs that §5c will rebind from a scratch dir are skipped here so
+    # the real home dir is never exposed, even momentarily.
     scratched_targets: set[str] = {target for _, target in (scratch_binds or [])}
 
     def _is_scratched(d: str) -> bool:
@@ -1814,11 +1806,7 @@ def build_bwrap_cmd(config: dict, project_dir: Path,
         full.mkdir(parents=True, exist_ok=True)
         cmd += ["--bind", str(full), str(full)]
 
-    # --- 5c. Ephemeral scratch binds -----------------------------------------
-    # Each (scratch_path, target) is rsync-seeded on the host before bwrap
-    # starts; the bind mounts the seeded scratch on top of the agent's
-    # ~/<subdir> so writes inside the sandbox are isolated. The host-side
-    # cleanup happens in cmd_run's finally block after bwrap exits.
+    # --- 5c. Ephemeral scratch binds (rsync-seeded in cmd_run) ---------------
     for scratch_path, target in scratch_binds or []:
         cmd += ["--bind", scratch_path, target]
 
@@ -2326,15 +2314,8 @@ def cmd_run(args, agent_extra: list[str]) -> None:
     # --- agent-sandbox (bwrap) backend path --------------------------------
 
     # --- Ephemeral scratch home dirs (per-run snapshot) -------------------
-    # Subdirs listed in `scratch_home_dirs` (typically activated by a
-    # sandbox-policy fragment like codex-paranoid.toml) get a per-run
-    # scratch directory: rsync-seeded from real `~/<subdir>` if it exists,
-    # bind-mounted over `$HOME/<subdir>` inside bwrap, and removed when
-    # the agent exits. Lets paranoid mode "see" the user's auth/state
-    # without giving the agent write access to the real config.
     scratch_binds: list[tuple[str, str]] = []
-    scratch_dirs_to_cleanup: list[str] = []
-    scratch_subdirs = list(agent_cfg.get("scratch_home_dirs", []))
+    scratch_subdirs = agent_cfg.get("scratch_home_dirs", [])
     if scratch_subdirs:
         if not shutil.which("rsync"):
             print(
@@ -2345,25 +2326,17 @@ def cmd_run(args, agent_extra: list[str]) -> None:
             )
             sys.exit(1)
         scratch_root = os.environ.get("XDG_RUNTIME_DIR") or "/tmp"
-        try:
-            os.makedirs(scratch_root, exist_ok=True)
-        except OSError:
-            scratch_root = "/tmp"
+        home_p = Path.home()
         for subdir in scratch_subdirs:
             sub_clean = subdir.lstrip("/").rstrip("/")
             if not sub_clean:
                 continue
-            # tempfile.mkdtemp avoids collisions across concurrent agents
-            # of the same type. The pid is in the prefix so leftover dirs
-            # from a SIGKILL'd run are recognizable on the host.
             scratch_path = tempfile.mkdtemp(
                 prefix=f"agent-sandbox-{agent_name}-{os.getpid()}-",
                 dir=scratch_root,
             )
-            scratch_dirs_to_cleanup.append(scratch_path)
-            real = Path.home() / sub_clean
+            real = home_p / sub_clean
             if real.is_dir():
-                # Trailing slash on src copies *contents* into dst.
                 rsync = subprocess.run(
                     ["rsync", "-a", "--", f"{real}/", f"{scratch_path}/"],
                     check=False,
@@ -2375,8 +2348,7 @@ def cmd_run(args, agent_extra: list[str]) -> None:
                         f"partially-seeded scratch dir.",
                         file=sys.stderr,
                     )
-            target = f"{str(Path.home())}/{sub_clean}"
-            scratch_binds.append((scratch_path, target))
+            scratch_binds.append((scratch_path, str(home_p / sub_clean)))
 
     # --- Credential proxy setup -------------------------------------------
     proxy_enabled = sec.get("credential_proxy", False)
@@ -2671,14 +2643,8 @@ def cmd_run(args, agent_extra: list[str]) -> None:
     finally:
         if proxy:
             proxy.stop()
-        for scratch_path in scratch_dirs_to_cleanup:
-            try:
-                shutil.rmtree(scratch_path, ignore_errors=True)
-            except OSError:
-                # Best-effort: a SIGKILL or a bind-mount we couldn't
-                # detach leaves the dir behind, but $XDG_RUNTIME_DIR is
-                # tmpfs and gets reclaimed at logout/reboot.
-                pass
+        for scratch_path, _ in scratch_binds:
+            shutil.rmtree(scratch_path, ignore_errors=True)
 
 
 def cmd_diff(args) -> None:

--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -213,12 +213,13 @@ HARDCODED_CLAUDE_DEFAULTS: dict = {
     "home_rw_dirs": [],
     "bwrap_conflict": False,
     "disable_inner_sandbox_args": [],
+    "scratch_home_dirs": [],
 }
 
 # Keys that every agent config must have (used for validation/defaults).
 AGENT_CONFIG_KEYS: tuple[str, ...] = (
     "command", "default_args", "env", "home_ro_dirs", "home_rw_dirs",
-    "bwrap_conflict", "disable_inner_sandbox_args",
+    "bwrap_conflict", "disable_inner_sandbox_args", "scratch_home_dirs",
 )
 
 # nono built-in profile names — agents that have a matching nono profile
@@ -1171,6 +1172,13 @@ def resolve_agent_config(config: dict, agent_name: str) -> dict:
         "home_rw_dirs": [],
         "bwrap_conflict": False,
         "disable_inner_sandbox_args": [],
+        # Subdirs of $HOME that are bound to per-run ephemeral scratch
+        # directories: the real ~/<subdir> is rsync-seeded into a scratch
+        # path under $XDG_RUNTIME_DIR (or /tmp) at spawn, bind-mounted
+        # over the agent's $HOME/<subdir>, and removed on exit. Activated
+        # by sandbox-policy fragments (e.g. codex-paranoid.toml) so the
+        # agent's writes to its own config dir don't touch the real one.
+        "scratch_home_dirs": [],
     }
 
     # --- Layer 1: shipped defaults from agents-defaults.toml -----------------
@@ -1704,7 +1712,8 @@ def build_bwrap_cmd(config: dict, project_dir: Path,
                     agent_config: dict | None = None,
                     agent_id: str | None = None,
                     agent_name: str = "claude",
-                    proxy_env: dict[str, str] | None = None) -> list[str]:
+                    proxy_env: dict[str, str] | None = None,
+                    scratch_binds: list[tuple[str, str]] | None = None) -> list[str]:
     home = str(Path.home())
     home_p = Path.home()
     sandbox = config.get("sandbox", {})
@@ -1782,14 +1791,36 @@ def build_bwrap_cmd(config: dict, project_dir: Path,
             cmd += ["--ro-bind", str(full), str(full)]
 
     # --- 5b. Agent-specific home dirs ----------------------------------------
+    # Subdirs that will be replaced by ephemeral scratch dirs (see §5c) are
+    # filtered out here so the real home dir is never exposed in the same
+    # run — even momentarily — and so we don't emit a redundant bind that
+    # bwrap would just shadow. Match by absolute target path so nested
+    # subdirs (e.g. ".config/gh") work too.
+    scratched_targets: set[str] = {target for _, target in (scratch_binds or [])}
+
+    def _is_scratched(d: str) -> bool:
+        return str(home_p / d.lstrip("/").rstrip("/")) in scratched_targets
+
     for d in agent_cfg.get("home_ro_dirs", []):
+        if _is_scratched(d):
+            continue
         full = home_p / d
         if full.exists():
             cmd += ["--ro-bind", str(full), str(full)]
     for d in agent_cfg.get("home_rw_dirs", []):
+        if _is_scratched(d):
+            continue
         full = home_p / d
         full.mkdir(parents=True, exist_ok=True)
         cmd += ["--bind", str(full), str(full)]
+
+    # --- 5c. Ephemeral scratch binds -----------------------------------------
+    # Each (scratch_path, target) is rsync-seeded on the host before bwrap
+    # starts; the bind mounts the seeded scratch on top of the agent's
+    # ~/<subdir> so writes inside the sandbox are isolated. The host-side
+    # cleanup happens in cmd_run's finally block after bwrap exits.
+    for scratch_path, target in scratch_binds or []:
+        cmd += ["--bind", scratch_path, target]
 
     # --- 6. Project directory (read-write) — AFTER ro mounts so it wins ------
     project = str(project_dir.resolve())
@@ -2294,6 +2325,59 @@ def cmd_run(args, agent_extra: list[str]) -> None:
 
     # --- agent-sandbox (bwrap) backend path --------------------------------
 
+    # --- Ephemeral scratch home dirs (per-run snapshot) -------------------
+    # Subdirs listed in `scratch_home_dirs` (typically activated by a
+    # sandbox-policy fragment like codex-paranoid.toml) get a per-run
+    # scratch directory: rsync-seeded from real `~/<subdir>` if it exists,
+    # bind-mounted over `$HOME/<subdir>` inside bwrap, and removed when
+    # the agent exits. Lets paranoid mode "see" the user's auth/state
+    # without giving the agent write access to the real config.
+    scratch_binds: list[tuple[str, str]] = []
+    scratch_dirs_to_cleanup: list[str] = []
+    scratch_subdirs = list(agent_cfg.get("scratch_home_dirs", []))
+    if scratch_subdirs:
+        if not shutil.which("rsync"):
+            print(
+                "Error: scratch_home_dirs requires 'rsync' on the host. "
+                "Install via your package manager (e.g. `dnf install rsync` "
+                "or `apt install rsync`).",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        scratch_root = os.environ.get("XDG_RUNTIME_DIR") or "/tmp"
+        try:
+            os.makedirs(scratch_root, exist_ok=True)
+        except OSError:
+            scratch_root = "/tmp"
+        for subdir in scratch_subdirs:
+            sub_clean = subdir.lstrip("/").rstrip("/")
+            if not sub_clean:
+                continue
+            # tempfile.mkdtemp avoids collisions across concurrent agents
+            # of the same type. The pid is in the prefix so leftover dirs
+            # from a SIGKILL'd run are recognizable on the host.
+            scratch_path = tempfile.mkdtemp(
+                prefix=f"agent-sandbox-{agent_name}-{os.getpid()}-",
+                dir=scratch_root,
+            )
+            scratch_dirs_to_cleanup.append(scratch_path)
+            real = Path.home() / sub_clean
+            if real.is_dir():
+                # Trailing slash on src copies *contents* into dst.
+                rsync = subprocess.run(
+                    ["rsync", "-a", "--", f"{real}/", f"{scratch_path}/"],
+                    check=False,
+                )
+                if rsync.returncode != 0:
+                    print(
+                        f"Warning: rsync of ~/{sub_clean} to scratch "
+                        f"returned {rsync.returncode}; agent will see a "
+                        f"partially-seeded scratch dir.",
+                        file=sys.stderr,
+                    )
+            target = f"{str(Path.home())}/{sub_clean}"
+            scratch_binds.append((scratch_path, target))
+
     # --- Credential proxy setup -------------------------------------------
     proxy_enabled = sec.get("credential_proxy", False)
     proxy: CredentialProxy | None = None
@@ -2435,7 +2519,8 @@ def cmd_run(args, agent_extra: list[str]) -> None:
                           extra_rw_cli=args.rw, extra_ro_cli=args.ro,
                           agent_config=agent_cfg, agent_id=args.id,
                           agent_name=agent_name,
-                          proxy_env=proxy_env if proxy_env else None)
+                          proxy_env=proxy_env if proxy_env else None,
+                          scratch_binds=scratch_binds or None)
 
     # Paranoid wrap: create a userns + fresh netns OUTSIDE bwrap so we can
     # bring up loopback (needs CAP_NET_ADMIN, which non-setuid bwrap drops
@@ -2550,6 +2635,12 @@ def cmd_run(args, agent_extra: list[str]) -> None:
             f"  bwrap fix   inner sandbox disabled via "
             f"{agent_cfg.get('disable_inner_sandbox_args', [])}"
         )
+    if scratch_binds:
+        scratched = ", ".join(
+            f"~/{Path(target).relative_to(Path.home())}"
+            for _, target in scratch_binds
+        )
+        print(f"  scratch     ephemeral copy of {scratched} (discarded on exit)")
     print(f"  permissions {'ask (safe mode)' if args.safe else 'per agent defaults'}")
     if args.rw:
         print(f"  extra rw    {', '.join(args.rw)}")
@@ -2580,6 +2671,14 @@ def cmd_run(args, agent_extra: list[str]) -> None:
     finally:
         if proxy:
             proxy.stop()
+        for scratch_path in scratch_dirs_to_cleanup:
+            try:
+                shutil.rmtree(scratch_path, ignore_errors=True)
+            except OSError:
+                # Best-effort: a SIGKILL or a bind-mount we couldn't
+                # detach leaves the dir behind, but $XDG_RUNTIME_DIR is
+                # tmpfs and gets reclaimed at logout/reboot.
+                pass
 
 
 def cmd_diff(args) -> None:

--- a/sandbox/profiles/codex-paranoid.toml
+++ b/sandbox/profiles/codex-paranoid.toml
@@ -1,0 +1,56 @@
+# Sandbox-policy fragment: codex — paranoid level.
+#
+# Loaded by `agent-sandbox run -a codex --sandbox-level paranoid` and
+# deep-merged on top of the user's resolved config. Lists like
+# home_ro_dirs and allow_domains are appended (not replaced).
+#
+# Paranoid means kernel-enforced isolation:
+#   - credential_proxy = true: OPENAI_API_KEY lives on the host keystore/env,
+#     never in the sandbox; the proxy injects the Authorization header at
+#     request time.
+#   - unshare_net = true: the agent runs in a fresh network namespace
+#     (cmd_run wraps bwrap with `unshare -U -n -r`) with only its own
+#     loopback. No route to anywhere — kernel rejects raw socket connections
+#     to attacker.com or anywhere else. The credential proxy is reached via
+#     a unix socket bind-mounted into the sandbox + an in-sandbox socat
+#     bridge that the agent talks to as plain TCP localhost.
+#   - allow_domains: hosts the proxy is allowed to forward to (whether by
+#     credential injection for known providers, or by pass-through for
+#     extras like pypi.org). Anything else gets 403 from the proxy.
+#
+# Note on codex's inner sandbox: codex applies its own filesystem sandbox
+# unless told otherwise. When running under our outer sandbox we disable it
+# via `disable_inner_sandbox_args = ["--sandbox", "danger-full-access"]`,
+# wired through the [agents.codex] entry in agent-sandbox's
+# agents-defaults.toml — it is appended to codex's argv in build_bwrap_cmd.
+# Nothing extra is needed in this fragment.
+#
+# To extend paranoid (e.g. paranoid + Azure OpenAI), don't fork this file —
+# just add to your ~/.agent-sandbox/config.toml:
+#
+#   [security]
+#   allow_domains = ["YOURRESOURCE.openai.azure.com"]
+#
+# The lists are append-merged, so the final allowlist is the base
+# (api.openai.com, auto-included from the credential rule) plus your extras.
+
+[env.extra]
+# Auto-pick the user's host OpenAI credential so the credential proxy has
+# something to inject without requiring `-P someprofile` or a manual entry
+# in the user's [env.extra]. If unset on the host, _expand_env_value
+# returns "" and _collect_proxy_rules silently drops it — same behavior as
+# claude-paranoid.toml.
+OPENAI_API_KEY = "$OPENAI_API_KEY"
+
+[security]
+credential_proxy = true
+unshare_net = true
+# allow_domains lists EXTRA hosts the agent can reach via the proxy, on top
+# of the domains already covered by credential rules (api.openai.com is
+# auto-included because we have an OpenAI credential rule — no need to
+# repeat it here). Empty by default.
+# Extend in your own ~/.agent-sandbox/config.toml — the lists are
+# append-merged:
+#   [security]
+#   allow_domains = ["pypi.org", "files.pythonhosted.org"]
+allow_domains = []

--- a/sandbox/profiles/codex-paranoid.toml
+++ b/sandbox/profiles/codex-paranoid.toml
@@ -25,6 +25,15 @@
 # agents-defaults.toml — it is appended to codex's argv in build_bwrap_cmd.
 # Nothing extra is needed in this fragment.
 #
+# Note on the ephemeral ~/.codex scratch: `scratch_home_dirs = [".codex"]`
+# below tells agent-sandbox to rsync the real `~/.codex` into a per-run
+# temp dir under $XDG_RUNTIME_DIR at spawn, bind-mount it over `~/.codex`
+# inside bwrap, and remove it on exit. The agent sees its own auth/state
+# but writes are isolated; the kernel-isolated network namespace plus the
+# scratch HOME together give bwrap paranoid the same isolation guarantees
+# as nono paranoid (which runs the equivalent rsync inside its bash
+# wrapper synthesized by the lince-dashboard plugin).
+#
 # To extend paranoid (e.g. paranoid + Azure OpenAI), don't fork this file —
 # just add to your ~/.agent-sandbox/config.toml:
 #
@@ -41,6 +50,15 @@
 # returns "" and _collect_proxy_rules silently drops it — same behavior as
 # claude-paranoid.toml.
 OPENAI_API_KEY = "$OPENAI_API_KEY"
+
+[agents.codex]
+# Per-run ephemeral copy of `~/.codex`: agent-sandbox rsyncs the real dir
+# into a temp path under $XDG_RUNTIME_DIR before launching bwrap, mounts
+# it over `~/.codex` inside the sandbox, and removes it after the agent
+# exits. Codex sees its own auth/state but cannot persist changes to the
+# real config. Mirrors what the nono paranoid bash wrapper does for the
+# same agent.
+scratch_home_dirs = [".codex"]
 
 [security]
 credential_proxy = true

--- a/sandbox/profiles/codex-paranoid.toml
+++ b/sandbox/profiles/codex-paranoid.toml
@@ -1,74 +1,23 @@
 # Sandbox-policy fragment: codex — paranoid level.
-#
-# Loaded by `agent-sandbox run -a codex --sandbox-level paranoid` and
-# deep-merged on top of the user's resolved config. Lists like
-# home_ro_dirs and allow_domains are appended (not replaced).
-#
-# Paranoid means kernel-enforced isolation:
-#   - credential_proxy = true: OPENAI_API_KEY lives on the host keystore/env,
-#     never in the sandbox; the proxy injects the Authorization header at
-#     request time.
-#   - unshare_net = true: the agent runs in a fresh network namespace
-#     (cmd_run wraps bwrap with `unshare -U -n -r`) with only its own
-#     loopback. No route to anywhere — kernel rejects raw socket connections
-#     to attacker.com or anywhere else. The credential proxy is reached via
-#     a unix socket bind-mounted into the sandbox + an in-sandbox socat
-#     bridge that the agent talks to as plain TCP localhost.
-#   - allow_domains: hosts the proxy is allowed to forward to (whether by
-#     credential injection for known providers, or by pass-through for
-#     extras like pypi.org). Anything else gets 403 from the proxy.
-#
-# Note on codex's inner sandbox: codex applies its own filesystem sandbox
-# unless told otherwise. When running under our outer sandbox we disable it
-# via `disable_inner_sandbox_args = ["--sandbox", "danger-full-access"]`,
-# wired through the [agents.codex] entry in agent-sandbox's
-# agents-defaults.toml — it is appended to codex's argv in build_bwrap_cmd.
-# Nothing extra is needed in this fragment.
-#
-# Note on the ephemeral ~/.codex scratch: `scratch_home_dirs = [".codex"]`
-# below tells agent-sandbox to rsync the real `~/.codex` into a per-run
-# temp dir under $XDG_RUNTIME_DIR at spawn, bind-mount it over `~/.codex`
-# inside bwrap, and remove it on exit. The agent sees its own auth/state
-# but writes are isolated; the kernel-isolated network namespace plus the
-# scratch HOME together give bwrap paranoid the same isolation guarantees
-# as nono paranoid (which runs the equivalent rsync inside its bash
-# wrapper synthesized by the lince-dashboard plugin).
-#
-# To extend paranoid (e.g. paranoid + Azure OpenAI), don't fork this file —
-# just add to your ~/.agent-sandbox/config.toml:
-#
-#   [security]
-#   allow_domains = ["YOURRESOURCE.openai.azure.com"]
-#
-# The lists are append-merged, so the final allowlist is the base
-# (api.openai.com, auto-included from the credential rule) plus your extras.
+# See docs/documentation/dashboard/sandbox-levels.md for what paranoid
+# does and how to ship a custom level. Lists are append-merged with the
+# user's ~/.agent-sandbox/config.toml.
 
 [env.extra]
-# Auto-pick the user's host OpenAI credential so the credential proxy has
-# something to inject without requiring `-P someprofile` or a manual entry
-# in the user's [env.extra]. If unset on the host, _expand_env_value
-# returns "" and _collect_proxy_rules silently drops it — same behavior as
-# claude-paranoid.toml.
+# Auto-map so the credential proxy has something to inject; unset host
+# vars are silently dropped by _collect_proxy_rules.
 OPENAI_API_KEY = "$OPENAI_API_KEY"
 
 [agents.codex]
-# Per-run ephemeral copy of `~/.codex`: agent-sandbox rsyncs the real dir
-# into a temp path under $XDG_RUNTIME_DIR before launching bwrap, mounts
-# it over `~/.codex` inside the sandbox, and removes it after the agent
-# exits. Codex sees its own auth/state but cannot persist changes to the
-# real config. Mirrors what the nono paranoid bash wrapper does for the
-# same agent.
+# Per-run ephemeral copy of ~/.codex (rsync-seeded, bind-mounted, removed
+# on exit). Mirrors what the nono paranoid bash wrapper does.
 scratch_home_dirs = [".codex"]
 
 [security]
 credential_proxy = true
 unshare_net = true
-# allow_domains lists EXTRA hosts the agent can reach via the proxy, on top
-# of the domains already covered by credential rules (api.openai.com is
-# auto-included because we have an OpenAI credential rule — no need to
-# repeat it here). Empty by default.
-# Extend in your own ~/.agent-sandbox/config.toml — the lists are
-# append-merged:
+# api.openai.com is auto-included from the credential rule. Extend by
+# appending in your own config:
 #   [security]
 #   allow_domains = ["pypi.org", "files.pythonhosted.org"]
 allow_domains = []

--- a/sandbox/profiles/codex-permissive.toml
+++ b/sandbox/profiles/codex-permissive.toml
@@ -1,0 +1,41 @@
+# Sandbox-policy fragment: codex — permissive level.
+#
+# Loaded by `agent-sandbox run -a codex --sandbox-level permissive` and
+# deep-merged on top of the user's resolved config. Lists like
+# home_ro_dirs and allow_domains are appended (not replaced).
+#
+# Permissive opens up github + the gh CLI's filesystem footprint while
+# keeping the credential proxy on. Network is NOT kernel-isolated here
+# (unshare_net is left at its default, off) — the threat model is "trusted
+# agent that needs broader access, not adversarial".
+#
+# Codex's inner sandbox is disabled via `disable_inner_sandbox_args` on
+# the [agents.codex] entry — see codex-paranoid.toml for the rationale.
+#
+# To narrow what the proxy is allowed to forward (without going to the
+# stricter paranoid level), keep this fragment but tighten allow_domains
+# in your own config:
+#
+#   [security]
+#   allow_domains = []   # block everything except credential-rule hosts
+
+[sandbox]
+home_ro_dirs = [".config/gh", ".cache", ".ssh/known_hosts"]
+
+[env]
+# Pass host-env GitHub tokens through. gh CLI authenticated via
+# `gh auth login --with-token` reads from ~/.config/gh/hosts.yml (mounted
+# above), but users authenticated via the system keyring rely on
+# GH_TOKEN / GITHUB_TOKEN being exported in their shell — the sandbox's
+# default --clearenv would otherwise wipe them. Append-merged with the
+# user's [env].passthrough.
+passthrough = ["GH_TOKEN", "GITHUB_TOKEN"]
+
+[security]
+credential_proxy = true
+block_git_push = true
+allow_domains = [
+    "api.github.com",
+    "github.com",
+    "objects.githubusercontent.com",
+]

--- a/sandbox/profiles/codex-permissive.toml
+++ b/sandbox/profiles/codex-permissive.toml
@@ -1,34 +1,12 @@
 # Sandbox-policy fragment: codex — permissive level.
-#
-# Loaded by `agent-sandbox run -a codex --sandbox-level permissive` and
-# deep-merged on top of the user's resolved config. Lists like
-# home_ro_dirs and allow_domains are appended (not replaced).
-#
-# Permissive opens up github + the gh CLI's filesystem footprint while
-# keeping the credential proxy on. Network is NOT kernel-isolated here
-# (unshare_net is left at its default, off) — the threat model is "trusted
-# agent that needs broader access, not adversarial".
-#
-# Codex's inner sandbox is disabled via `disable_inner_sandbox_args` on
-# the [agents.codex] entry — see codex-paranoid.toml for the rationale.
-#
-# To narrow what the proxy is allowed to forward (without going to the
-# stricter paranoid level), keep this fragment but tighten allow_domains
-# in your own config:
-#
-#   [security]
-#   allow_domains = []   # block everything except credential-rule hosts
+# See docs/documentation/dashboard/sandbox-levels.md. Lists are
+# append-merged with the user's ~/.agent-sandbox/config.toml.
 
 [sandbox]
 home_ro_dirs = [".config/gh", ".cache", ".ssh/known_hosts"]
 
 [env]
-# Pass host-env GitHub tokens through. gh CLI authenticated via
-# `gh auth login --with-token` reads from ~/.config/gh/hosts.yml (mounted
-# above), but users authenticated via the system keyring rely on
-# GH_TOKEN / GITHUB_TOKEN being exported in their shell — the sandbox's
-# default --clearenv would otherwise wipe them. Append-merged with the
-# user's [env].passthrough.
+# Keyring-auth users rely on GH_TOKEN/GITHUB_TOKEN; --clearenv would wipe them.
 passthrough = ["GH_TOKEN", "GITHUB_TOKEN"]
 
 [security]


### PR DESCRIPTION
Closes [LINCE-99](backlog/tasks/lince-99%20-%20Three-sandbox-levels-—-codex-follow-up.md). Tracks GH issue #49 (codex sandbox levels). Builds on PR #57 (claude prototype, LINCE-98).

## Summary

- **Three-level sandbox model for codex**: collapse `[agents.codex]` (legacy unsandboxed), `[agents.codex-bwrap]`, and `[agents.codex-nono]` into a single `[agents.codex]` driven by `sandbox_level` + `sandbox_backend`. Legacy unsandboxed renamed to `[agents.codex-unsandboxed]` (mirrors claude pattern). Ships paranoid + permissive bwrap fragments and nono profiles.
- **Codex inner-sandbox conflict preserved** across all three levels via `disable_inner_sandbox_args = ["--sandbox", "danger-full-access"]`. The bwrap path reads it from `agents-defaults.toml`; the nono path bakes it into the synthesized `inner_command` in `lince-dashboard/plugin/src/agent.rs`.
- **`OPENAI_API_KEY` per level**: passthrough on normal/permissive; proxy-injected on paranoid (host keystore/env, never enters the sandbox process). The paranoid bwrap fragment auto-maps it in `[env.extra]` so the credential proxy has something to inject.
- **New: generic ephemeral `scratch_home_dirs` mechanism** in `sandbox/agent-sandbox`. Any agent fragment can opt subdirs of `$HOME` into a per-run scratch dir: rsync-seeded from real `~/<subdir>` at spawn, bind-mounted over `$HOME/<subdir>` inside bwrap, and `rm -rf`d in the run's `finally` block. Codex paranoid opts in via `[agents.codex] scratch_home_dirs = [".codex"]`. Same outcome as the nono paranoid bash wrapper, different code path. Generic so LINCE-100/101/102 (gemini/opencode/pi) can use it without touching `agent-sandbox`.
- **Plugin (`agent.rs`)**: codex match arm in `synthesize_sandboxed_command` (single tuple match yielding `(inner_argv, agent_home_subdir)` so adding gemini/opencode/pi only touches one place); always emits `--agent <base>` on the AgentSandbox branch so non-claude agents dispatch correctly.
- **Docs**: `docs/documentation/dashboard/sandbox-levels.md` gets a new §7 \"Per-agent specifics — codex\" with per-level table, inner-sandbox conflict, `OPENAI_API_KEY`-per-level, and a description of the unified scratch mechanism on both backends. §6 gains the `openai_api_key` keystore commands.

## Follow-up backlog tasks (also created)

- **LINCE-103 / GH #58** — migrate claude off the bespoke `[claude] use_real_config` mechanism onto the same generic `scratch_home_dirs` (Phase 1: paranoid only; Phase 2: retire `use_real_config`, RFC first).
- **LINCE-104 / GH #59** — split `agents-defaults.toml` (loaded) from a new `agents-template.toml` (reference-only) so alternative variants (`*-paranoid`, `*-permissive`) live as fully uncommented TOML in the template file rather than as commented blocks polluting the defaults file. LINCE-100/101/102 are updated to depend on this and to add their variants directly to `agents-template.toml`.

## Files

**New:**
- `lince-dashboard/nono-profiles/lince-codex-paranoid.json`
- `lince-dashboard/nono-profiles/lince-codex-permissive.json`
- `sandbox/profiles/codex-paranoid.toml`
- `sandbox/profiles/codex-permissive.toml`

**Modified:**
- `lince-dashboard/agents-defaults.toml` — collapsed codex entries
- `lince-dashboard/plugin/src/agent.rs` — codex dispatch, always-emit `--agent <base>`
- `sandbox/agent-sandbox` — generic `scratch_home_dirs` mechanism
- `docs/documentation/dashboard/sandbox-levels.md` — §7 codex specifics, §6 openai keystore

`install.sh` is unchanged — it already iterates `lince-*.json` and `*.toml` from the profiles dir.

## Test plan

- [x] `cargo build --target wasm32-wasip1` succeeds.
- [x] `python -c py_compile sandbox/agent-sandbox` ✓; new TOML/JSON files parse cleanly.
- [ ] **Manual (needs reviewer)**: `agent-sandbox run -a codex --sandbox-level paranoid -- bash` — verify (1) `ls -la ~/.codex/` shows scratch contents (not real ~/.codex); (2) `curl https://attacker.com` fails at netns level (not 403); (3) `curl -x http://127.0.0.1:8118 https://api.openai.com/v1/models | head` returns 200; (4) codex starts cleanly inside the sandbox without inner-sandbox bwrap-nesting errors; (5) host has exactly one running socat per running agent and `~/.agent-sandbox/proxy-*.sock` is cleaned on exit; (6) the per-run scratch dir under `$XDG_RUNTIME_DIR` is removed after the agent exits.
- [ ] **Manual**: `agent-sandbox run -a codex --sandbox-level permissive -- bash` — verify `gh auth status` works, `gh pr create` works against an allowed repo, `docker ps` fails (binary not present).
- [ ] **Manual**: dashboard N-picker shows \"OpenAI Codex\" once (the new normal entry) and \"OpenAI Codex (unsandboxed)\" separately.

## Risks

- Behavior change for users on the legacy `[agents.codex-bwrap]` / `[agents.codex-nono]` entries: their saved-agent state may reference the old names. Mitigation: existing users still have the legacy entries in their installed `~/.config/lince-dashboard/agents-defaults.toml` until they re-run `install.sh` (which backs the file up).
- `scratch_home_dirs` requires `rsync` on the host. `agent-sandbox` errors out at startup with a clear install hint if it's missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)