### PR TITLE
dashboard: split variants to agents-template.toml + quickstart sandbox-levels TUI

### DIFF
--- a/backlog/tasks/lince-104 - agents-defaults.toml-split-active-entries-from-variants-into-agents-template.toml.md
+++ b/backlog/tasks/lince-104 - agents-defaults.toml-split-active-entries-from-variants-into-agents-template.toml.md
@@ -3,9 +3,11 @@ id: LINCE-104
 title: >-
   agents-defaults.toml: split active entries from variants into
   agents-template.toml
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - claude
 created_date: '2026-05-05 19:01'
+updated_date: '2026-05-05 19:51'
 labels:
   - lince-dashboard
   - refactor
@@ -26,15 +28,15 @@ priority: medium
 <!-- SECTION:DESCRIPTION:BEGIN -->
 ## Scope
 
-Split the variant entries out of `lince-dashboard/agents-defaults.toml` into a new sibling file `agents-template.toml` that is **not** loaded by the dashboard. The defaults file then contains only active entries (one per agent + `-unsandboxed` variants). Apply to both claude and codex — the only agents with variants today.
+Split the variant entries out of `lince-dashboard/agents-defaults.toml` into a new sibling file `agents-template.toml` that is **not** loaded by the dashboard, and add a quickstart multi-select prompt to `install.sh` so users can pick which alternative levels to enable across all supported agents at install time. Apply to both claude and codex — the only agents with variants today.
 
 Tracks GH issue [#59](https://github.com/RisorseArtificiali/lince/issues/59). Land after LINCE-99 merges, before LINCE-100/101/102 start (so gemini/opencode/pi adopt the new layout from day one).
 
 ## Why
 
-After LINCE-98 (claude) and LINCE-99 (codex), `agents-defaults.toml` carries long commented blocks (`# [agents.claude-paranoid]`, `# [agents.codex-permissive]`, ...) so users can uncomment to add a variant to the N-picker. The file is hard to skim and gets worse as more agents land — gemini/opencode/pi would each add ~2 commented blocks, ballooning the file by 6 sections of disabled config.
+After LINCE-98 (claude) and LINCE-99 (codex), `agents-defaults.toml` carries long commented blocks (`# [agents.claude-paranoid]`, `# [agents.codex-permissive]`, ...) so users can uncomment to add a variant to the N-picker. The file is hard to skim and gets worse as more agents land — gemini/opencode/pi would each add ~2 commented blocks, ballooning the file by 6 sections of disabled config. Manual uncomment-in-place is also fragile (no syntax highlighting, easy to miss a line, no install-time UX).
 
-The cleaner model is symmetric with how the plugin already handles user overrides: the user's `~/.config/lince-dashboard/config.toml` can carry its own `[agents.<name>]` blocks that the loader merges on top of `agents-defaults.toml`. Today users have to either uncomment-in-place inside `agents-defaults.toml` or copy-paste from a comment. Making the template a real TOML file in its own right is just better ergonomics for the same mechanism.
+The cleaner model is symmetric with how the plugin already handles user overrides: the user's `~/.config/lince-dashboard/config.toml` can carry its own `[agents.<name>]` blocks that the loader merges on top of `agents-defaults.toml`. Today users have to copy-paste from a comment. Making the template a real TOML file in its own right + having the installer offer a multi-select that pulls from it is just better ergonomics for the same mechanism.
 
 ## File layout after this task
 
@@ -49,9 +51,9 @@ Only active entries:
 - `[agents.opencode]`, `[agents.opencode-bwrap]`, `[agents.opencode-nono]` (until LINCE-101)
 - `[agents.pi]`, `[agents.pi-bwrap]`, `[agents.pi-nono]` (until LINCE-102)
 
-No commented `[agents.*]` blocks. A header comment at the top points to `agents-template.toml` and explains the override mechanism.
+No commented `[agents.*]` blocks. Header comment points to `agents-template.toml` and explains the override mechanism.
 
-### `lince-dashboard/agents-template.toml` (NOT loaded — reference only)
+### `lince-dashboard/agents-template.toml` (NOT loaded — reference + install source)
 
 Fully uncommented alternative variants:
 - `[agents.claude-paranoid]`
@@ -60,36 +62,66 @@ Fully uncommented alternative variants:
 - `[agents.codex-permissive]`
 
 Header explains:
-- This file is **not** read by the dashboard.
-- It is a copy-paste source for users who want to add a variant to their N-picker.
-- The user copies the desired block into their own `~/.config/lince-dashboard/config.toml`. The plugin's loader then merges it on top of `agents-defaults.toml` and the variant appears in the N-picker.
+- The file is **not** read by the dashboard.
+- It serves two purposes: copy-paste source for manual edits, **and** the source the install-time multi-select pulls from.
+- Per-agent feature support is implicit: if a given agent has a `[agents.<agent>-<level>]` block here, it supports that level. If it doesn't, the level is unsupported for that agent and any installer-level selection is silently skipped for it.
 
 `install.sh` copies the file into `~/.config/lince-dashboard/` alongside `agents-defaults.toml` so users can find it locally without browsing the repo.
 
 LINCE-100/101/102 add their own variants to this same file (paranoid/permissive for gemini, opencode, pi) once they land — never as commented blocks in `agents-defaults.toml`.
 
+## Quickstart UX: multi-select sandbox levels
+
+Add a new step to `lince-dashboard/install.sh` (and any equivalent quickstart flow) that prompts:
+
+```
+Which sandbox levels do you want enabled in the N-picker?
+[x] normal       (always on — the default level)
+[ ] paranoid     (kernel-isolated network, ephemeral home scratch)
+[ ] permissive   (gh CLI + GitHub allowlist)
+```
+
+- `normal` is always selected, **not** user-changeable; listed for clarity.
+- `paranoid` and `permissive` default to **off**; the user opts in.
+- Multi-select: any combination is valid.
+
+For each selected level, the installer reads `lince-dashboard/agents-template.toml` and copies every `[agents.<agent>-<level>]` block (and its companion `[agents.<agent>-<level>.env_vars]` block, if present) into the user's `~/.config/lince-dashboard/config.toml`. The plugin's existing user-overlay merge picks them up on the next dashboard launch — they show up as separate `(paranoid)` / `(permissive)` entries in the N-picker.
+
+**Per-agent feature support is implicit in the template file.** If an agent doesn't ship a `[agents.<agent>-<level>]` block in `agents-template.toml`, that level isn't supported for that agent and is silently skipped — the user's selection is honoured for every agent that does support it.
+
+### Idempotency
+
+Re-running `install.sh` must not duplicate blocks. Detect existing `[agents.<agent>-<level>]` headers in the user's `config.toml` and skip already-present blocks. Users who want a fresh state remove the block manually first (consistent with how `install.sh` already handles `config.toml` backups).
+
+### Non-interactive mode
+
+Non-interactive install paths (CI, scripted install, `--yes`) should accept a flag like `--sandbox-levels=paranoid,permissive` (or env var `LINCE_SANDBOX_LEVELS`) to reproduce the multi-select without a TTY prompt. Default for non-interactive: only `normal` (today's behaviour).
+
 ## Implementation steps
 
 1. Create `lince-dashboard/agents-template.toml` with the four variants for claude and codex (move them out of `agents-defaults.toml`, uncomment, polish).
-2. Strip the commented variant blocks from `lince-dashboard/agents-defaults.toml`. Add a header pointer to `agents-template.toml` and a one-line explanation of how to enable a variant via `config.toml`.
+2. Strip the commented variant blocks from `lince-dashboard/agents-defaults.toml`. Add a header pointer to `agents-template.toml` and a one-line explanation of how to enable a variant via `config.toml` (or via the install prompt).
 3. Update `lince-dashboard/install.sh`:
    - Step 9 (or wherever) copies `agents-template.toml` to `~/.config/lince-dashboard/agents-template.toml`.
-   - Update the printed summary to mention the new file.
-4. Verify the plugin loader does **not** read `agents-template.toml`. Today the loader reads `agents-defaults.toml` (built-in) and `config.toml` (user overrides). No code change should be needed if we name the new file `agents-template.toml` (i.e. not matching either expected filename).
-5. Update `docs/documentation/dashboard/sandbox-levels.md` with a new short section: *\"How to enable a paranoid/permissive variant in the N-picker\"*. Worked example: copy `[agents.claude-paranoid]` from `~/.config/lince-dashboard/agents-template.toml` into `~/.config/lince-dashboard/config.toml`, restart the dashboard, the entry shows up.
+   - **New step**: multi-select prompt (paranoid / permissive). For each selected level, parse `agents-template.toml`, find all `[agents.*-<level>]` blocks, and append them (with their `*.env_vars` companions) into `~/.config/lince-dashboard/config.toml`. Skip blocks that are already present.
+   - Honour `--sandbox-levels=...` flag (or `LINCE_SANDBOX_LEVELS` env var) for non-interactive runs.
+   - Update the printed summary to show which levels were enabled and for which agents.
+4. Verify the plugin loader does **not** read `agents-template.toml`. Today the loader reads `agents-defaults.toml` (built-in) and `config.toml` (user overrides). No code change should be needed if we name the new file `agents-template.toml`.
+5. Update `docs/documentation/dashboard/sandbox-levels.md` with a new short section: *"How to enable paranoid/permissive variants in the N-picker"*. Cover both the install prompt and the manual copy-from-template flow. Worked example shows the prompt + the resulting `config.toml` snippet.
 6. Update the LINCE-setup skill (`lince-dashboard/skills/lince-setup/`) if it references the commented-variant pattern.
-7. Re-test: claude (normal) and codex (normal) still spawn from the N-picker as today; copying a variant block from the template file into a fresh `config.toml` and restarting the dashboard adds the variant to the picker.
+7. Re-test: claude (normal) and codex (normal) still spawn from the N-picker as today; running install with paranoid + permissive selected adds both variants for both agents to the picker; re-running install doesn't duplicate.
 
 ## Out of scope
 
 - Plugin loader changes (none needed — we just don't add a third source file).
 - Changes to how user overrides in `config.toml` are merged (existing mechanism already does what we need).
-- Other agents (gemini/opencode/pi). Their tasks (LINCE-100/101/102) are updated to depend on this one and to add their variants directly to `agents-template.toml`.
+- Other agents (gemini/opencode/pi). Their tasks (LINCE-100/101/102) are updated to depend on this one and to add their variants directly to `agents-template.toml`. Once they land, the same multi-select prompt automatically picks them up — no install-script change needed per agent.
+- A "remove a level" / "uninstall variant" UX. Manual edit of `config.toml` is fine for now.
 
 ## Risks
 
-- Users who already uncommented variants in `agents-defaults.toml` lose them on the next `install.sh --update` run. **Mitigation**: install.sh's existing backup behavior (`*.bak.<timestamp>`) preserves the prior file; the migration note in the install summary tells users to re-add their variants by copying from `agents-template.toml` into their `config.toml`.
-- Copy-paste workflow vs. uncomment-in-place is one extra step. Acceptable trade for a cleaner defaults file and proper TOML for the templates.
+- Users who already uncommented variants in `agents-defaults.toml` lose them on the next `install.sh --update` run. **Mitigation**: install.sh's existing backup behavior (`*.bak.<timestamp>`) preserves the prior file; the migration note in the install summary tells users to re-run install and pick their levels in the new prompt, or to copy from `agents-template.toml` to `config.toml` manually.
+- The install prompt parses `agents-template.toml`. Robust TOML parsing in bash is awkward; a simple block-extractor (find `[agents.*-<level>]`, slurp until next top-level `[` or EOF) is enough since the template file is generated by us and follows a known shape. If we want to be safe, do the parse in Python (the install already runs Python via `python3` for some checks) instead of awk/sed.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
@@ -97,10 +129,14 @@ LINCE-100/101/102 add their own variants to this same file (paranoid/permissive 
 - [ ] #1 lince-dashboard/agents-defaults.toml contains no commented [agents.*] blocks; only active entries
 - [ ] #2 lince-dashboard/agents-defaults.toml has a header comment pointing to agents-template.toml and explaining the override-via-config.toml mechanism
 - [ ] #3 lince-dashboard/agents-template.toml exists with fully uncommented [agents.claude-paranoid], [agents.claude-permissive], [agents.codex-paranoid], [agents.codex-permissive]
-- [ ] #4 agents-template.toml has a prominent header making clear it is NOT loaded by the dashboard and is a copy-paste source
+- [ ] #4 agents-template.toml has a prominent header making clear it is NOT loaded by the dashboard; it doubles as copy-paste source AND install-time multi-select source
 - [ ] #5 lince-dashboard/install.sh copies agents-template.toml into ~/.config/lince-dashboard/ alongside agents-defaults.toml; install summary mentions it
-- [ ] #6 Plugin loader is unchanged — it does not read agents-template.toml (verify by inspecting config.rs and any TOML lookup paths)
-- [ ] #7 docs/documentation/dashboard/sandbox-levels.md has a 'How to enable a paranoid/permissive variant' section with a worked copy-from-template example
-- [ ] #8 Re-test: claude (normal) and codex (normal) still spawn from the N-picker; copying [agents.claude-paranoid] from the template into a user's config.toml adds it to the picker after dashboard restart
-- [ ] #9 LINCE-100, LINCE-101, LINCE-102 are updated to depend on this task and to add their variants to agents-template.toml directly (no commented blocks)
+- [ ] #6 install.sh adds a multi-select prompt: normal (locked-on), paranoid, permissive. Selected levels' blocks from agents-template.toml are appended into ~/.config/lince-dashboard/config.toml
+- [ ] #7 Per-agent skip semantics: if an agent doesn't have a matching [agents.<agent>-<level>] block in the template, it is silently skipped for that level; selection is honoured for every agent that does support it
+- [ ] #8 Idempotent: re-running install.sh does not duplicate [agents.*-<level>] blocks already in the user's config.toml
+- [ ] #9 Non-interactive flag (e.g. --sandbox-levels=paranoid,permissive or LINCE_SANDBOX_LEVELS env var) reproduces the multi-select without a TTY prompt; default is 'normal' only
+- [ ] #10 Plugin loader is unchanged — it does not read agents-template.toml (verify by inspecting config.rs and any TOML lookup paths)
+- [ ] #11 docs/documentation/dashboard/sandbox-levels.md has a 'How to enable paranoid/permissive variants' section covering both the install prompt and the manual copy-from-template flow
+- [ ] #12 Re-test: claude (normal) and codex (normal) still spawn from the N-picker; install with paranoid + permissive selected adds both variants for both agents; re-running install doesn't duplicate
+- [ ] #13 LINCE-100, LINCE-101, LINCE-102 are updated to depend on this task and to add their variants to agents-template.toml directly (no commented blocks). New agents added there are picked up by the install prompt automatically.
 <!-- AC:END -->

--- a/docs/documentation/dashboard/sandbox-levels.md
+++ b/docs/documentation/dashboard/sandbox-levels.md
@@ -239,7 +239,38 @@ The default is per-OS: Linux picks `bwrap` (agent-sandbox), macOS picks `nono`. 
 
 **Prerequisites for paranoid + bwrap.** `socat` must be available on the host's `$PATH` (most distros: install the `socat` package). `install.sh` warns when it is missing. If `unshare_net = true` is resolved at run time and `socat` is not found, `agent-sandbox` errors out with a clear message rather than silently degrading.
 
-## 5. Customization
+## 5. Enabling paranoid / permissive variants in the N-picker
+
+The dashboard ships only the `normal` level enabled out of the box — that's the entry you see in the N-picker as e.g. *Claude Code* or *OpenAI Codex*. Paranoid and permissive variants are available but **opt-in**: to make them appear as separate `(paranoid)` / `(permissive)` entries in the picker you have to enable them in your dashboard config.
+
+There are two paths.
+
+### 5.1 During install
+
+`install.sh` prompts for which extra levels to enable across all supported agents:
+
+```
+  Sandbox levels for the N-picker:
+    [x] normal       (always on — the default level)
+    [ ] paranoid     (kernel-isolated network, ephemeral home scratch)
+    [ ] permissive   (gh CLI + GitHub allowlist)
+  Enable paranoid? (y/n):
+  Enable permissive? (y/n):
+```
+
+For each level you say yes to, the installer reads `lince-dashboard/agents-template.toml`, finds every `[agents.<agent>-<level>]` block, and appends it (with its `[agents.<agent>-<level>.env_vars]` companion, if present) into your `~/.config/lince-dashboard/config.toml`. Re-running install does not duplicate blocks already present — it's safe to re-run any time.
+
+For headless installs (CI, scripted setup), pass `--sandbox-levels=paranoid,permissive` or set `LINCE_SANDBOX_LEVELS=paranoid,permissive` to skip the prompt.
+
+**Per-agent feature support is implicit.** Only agents that ship a `[agents.<agent>-<level>]` block in `agents-template.toml` get a variant for that level. Agents without one are silently skipped — your selection is honoured for every agent that does support the level. Today claude and codex support both paranoid and permissive; gemini, opencode, and pi will follow once their respective tasks land (LINCE-100/101/102), and the install prompt will pick them up automatically.
+
+### 5.2 After install (manual)
+
+Open `~/.config/lince-dashboard/agents-template.toml` (installed by `install.sh` as a copy-paste source — **not** loaded by the dashboard), copy any `[agents.<agent>-<level>]` block (and its `[agents.<agent>-<level>.env_vars]` companion) into your `~/.config/lince-dashboard/config.toml`, and restart the dashboard. The plugin merges your `config.toml` on top of `agents-defaults.toml` and the new entry shows up in the picker.
+
+This is the same mechanism the install prompt uses internally — the prompt is just the bulk-apply UX. Use the manual path when you want a single agent at a single level, or when you're hand-curating your config.
+
+## 6. Customization
 
 `sandbox_level` is a **free-form profile suffix, not a closed enum**. The three shipped levels are opinionated examples of how to use it. You are expected to ship your own when the defaults don't fit.
 
@@ -317,7 +348,7 @@ agent-sandbox run --sandbox-level paranoid <command>
 
 The resolved config is paranoid + the two extra hosts: kernel netns isolation is unchanged, the proxy allowlist becomes `["api.anthropic.com", "pypi.org", "files.pythonhosted.org"]`, and `pip install` resolves through the proxy. This works because `allow_domains` is append-merged with the paranoid fragment's list, not overwritten.
 
-## 6. Keystore setup for paranoid
+## 7. Keystore setup for paranoid
 
 Paranoid relies on the Anthropic API key being in nono's credential keystore — **not** in `ANTHROPIC_API_KEY` in your environment. The point is that the key never enters the sandbox process tree; nono injects the `Authorization` header on the host side as the request flows through the credential proxy.
 
@@ -344,7 +375,7 @@ The same mechanism applies to OpenAI Codex, with the keystore account name `open
 - **macOS**: `security add-generic-password -s "nono" -a "openai_api_key" -w "sk-..."`
 - **Linux**: `secret-tool store --label "nono openai" service nono account openai_api_key`
 
-## 7. Per-agent specifics
+## 8. Per-agent specifics
 
 The shipped levels apply across all sandboxed agents, but each agent has quirks worth calling out. The general mechanics are documented above; this section is for the per-agent deltas.
 
@@ -382,11 +413,11 @@ The result is identical to the user: the agent sees its own auth/state at startu
 **Common custom levels for codex.** The same `sandbox_level` knob accepts arbitrary suffixes — drop a profile at `~/.config/nono/profiles/lince-codex-<name>.json` (or a TOML fragment under `~/.agent-sandbox/profiles/`) and reference it via `sandbox_level = "<name>"`. Two common patterns:
 
 - **`lince-codex-with-azure`** — adds an `allow_domain` for `<your-resource>.openai.azure.com` so Codex can hit Azure OpenAI. Keep `credentials: ["openai"]` and set `OPENAI_BASE_URL` to your Azure endpoint via `[env.extra]` in the matching agent-sandbox fragment.
-- **`lince-codex-with-aws`** — same pattern as the Claude + Bedrock example in §5; replace the `credentials` entry with whatever Bedrock auth scheme your codex setup uses, and grant read access to `~/.aws` for the SDK.
+- **`lince-codex-with-aws`** — same pattern as the Claude + Bedrock example in §6; replace the `credentials` entry with whatever Bedrock auth scheme your codex setup uses, and grant read access to `~/.aws` for the SDK.
 
-For the master mechanics (file-naming convention, append-merge semantics, choosing a backend), see §4 and §5 above — those rules apply unchanged to codex.
+For the master mechanics (file-naming convention, append-merge semantics, choosing a backend), see §4 and §6 above — those rules apply unchanged to codex.
 
-## 8. Future work
+## 9. Future work
 
 The new `sandbox_level` model is what the upcoming wizard ('N' picker) UX changes are built on — the picker becomes a two-axis chooser (agent type x sandbox level) instead of needing a separate `agents.*` entry per variant. Progress is tracked in [GitHub issue #53](https://github.com/RisorseArtificiali/lince/issues/53). [GitHub issue #54](https://github.com/RisorseArtificiali/lince/issues/54) tracks fragment-level `extends` inheritance so custom fragments can declare a parent level explicitly instead of relying on deep-merge order — a smaller, separate scope from the now-completed bwrap paranoid network hardening.
 

--- a/docs/documentation/dashboard/sandbox-levels.md
+++ b/docs/documentation/dashboard/sandbox-levels.md
@@ -245,30 +245,32 @@ The dashboard ships only the `normal` level enabled out of the box — that's th
 
 There are two paths.
 
-### 5.1 During install
+### 5.1 Through the quickstart TUI
 
-`install.sh` prompts for which extra levels to enable across all supported agents:
+`quickstart.sh` Step 2 ("Sandbox levels") is a number-toggle multi-select where `normal` is locked on and `paranoid` / `permissive` are togglable:
 
 ```
-  Sandbox levels for the N-picker:
-    [x] normal       (always on — the default level)
-    [ ] paranoid     (kernel-isolated network, ephemeral home scratch)
-    [ ] permissive   (gh CLI + GitHub allowlist)
-  Enable paranoid? (y/n):
-  Enable permissive? (y/n):
+  Step 2: Sandbox levels
+
+    [x] 1) normal — always on — the default level (locked)
+    [ ] 2) paranoid — kernel-isolated network, ephemeral home scratch
+    [ ] 3) permissive — gh CLI + GitHub allowlist
+
+    Press 2-3 to toggle, Enter to confirm
+    >
 ```
 
-For each level you say yes to, the installer reads `lince-dashboard/agents-template.toml`, finds every `[agents.<agent>-<level>]` block, and appends it (with its `[agents.<agent>-<level>.env_vars]` companion, if present) into your `~/.config/lince-dashboard/config.toml`. Re-running install does not duplicate blocks already present — it's safe to re-run any time.
+Press `2` and/or `3` to toggle, `Enter` to confirm. The selection is forwarded to `lince-dashboard/install.sh` as `--sandbox-levels=...` (you can also set `LINCE_SANDBOX_LEVELS` for headless installs). For each selected level, `install.sh` reads `lince-dashboard/agents-template.toml`, finds every `[agents.<agent>-<level>]` block, and appends it (with its `[agents.<agent>-<level>.env_vars]` companion, if present) into your `~/.config/lince-dashboard/config.toml`. Re-running is safe — already-present blocks are not duplicated.
 
-For headless installs (CI, scripted setup), pass `--sandbox-levels=paranoid,permissive` or set `LINCE_SANDBOX_LEVELS=paranoid,permissive` to skip the prompt.
+`install.sh` invoked **standalone** (without going through the quickstart) does not prompt. Pass `--sandbox-levels=paranoid,permissive` or set `LINCE_SANDBOX_LEVELS` to opt in.
 
-**Per-agent feature support is implicit.** Only agents that ship a `[agents.<agent>-<level>]` block in `agents-template.toml` get a variant for that level. Agents without one are silently skipped — your selection is honoured for every agent that does support the level. Today claude and codex support both paranoid and permissive; gemini, opencode, and pi will follow once their respective tasks land (LINCE-100/101/102), and the install prompt will pick them up automatically.
+**Per-agent feature support is implicit.** Only agents that ship a `[agents.<agent>-<level>]` block in `agents-template.toml` get a variant for that level. Agents without one are silently skipped — your selection is honoured for every agent that does support the level. Today claude and codex support both paranoid and permissive; gemini, opencode, and pi follow once their respective tasks land (LINCE-100/101/102), and the multi-select picks them up automatically.
 
 ### 5.2 After install (manual)
 
 Open `~/.config/lince-dashboard/agents-template.toml` (installed by `install.sh` as a copy-paste source — **not** loaded by the dashboard), copy any `[agents.<agent>-<level>]` block (and its `[agents.<agent>-<level>.env_vars]` companion) into your `~/.config/lince-dashboard/config.toml`, and restart the dashboard. The plugin merges your `config.toml` on top of `agents-defaults.toml` and the new entry shows up in the picker.
 
-This is the same mechanism the install prompt uses internally — the prompt is just the bulk-apply UX. Use the manual path when you want a single agent at a single level, or when you're hand-curating your config.
+This is the same mechanism the quickstart TUI uses internally — the TUI is just the bulk-apply UX. Use the manual path when you want a single agent at a single level, or when you're hand-curating your config.
 
 ## 6. Customization
 

--- a/lince-dashboard/agents-defaults.toml
+++ b/lince-dashboard/agents-defaults.toml
@@ -21,6 +21,12 @@
 # but kept for legacy/no-level fallback. See:
 #   docs/documentation/dashboard/sandbox-levels.md
 #   https://lince.sh/documentation/#/dashboard/sandbox-levels
+#
+# Alternative paranoid / permissive variants live in `agents-template.toml`
+# (sibling file, NOT loaded by the dashboard). To enable them, either re-run
+# install.sh and pick the levels in the prompt, or copy the desired blocks
+# from `~/.config/lince-dashboard/agents-template.toml` into your own
+# `~/.config/lince-dashboard/config.toml`.
 
 [agents.claude]
 # Legacy fallback command — ignored when sandbox_level is set (the plugin
@@ -41,39 +47,6 @@ sandbox_level = "normal"          # paranoid | normal | permissive (or custom; s
 # sandbox_backend defaults to "agent-sandbox" (bwrap) on Linux, "nono" on macOS.
 # Uncomment to force a specific backend (overrides the OS default):
 # sandbox_backend = "nono"
-
-# Alternative levels — UNCOMMENT one of the blocks below to add a paranoid
-# or permissive variant of claude to the N-picker. They show up as separate
-# entries; the original [agents.claude] above stays as the "normal" default.
-# Both levels are kernel-enforced under nono and proxy-enforced under bwrap.
-# See docs/documentation/dashboard/sandbox-levels.md for what each level does
-# and how to ship a custom level.
-#
-# [agents.claude-paranoid]
-# command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}"]
-# pane_title_pattern = "agent-sandbox"
-# status_pipe_name = "claude-status"
-# display_name = "Claude Code (paranoid)"
-# short_label = "CLP"
-# color = "green"
-# sandboxed = true
-# has_native_hooks = true
-# home_ro_dirs = ["~/.claude/"]
-# profiles = ["__discover__"]
-# sandbox_level = "paranoid"
-#
-# [agents.claude-permissive]
-# command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}"]
-# pane_title_pattern = "agent-sandbox"
-# status_pipe_name = "claude-status"
-# display_name = "Claude Code (permissive)"
-# short_label = "CL+"
-# color = "yellow"
-# sandboxed = true
-# has_native_hooks = true
-# home_ro_dirs = ["~/.claude/"]
-# profiles = ["__discover__"]
-# sandbox_level = "permissive"
 
 [agents.claude-unsandboxed]
 command = ["claude"]
@@ -108,51 +81,6 @@ sandbox_level = "normal"          # paranoid | normal | permissive (or custom; s
 
 [agents.codex.env_vars]
 OPENAI_API_KEY = "$OPENAI_API_KEY"
-
-# Alternative levels — UNCOMMENT one of the blocks below to add a paranoid
-# or permissive variant of codex to the N-picker. They show up as separate
-# entries; the original [agents.codex] above stays as the "normal" default.
-# Both levels are kernel-enforced under nono and proxy-enforced under bwrap.
-# See docs/documentation/dashboard/sandbox-levels.md for what each level does
-# and how to ship a custom level.
-#
-# [agents.codex-paranoid]
-# command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}", "--agent", "codex"]
-# pane_title_pattern = "agent-sandbox"
-# status_pipe_name = "lince-status"
-# display_name = "OpenAI Codex (paranoid)"
-# short_label = "CDP"
-# color = "green"
-# sandboxed = true
-# has_native_hooks = false
-# ignore_wrapper_start = true
-# bwrap_conflict = true
-# disable_inner_sandbox_args = ["--sandbox", "danger-full-access"]
-# home_ro_dirs = ["~/.codex/"]
-# profiles = ["__discover__"]
-# sandbox_level = "paranoid"
-#
-# [agents.codex-paranoid.env_vars]
-# OPENAI_API_KEY = "$OPENAI_API_KEY"
-#
-# [agents.codex-permissive]
-# command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}", "--agent", "codex"]
-# pane_title_pattern = "agent-sandbox"
-# status_pipe_name = "lince-status"
-# display_name = "OpenAI Codex (permissive)"
-# short_label = "CD+"
-# color = "yellow"
-# sandboxed = true
-# has_native_hooks = false
-# ignore_wrapper_start = true
-# bwrap_conflict = true
-# disable_inner_sandbox_args = ["--sandbox", "danger-full-access"]
-# home_ro_dirs = ["~/.codex/"]
-# profiles = ["__discover__"]
-# sandbox_level = "permissive"
-#
-# [agents.codex-permissive.env_vars]
-# OPENAI_API_KEY = "$OPENAI_API_KEY"
 
 [agents.codex-unsandboxed]
 command = ["codex", "--full-auto"]

--- a/lince-dashboard/agents-template.toml
+++ b/lince-dashboard/agents-template.toml
@@ -1,0 +1,92 @@
+# Sandbox-level variants — alternative entries you can enable.
+#
+# THIS FILE IS NOT LOADED BY THE DASHBOARD.
+#
+# It serves two purposes:
+#
+#  1. Reference / copy-paste source. Copy any [agents.<agent>-<level>]
+#     block (and its companion [agents.<agent>-<level>.env_vars] block,
+#     if present) into your own ~/.config/lince-dashboard/config.toml
+#     and the variant shows up in the N-picker on the next dashboard
+#     launch. The plugin merges your config.toml on top of
+#     agents-defaults.toml.
+#
+#  2. Source for the install-time multi-select prompt. When you run
+#     install.sh and pick paranoid and/or permissive, every block under
+#     the matching level is appended to your config.toml — supported
+#     agents only (an agent that doesn't appear here for a given level
+#     simply doesn't support that level and is skipped).
+#
+# Per-agent feature support is implicit: presence of a block here means
+# "this agent supports this level". Adding a new agent's variants to
+# this file is enough — install.sh picks them up automatically.
+#
+# See: docs/documentation/dashboard/sandbox-levels.md
+
+# ── Claude ──────────────────────────────────────────────────────────
+
+[agents.claude-paranoid]
+command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}"]
+pane_title_pattern = "agent-sandbox"
+status_pipe_name = "claude-status"
+display_name = "Claude Code (paranoid)"
+short_label = "CLP"
+color = "green"
+sandboxed = true
+has_native_hooks = true
+home_ro_dirs = ["~/.claude/"]
+profiles = ["__discover__"]
+sandbox_level = "paranoid"
+
+[agents.claude-permissive]
+command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}"]
+pane_title_pattern = "agent-sandbox"
+status_pipe_name = "claude-status"
+display_name = "Claude Code (permissive)"
+short_label = "CL+"
+color = "yellow"
+sandboxed = true
+has_native_hooks = true
+home_ro_dirs = ["~/.claude/"]
+profiles = ["__discover__"]
+sandbox_level = "permissive"
+
+# ── Codex ───────────────────────────────────────────────────────────
+
+[agents.codex-paranoid]
+command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}", "--agent", "codex"]
+pane_title_pattern = "agent-sandbox"
+status_pipe_name = "lince-status"
+display_name = "OpenAI Codex (paranoid)"
+short_label = "CDP"
+color = "green"
+sandboxed = true
+has_native_hooks = false
+ignore_wrapper_start = true
+bwrap_conflict = true
+disable_inner_sandbox_args = ["--sandbox", "danger-full-access"]
+home_ro_dirs = ["~/.codex/"]
+profiles = ["__discover__"]
+sandbox_level = "paranoid"
+
+[agents.codex-paranoid.env_vars]
+OPENAI_API_KEY = "$OPENAI_API_KEY"
+
+[agents.codex-permissive]
+command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}", "--agent", "codex"]
+pane_title_pattern = "agent-sandbox"
+status_pipe_name = "lince-status"
+display_name = "OpenAI Codex (permissive)"
+short_label = "CD+"
+color = "yellow"
+sandboxed = true
+has_native_hooks = false
+ignore_wrapper_start = true
+bwrap_conflict = true
+disable_inner_sandbox_args = ["--sandbox", "danger-full-access"]
+home_ro_dirs = ["~/.codex/"]
+profiles = ["__discover__"]
+sandbox_level = "permissive"
+
+[agents.codex-permissive.env_vars]
+OPENAI_API_KEY = "$OPENAI_API_KEY"

--- a/lince-dashboard/install.sh
+++ b/lince-dashboard/install.sh
@@ -9,17 +9,8 @@ NC='\033[0m'
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# CLI flag / env var: which extra sandbox levels to enable in the N-picker.
-# `normal` is always implicit (the dashboard ships it as the default level
-# in agents-defaults.toml). The interactive selection lives in the top-level
-# quickstart.sh; install.sh only honours the resolved choice it forwards.
-#
-#   --sandbox-levels=paranoid,permissive
-#   LINCE_SANDBOX_LEVELS=paranoid env: same effect.
-#
-# Empty string means "normal only" (no extras). Unset means "normal only" too;
-# install.sh does not prompt the user — when run standalone, edit the user's
-# config.toml manually or pass the flag.
+# --sandbox-levels=... / LINCE_SANDBOX_LEVELS: extra levels beyond `normal`.
+# Resolved interactively by quickstart.sh and forwarded to install.sh.
 SANDBOX_LEVELS_OPT_SET=false
 SANDBOX_LEVELS_OPT=""
 for arg in "$@"; do
@@ -339,7 +330,6 @@ if [ -n "$SELECTED_LEVELS" ] && [ -f "$AGENTS_TEMPLATE_DST" ]; then
     if ! command -v python3 >/dev/null 2>&1; then
         echo -e "${YELLOW}  ⚠ python3 not found — cannot apply --sandbox-levels; skipping${NC}"
     else
-        touch "$USER_CONFIG"
         added=$(python3 "$SCRIPT_DIR/scripts/apply-sandbox-levels.py" \
                     "$AGENTS_TEMPLATE_DST" "$USER_CONFIG" "$SELECTED_LEVELS")
         if [ -n "$added" ]; then

--- a/lince-dashboard/install.sh
+++ b/lince-dashboard/install.sh
@@ -9,20 +9,31 @@ NC='\033[0m'
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# CLI flag: --sandbox-levels=paranoid,permissive (or LINCE_SANDBOX_LEVELS env).
-# Suppresses the interactive prompt when set. `normal` is always included
-# implicitly (it's the dashboard default).
+# CLI flag / env var: which extra sandbox levels to enable in the N-picker.
+# `normal` is always implicit (the dashboard ships it as the default level
+# in agents-defaults.toml). The interactive selection lives in the top-level
+# quickstart.sh; install.sh only honours the resolved choice it forwards.
+#
+#   --sandbox-levels=paranoid,permissive
+#   LINCE_SANDBOX_LEVELS=paranoid env: same effect.
+#
+# Empty string means "normal only" (no extras). Unset means "normal only" too;
+# install.sh does not prompt the user — when run standalone, edit the user's
+# config.toml manually or pass the flag.
+SANDBOX_LEVELS_OPT_SET=false
 SANDBOX_LEVELS_OPT=""
 for arg in "$@"; do
     case "$arg" in
-        --sandbox-levels=*) SANDBOX_LEVELS_OPT="${arg#*=}" ;;
+        --sandbox-levels=*)
+            SANDBOX_LEVELS_OPT="${arg#*=}"
+            SANDBOX_LEVELS_OPT_SET=true
+            ;;
         --help|-h)
             echo "Usage: $0 [--sandbox-levels=paranoid,permissive]"
             echo ""
-            echo "  --sandbox-levels=LIST   Comma-separated list of sandbox levels"
-            echo "                          to enable in the N-picker (in addition to"
-            echo "                          'normal', which is always on). Suppresses"
-            echo "                          the interactive prompt."
+            echo "  --sandbox-levels=LIST   Comma-separated list of extra sandbox"
+            echo "                          levels (paranoid, permissive). Empty or"
+            echo "                          unset = normal only."
             echo "                          Same as setting LINCE_SANDBOX_LEVELS."
             exit 0 ;;
     esac
@@ -317,21 +328,11 @@ else
     echo -e "${YELLOW}  ⚠ agents-template.toml not found — skipping${NC}"
 fi
 
-# Decide which extra sandbox levels to enable in the N-picker.
-# Precedence: --sandbox-levels=... flag > LINCE_SANDBOX_LEVELS env > prompt.
-SELECTED_LEVELS="${SANDBOX_LEVELS_OPT:-${LINCE_SANDBOX_LEVELS:-}}"
-if [ -z "$SELECTED_LEVELS" ] && [ -t 0 ] && [ -t 1 ] && [ -f "$AGENTS_TEMPLATE_DST" ]; then
-    echo ""
-    echo "  Sandbox levels for the N-picker:"
-    echo "    [x] normal       (always on — the default level)"
-    echo "    [ ] paranoid     (kernel-isolated network, ephemeral home scratch)"
-    echo "    [ ] permissive   (gh CLI + GitHub allowlist)"
-    if confirm "  Enable paranoid?"; then
-        SELECTED_LEVELS="paranoid"
-    fi
-    if confirm "  Enable permissive?"; then
-        SELECTED_LEVELS="${SELECTED_LEVELS:+$SELECTED_LEVELS,}permissive"
-    fi
+# Resolve the level selection: explicit flag wins; else env var; else normal-only.
+if [ "$SANDBOX_LEVELS_OPT_SET" = true ]; then
+    SELECTED_LEVELS="$SANDBOX_LEVELS_OPT"
+else
+    SELECTED_LEVELS="${LINCE_SANDBOX_LEVELS:-}"
 fi
 
 if [ -n "$SELECTED_LEVELS" ] && [ -f "$AGENTS_TEMPLATE_DST" ]; then

--- a/lince-dashboard/install.sh
+++ b/lince-dashboard/install.sh
@@ -9,6 +9,25 @@ NC='\033[0m'
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# CLI flag: --sandbox-levels=paranoid,permissive (or LINCE_SANDBOX_LEVELS env).
+# Suppresses the interactive prompt when set. `normal` is always included
+# implicitly (it's the dashboard default).
+SANDBOX_LEVELS_OPT=""
+for arg in "$@"; do
+    case "$arg" in
+        --sandbox-levels=*) SANDBOX_LEVELS_OPT="${arg#*=}" ;;
+        --help|-h)
+            echo "Usage: $0 [--sandbox-levels=paranoid,permissive]"
+            echo ""
+            echo "  --sandbox-levels=LIST   Comma-separated list of sandbox levels"
+            echo "                          to enable in the N-picker (in addition to"
+            echo "                          'normal', which is always on). Suppresses"
+            echo "                          the interactive prompt."
+            echo "                          Same as setting LINCE_SANDBOX_LEVELS."
+            exit 0 ;;
+    esac
+done
+
 echo -e "${BLUE}================================================${NC}"
 echo -e "${BLUE}   LINCE Dashboard — Installer${NC}"
 echo -e "${BLUE}================================================${NC}"
@@ -275,17 +294,60 @@ else
 fi
 echo ""
 
-# ── Step 9: Install agents-defaults.toml ─────────────────────────────
-echo -e "${GREEN}[9/12] Installing agent defaults...${NC}"
+# ── Step 9: Install agents-defaults.toml + agents-template.toml ──────
+echo -e "${GREEN}[9/12] Installing agent defaults and templates...${NC}"
 
 AGENTS_DEFAULTS_SRC="$SCRIPT_DIR/agents-defaults.toml"
 AGENTS_DEFAULTS_DST="$CONFIG_DIR/agents-defaults.toml"
+AGENTS_TEMPLATE_SRC="$SCRIPT_DIR/agents-template.toml"
+AGENTS_TEMPLATE_DST="$CONFIG_DIR/agents-template.toml"
+USER_CONFIG="$CONFIG_DIR/config.toml"
 
 if [ -f "$AGENTS_DEFAULTS_SRC" ]; then
     cp "$AGENTS_DEFAULTS_SRC" "$AGENTS_DEFAULTS_DST"
     echo -e "${GREEN}  ✓ Installed: $AGENTS_DEFAULTS_DST${NC}"
 else
     echo -e "${YELLOW}  ⚠ agents-defaults.toml not found — skipping${NC}"
+fi
+
+if [ -f "$AGENTS_TEMPLATE_SRC" ]; then
+    cp "$AGENTS_TEMPLATE_SRC" "$AGENTS_TEMPLATE_DST"
+    echo -e "${GREEN}  ✓ Installed: $AGENTS_TEMPLATE_DST${NC}"
+else
+    echo -e "${YELLOW}  ⚠ agents-template.toml not found — skipping${NC}"
+fi
+
+# Decide which extra sandbox levels to enable in the N-picker.
+# Precedence: --sandbox-levels=... flag > LINCE_SANDBOX_LEVELS env > prompt.
+SELECTED_LEVELS="${SANDBOX_LEVELS_OPT:-${LINCE_SANDBOX_LEVELS:-}}"
+if [ -z "$SELECTED_LEVELS" ] && [ -t 0 ] && [ -t 1 ] && [ -f "$AGENTS_TEMPLATE_DST" ]; then
+    echo ""
+    echo "  Sandbox levels for the N-picker:"
+    echo "    [x] normal       (always on — the default level)"
+    echo "    [ ] paranoid     (kernel-isolated network, ephemeral home scratch)"
+    echo "    [ ] permissive   (gh CLI + GitHub allowlist)"
+    if confirm "  Enable paranoid?"; then
+        SELECTED_LEVELS="paranoid"
+    fi
+    if confirm "  Enable permissive?"; then
+        SELECTED_LEVELS="${SELECTED_LEVELS:+$SELECTED_LEVELS,}permissive"
+    fi
+fi
+
+if [ -n "$SELECTED_LEVELS" ] && [ -f "$AGENTS_TEMPLATE_DST" ]; then
+    if ! command -v python3 >/dev/null 2>&1; then
+        echo -e "${YELLOW}  ⚠ python3 not found — cannot apply --sandbox-levels; skipping${NC}"
+    else
+        touch "$USER_CONFIG"
+        added=$(python3 "$SCRIPT_DIR/scripts/apply-sandbox-levels.py" \
+                    "$AGENTS_TEMPLATE_DST" "$USER_CONFIG" "$SELECTED_LEVELS")
+        if [ -n "$added" ]; then
+            echo -e "${GREEN}  ✓ Enabled levels in $USER_CONFIG:${NC}"
+            echo "$added" | sed 's/^/      • /'
+        else
+            echo -e "${GREEN}  ✓ Sandbox levels already in $USER_CONFIG (nothing to do)${NC}"
+        fi
+    fi
 fi
 echo ""
 
@@ -410,6 +472,10 @@ echo "  Hooks:    ~/.local/bin/claude-status-hook.sh"
 echo "            ~/.local/bin/codex-status-hook.sh"
 echo "  Wrapper:  ~/.local/bin/lince-agent-wrapper"
 echo "  Defaults: ~/.config/lince-dashboard/agents-defaults.toml"
+echo "  Template: ~/.config/lince-dashboard/agents-template.toml"
+if [ -n "$SELECTED_LEVELS" ]; then
+    echo "  Levels:   $SELECTED_LEVELS (added to ~/.config/lince-dashboard/config.toml)"
+fi
 echo "  Nono:     ~/.config/nono/profiles/lince-*.json"
 echo "  Skill:    ~/.claude/skills/lince-setup/"
 echo ""

--- a/lince-dashboard/scripts/apply-sandbox-levels.py
+++ b/lince-dashboard/scripts/apply-sandbox-levels.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Append selected sandbox-level agent blocks from agents-template.toml
+into the user's lince-dashboard config.toml.
+
+Usage: apply-sandbox-levels.py <template> <user_config> <levels_csv>
+
+Per-agent feature support is implicit: only `[agents.<agent>-<level>]`
+blocks present in <template> are applied. Already-present blocks in
+<user_config> are skipped (idempotent across re-runs).
+
+Prints one `agent-level` per line for each block actually appended.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+SECTION_RE = re.compile(r"(?m)^(\[agents\.[^\]]+\])\s*$")
+
+
+def split_sections(text: str) -> dict[str, str]:
+    """Map [agents.X] header → that section's text (header through to the
+    char before the next [agents.*] header or EOF), preserving comments."""
+    matches = list(SECTION_RE.finditer(text))
+    sections: dict[str, str] = {}
+    for i, m in enumerate(matches):
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        sections[m.group(1)] = text[m.start():end].rstrip() + "\n"
+    return sections
+
+
+def has_section(cfg_text: str, agent_name: str) -> bool:
+    pattern = rf"^\[agents\.{re.escape(agent_name)}\]\s*$"
+    return re.search(pattern, cfg_text, re.M) is not None
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 4:
+        print(__doc__, file=sys.stderr)
+        return 2
+
+    template_path = Path(argv[1])
+    cfg_path = Path(argv[2])
+    levels = [
+        level.strip()
+        for level in argv[3].split(",")
+        if level.strip() and level.strip() != "normal"
+    ]
+
+    if not levels:
+        return 0
+
+    template_text = template_path.read_text()
+    sections = split_sections(template_text)
+
+    cfg_text = cfg_path.read_text() if cfg_path.exists() else ""
+
+    added: list[str] = []
+    for level in levels:
+        head_re = re.compile(rf"^\[agents\.([\w-]+)-{re.escape(level)}\]\s*$", re.M)
+        for hm in head_re.finditer(template_text):
+            agent_name = f"{hm.group(1)}-{level}"
+            if has_section(cfg_text, agent_name):
+                continue
+            block = sections.get(f"[agents.{agent_name}]", "")
+            env_block = sections.get(f"[agents.{agent_name}.env_vars]", "")
+            if not block:
+                continue
+            cfg_text = cfg_text.rstrip() + "\n\n" + block
+            if env_block:
+                cfg_text = cfg_text.rstrip() + "\n\n" + env_block
+            added.append(agent_name)
+
+    if added:
+        cfg_path.write_text(cfg_text + ("\n" if not cfg_text.endswith("\n") else ""))
+    print("\n".join(added))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/lince-dashboard/scripts/apply-sandbox-levels.py
+++ b/lince-dashboard/scripts/apply-sandbox-levels.py
@@ -30,11 +30,6 @@ def split_sections(text: str) -> dict[str, str]:
     return sections
 
 
-def has_section(cfg_text: str, agent_name: str) -> bool:
-    pattern = rf"^\[agents\.{re.escape(agent_name)}\]\s*$"
-    return re.search(pattern, cfg_text, re.M) is not None
-
-
 def main(argv: list[str]) -> int:
     if len(argv) != 4:
         print(__doc__, file=sys.stderr)
@@ -53,21 +48,22 @@ def main(argv: list[str]) -> int:
 
     template_text = template_path.read_text()
     sections = split_sections(template_text)
-
     cfg_text = cfg_path.read_text() if cfg_path.exists() else ""
+    existing = {m.group(1) for m in SECTION_RE.finditer(cfg_text)}
 
     added: list[str] = []
     for level in levels:
         head_re = re.compile(rf"^\[agents\.([\w-]+)-{re.escape(level)}\]\s*$", re.M)
         for hm in head_re.finditer(template_text):
             agent_name = f"{hm.group(1)}-{level}"
-            if has_section(cfg_text, agent_name):
+            block_key = f"[agents.{agent_name}]"
+            if block_key in existing:
                 continue
-            block = sections.get(f"[agents.{agent_name}]", "")
-            env_block = sections.get(f"[agents.{agent_name}.env_vars]", "")
+            block = sections.get(block_key, "")
             if not block:
                 continue
             cfg_text = cfg_text.rstrip() + "\n\n" + block
+            env_block = sections.get(f"[agents.{agent_name}.env_vars]", "")
             if env_block:
                 cfg_text = cfg_text.rstrip() + "\n\n" + env_block
             added.append(agent_name)

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -56,16 +56,12 @@ BACKENDS=(
 # Track backend selection state (1=selected, 0=not)
 BACKEND_SELECTED=(1 0 0)  # bwrap on by default
 
-# Available sandbox levels: key|display_name|description
-# normal is locked-on (the default level the dashboard ships); paranoid and
-# permissive are opt-in extra entries pulled from agents-template.toml into
-# the user's config.toml.
+# Sandbox levels: name|description. Index 0 (normal) is locked on.
 LEVELS=(
-    "normal|normal|always on — the default level"
-    "paranoid|paranoid|kernel-isolated network, ephemeral home scratch"
-    "permissive|permissive|gh CLI + GitHub allowlist"
+    "normal|always on — the default level"
+    "paranoid|kernel-isolated network, ephemeral home scratch"
+    "permissive|gh CLI + GitHub allowlist"
 )
-# Index 0 (normal) is locked on; 1 (paranoid) and 2 (permissive) default off.
 LEVEL_SELECTED=(1 0 0)
 
 # ── Helpers ──────────────────────────────────────────────────────────
@@ -90,6 +86,12 @@ print_banner() {
 
 print_separator() {
     echo -e "${DIM}────────────────────────────────────────────────────${NC}"
+}
+
+# Move cursor up N lines and clear to end of screen — used by the
+# multi-select TUIs to redraw their menu in place.
+redraw_up() {
+    echo -en "\033[$1A\033[J"
 }
 
 # ── TUI: Backend selection (multi-select) ───────────────────────────
@@ -195,9 +197,7 @@ select_backends() {
                 ;;
         esac
 
-        # Move cursor up to redraw
-        local lines_up=$(( ${#BACKENDS[@]} + 3 ))
-        echo -en "\033[${lines_up}A\033[J"
+        redraw_up $(( ${#BACKENDS[@]} + 3 ))
     done
 
     # Build selected backends list
@@ -247,10 +247,6 @@ select_backends() {
 }
 
 # ── TUI: Sandbox-level selection (multi-select) ─────────────────────
-# Pulls extra paranoid / permissive agent entries out of
-# agents-template.toml and (later) into the user's config.toml. normal
-# is locked on — it's the level [agents.<name>] in agents-defaults.toml
-# already ships with.
 select_sandbox_levels() {
     echo ""
     print_separator
@@ -261,15 +257,14 @@ select_sandbox_levels() {
     echo -e "  in the N-picker. Variants are pulled from agents-template.toml"
     echo -e "  and added to your config.toml."
     echo ""
-    echo -e "  ${DIM}Per-agent feature support is implicit: agents that don't ship a${NC}"
-    echo -e "  ${DIM}block for a level are silently skipped.${NC}"
+    echo -e "  ${DIM}Agents that don't ship a block for a level are skipped.${NC}"
     echo ""
     echo -e "  ${DIM}Toggle with number keys, press Enter when done:${NC}"
     echo ""
 
     while true; do
         for i in "${!LEVELS[@]}"; do
-            IFS='|' read -r key name desc <<< "${LEVELS[$i]}"
+            IFS='|' read -r name desc <<< "${LEVELS[$i]}"
             if [ $i -eq 0 ]; then
                 echo -e "  ${GREEN}[x]${NC} ${BOLD}$((i+1))) $name${NC} ${DIM}— $desc${NC} ${DIM}(locked)${NC}"
             elif [ "${LEVEL_SELECTED[$i]}" = "1" ]; then
@@ -286,7 +281,7 @@ select_sandbox_levels() {
         case "$REPLY" in
             [1-9])
                 local idx=$((REPLY - 1))
-                # Index 0 = normal, locked on. Ignore.
+                # idx 0 (normal) is locked.
                 if [ $idx -gt 0 ] && [ $idx -lt ${#LEVELS[@]} ]; then
                     if [ "${LEVEL_SELECTED[$idx]}" = "1" ]; then
                         LEVEL_SELECTED[$idx]=0
@@ -300,17 +295,15 @@ select_sandbox_levels() {
                 ;;
         esac
 
-        local lines_up=$(( ${#LEVELS[@]} + 3 ))
-        echo -en "\033[${lines_up}A\033[J"
+        redraw_up $(( ${#LEVELS[@]} + 3 ))
     done
 
-    # Build SELECTED_LEVELS as a comma-list of extras (excluding normal).
     SELECTED_LEVELS=""
     for i in "${!LEVELS[@]}"; do
         [ $i -eq 0 ] && continue
         if [ "${LEVEL_SELECTED[$i]}" = "1" ]; then
-            IFS='|' read -r key _ _ <<< "${LEVELS[$i]}"
-            SELECTED_LEVELS="${SELECTED_LEVELS:+$SELECTED_LEVELS,}$key"
+            IFS='|' read -r name _ <<< "${LEVELS[$i]}"
+            SELECTED_LEVELS="${SELECTED_LEVELS:+$SELECTED_LEVELS,}$name"
         fi
     done
 
@@ -380,9 +373,7 @@ select_agents() {
                 ;;
         esac
 
-        # Move cursor up to redraw (number of agents + 2 lines for prompt)
-        local lines_up=$(( ${#AGENTS[@]} + 3 ))
-        echo -en "\033[${lines_up}A\033[J"
+        redraw_up $(( ${#AGENTS[@]} + 3 ))
     done
 
     # Build selected agents list

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -32,6 +32,7 @@ NC='\033[0m'
 # ── State ────────────────────────────────────────────────────────────
 SELECTED_BACKENDS=()       # populated by select_backends(): "bwrap", "nono", "unsandboxed"
 SELECTED_AGENTS=()
+SELECTED_LEVELS=""         # comma-csv of extra sandbox levels (e.g. "paranoid,permissive")
 INSTALL_VOXCODE=false
 USE_DEFAULTS=false
 
@@ -54,6 +55,18 @@ BACKENDS=(
 )
 # Track backend selection state (1=selected, 0=not)
 BACKEND_SELECTED=(1 0 0)  # bwrap on by default
+
+# Available sandbox levels: key|display_name|description
+# normal is locked-on (the default level the dashboard ships); paranoid and
+# permissive are opt-in extra entries pulled from agents-template.toml into
+# the user's config.toml.
+LEVELS=(
+    "normal|normal|always on — the default level"
+    "paranoid|paranoid|kernel-isolated network, ephemeral home scratch"
+    "permissive|permissive|gh CLI + GitHub allowlist"
+)
+# Index 0 (normal) is locked on; 1 (paranoid) and 2 (permissive) default off.
+LEVEL_SELECTED=(1 0 0)
 
 # ── Helpers ──────────────────────────────────────────────────────────
 confirm() {
@@ -233,6 +246,81 @@ select_backends() {
     echo -e "  ${GREEN}✓${NC} Backends: ${BOLD}${SELECTED_BACKENDS[*]}${NC}"
 }
 
+# ── TUI: Sandbox-level selection (multi-select) ─────────────────────
+# Pulls extra paranoid / permissive agent entries out of
+# agents-template.toml and (later) into the user's config.toml. normal
+# is locked on — it's the level [agents.<name>] in agents-defaults.toml
+# already ships with.
+select_sandbox_levels() {
+    echo ""
+    print_separator
+    echo -e "${BOLD}Step 2: Sandbox levels${NC}"
+    echo ""
+    echo -e "  Each agent ships with the ${BOLD}normal${NC} level enabled. You can"
+    echo -e "  also expose ${BOLD}paranoid${NC} and/or ${BOLD}permissive${NC} as separate entries"
+    echo -e "  in the N-picker. Variants are pulled from agents-template.toml"
+    echo -e "  and added to your config.toml."
+    echo ""
+    echo -e "  ${DIM}Per-agent feature support is implicit: agents that don't ship a${NC}"
+    echo -e "  ${DIM}block for a level are silently skipped.${NC}"
+    echo ""
+    echo -e "  ${DIM}Toggle with number keys, press Enter when done:${NC}"
+    echo ""
+
+    while true; do
+        for i in "${!LEVELS[@]}"; do
+            IFS='|' read -r key name desc <<< "${LEVELS[$i]}"
+            if [ $i -eq 0 ]; then
+                echo -e "  ${GREEN}[x]${NC} ${BOLD}$((i+1))) $name${NC} ${DIM}— $desc${NC} ${DIM}(locked)${NC}"
+            elif [ "${LEVEL_SELECTED[$i]}" = "1" ]; then
+                echo -e "  ${GREEN}[x]${NC} ${BOLD}$((i+1))) $name${NC} ${DIM}— $desc${NC}"
+            else
+                echo -e "  ${DIM}[ ] $((i+1))) $name — $desc${NC}"
+            fi
+        done
+        echo ""
+        echo -e "  ${DIM}Press 2-${#LEVELS[@]} to toggle, Enter to confirm${NC}"
+        read -p "  > " -n 1 -r
+        echo ""
+
+        case "$REPLY" in
+            [1-9])
+                local idx=$((REPLY - 1))
+                # Index 0 = normal, locked on. Ignore.
+                if [ $idx -gt 0 ] && [ $idx -lt ${#LEVELS[@]} ]; then
+                    if [ "${LEVEL_SELECTED[$idx]}" = "1" ]; then
+                        LEVEL_SELECTED[$idx]=0
+                    else
+                        LEVEL_SELECTED[$idx]=1
+                    fi
+                fi
+                ;;
+            "")
+                break
+                ;;
+        esac
+
+        local lines_up=$(( ${#LEVELS[@]} + 3 ))
+        echo -en "\033[${lines_up}A\033[J"
+    done
+
+    # Build SELECTED_LEVELS as a comma-list of extras (excluding normal).
+    SELECTED_LEVELS=""
+    for i in "${!LEVELS[@]}"; do
+        [ $i -eq 0 ] && continue
+        if [ "${LEVEL_SELECTED[$i]}" = "1" ]; then
+            IFS='|' read -r key _ _ <<< "${LEVELS[$i]}"
+            SELECTED_LEVELS="${SELECTED_LEVELS:+$SELECTED_LEVELS,}$key"
+        fi
+    done
+
+    if [ -z "$SELECTED_LEVELS" ]; then
+        echo -e "  ${GREEN}✓${NC} Levels: ${BOLD}normal${NC} ${DIM}(only)${NC}"
+    else
+        echo -e "  ${GREEN}✓${NC} Levels: ${BOLD}normal, $SELECTED_LEVELS${NC}"
+    fi
+}
+
 # Helper: check if a backend is selected
 has_backend() {
     local target="$1"
@@ -246,7 +334,7 @@ has_backend() {
 select_agents() {
     echo ""
     print_separator
-    echo -e "${BOLD}Step 2: Select agents to configure${NC}"
+    echo -e "${BOLD}Step 3: Select agents to configure${NC}"
     echo ""
     echo -e "  ${DIM}These are sandboxing wrappers and dashboard entries for each agent.${NC}"
     echo -e "  ${DIM}The agents themselves (claude, codex, gemini, etc.) must be${NC}"
@@ -319,7 +407,7 @@ select_agents() {
 select_voxcode() {
     echo ""
     print_separator
-    echo -e "${BOLD}Step 3: Voice input (VoxCode)${NC}"
+    echo -e "${BOLD}Step 4: Voice input (VoxCode)${NC}"
     echo ""
     echo -e "  VoxCode lets you speak to your agents — transcriptions are"
     echo -e "  routed to the focused agent via the dashboard."
@@ -386,6 +474,11 @@ confirm_installation() {
         echo -e "  ${GREEN}✓${NC} agent-sandbox    ${DIM}(secure isolation for agents)${NC}"
     fi
     echo -e "    Backends: ${BOLD}${SELECTED_BACKENDS[*]}${NC}"
+    if [ -n "$SELECTED_LEVELS" ]; then
+        echo -e "    Levels:   ${BOLD}normal, $SELECTED_LEVELS${NC}"
+    else
+        echo -e "    Levels:   ${BOLD}normal${NC} ${DIM}(only)${NC}"
+    fi
 
     echo -e "  ${GREEN}✓${NC} lince-dashboard  ${DIM}(multi-agent TUI)${NC}"
 
@@ -550,7 +643,9 @@ do_install_dashboard() {
     echo ""
 
     cd "$SCRIPT_DIR/lince-dashboard"
-    if bash install.sh; then
+    # Pass the level selection through so install.sh skips its own prompt and
+    # writes the matching [agents.*-<level>] blocks into config.toml.
+    if bash install.sh "--sandbox-levels=$SELECTED_LEVELS"; then
         echo -e "${GREEN}✓ lince-dashboard installed${NC}"
     else
         echo -e "${RED}✗ lince-dashboard installation failed${NC}"
@@ -801,9 +896,11 @@ if [ "$USE_DEFAULTS" = true ]; then
         IFS='|' read -r key _ _ <<< "${AGENTS[$i]}"
         SELECTED_AGENTS+=("$key")
     done
-    echo -e "  ${DIM}Using defaults: all agents, bwrap sandbox${NC}"
+    SELECTED_LEVELS=""  # normal-only by default
+    echo -e "  ${DIM}Using defaults: all agents, bwrap sandbox, normal level only${NC}"
 else
     select_backends
+    select_sandbox_levels
     select_agents
     if [ "$(uname -s)" != "Darwin" ]; then
         select_voxcode


### PR DESCRIPTION
Closes #59. Implements LINCE-104.

## Summary

Move the alternative paranoid/permissive entries out of `lince-dashboard/agents-defaults.toml` (where they were commented-out blocks polluting the file) into a new sibling `agents-template.toml` that ships uncommented but is **not** loaded by the dashboard. Add a number-toggle multi-select to `quickstart.sh` Step 2 so users can opt every supported agent into paranoid and/or permissive at install time, in the same TUI style as the existing backend / agent selectors.

## Files

**New**
- `lince-dashboard/agents-template.toml` — `[agents.claude-paranoid]`, `[agents.claude-permissive]`, `[agents.codex-paranoid]`, `[agents.codex-permissive]` as fully uncommented TOML. Header explains it is reference-only and doubles as the install-time multi-select source.
- `lince-dashboard/scripts/apply-sandbox-levels.py` — block-extractor that copies `[agents.X-<level>]` (and its `.env_vars` companion) from the template into the user's `config.toml`. Pre-computes a set of existing section headers for O(N+M) idempotent merging.

**Modified**
- `lince-dashboard/agents-defaults.toml` — strip the 4 commented variant blocks; header points to `agents-template.toml` and explains the override mechanism.
- `lince-dashboard/install.sh` — install `agents-template.toml`; honour `--sandbox-levels=...` flag and `LINCE_SANDBOX_LEVELS` env var; standalone `install.sh` no longer prompts (the TUI lives in `quickstart.sh`).
- `quickstart.sh` — new Step 2 "Sandbox levels" with the same number-toggle UI as the other selectors. `normal` is locked-on, `paranoid` / `permissive` are opt-in. Selection is forwarded to `install.sh --sandbox-levels=...`. Tiny `redraw_up()` helper removes the duplicated cursor-up + clear-eos escape from all three menus.
- `docs/documentation/dashboard/sandbox-levels.md` — new §5 "Enabling paranoid / permissive variants" covering both the quickstart TUI and the manual copy-from-template flow. Existing §5–8 renumbered to §6–9; cross-refs updated.

Plugin loader unchanged: it still reads only `agents-defaults.toml` and the user's `config.toml`. `agents-template.toml` is reference data the installer parses, never the runtime.

## What the user sees

```
Step 2: Sandbox levels

  [x] 1) normal — always on — the default level (locked)
  [ ] 2) paranoid — kernel-isolated network, ephemeral home scratch
  [ ] 3) permissive — gh CLI + GitHub allowlist

  Press 2-3 to toggle, Enter to confirm
  >
```

Per-agent feature support is implicit in the template file: agents that don't ship a block for a selected level are silently skipped. LINCE-100/101/102 (gemini/opencode/pi) just add their `*-paranoid` / `*-permissive` blocks to `agents-template.toml` and the same TUI picks them up automatically — no install-script change per agent.

## Verification

- `bash -n` clean on `quickstart.sh`, `install.sh`, helper.
- `python -c py_compile` clean on `apply-sandbox-levels.py`.
- Both TOML files parse with `tomllib`.
- Plugin loader (`config.rs`) confirmed to read only `agents-defaults.toml` + `config.toml`; `agents-template.toml` not referenced.
- End-to-end: fresh apply with `paranoid,permissive` adds the 4 expected blocks; re-run adds 0 (idempotent); empty/unsupported levels are no-ops; partial-supported (e.g. `paranoid,fictional`) honours what exists.

## Test plan

- [ ] `./quickstart.sh` and step through:
  - [ ] Step 2 renders correctly; pressing `1` is silently ignored (normal locked).
  - [ ] `2` then Enter → only paranoid blocks land in `~/.config/lince-dashboard/config.toml`.
  - [ ] `2 3` then Enter → both paranoid and permissive blocks land.
  - [ ] Just Enter → `~/.config/lince-dashboard/config.toml` unchanged (only normal, the default).
- [ ] Re-running `./quickstart.sh` with the same selection does not duplicate blocks.
- [ ] `LINCE_SANDBOX_LEVELS=paranoid,permissive ./lince-dashboard/install.sh` (standalone, no quickstart) applies the same selection without prompting.
- [ ] Dashboard N-picker shows the new entries (`Claude Code (paranoid)`, `OpenAI Codex (permissive)`, etc.) after restart.

## Follow-ups

- LINCE-100/101/102 (gemini/opencode/pi) now depend on this. They land their alternative variants directly in `agents-template.toml` — no commented blocks anywhere.
- LINCE-103 (claude → `scratch_home_dirs` migration, GH #58) is independent and unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)