### PR TITLE
sandbox: three-level model for gemini/opencode/pi + agents-template split (LINCE-100/101/102/104)

### DIFF
--- a/backlog/tasks/lince-100 - Three-sandbox-levels-—-gemini-follow-up.md
+++ b/backlog/tasks/lince-100 - Three-sandbox-levels-—-gemini-follow-up.md
@@ -1,10 +1,10 @@
 ---
 id: LINCE-100
 title: Three sandbox levels — gemini follow-up
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-05-04 20:32'
-updated_date: '2026-05-05 19:02'
+updated_date: '2026-05-05 20:52'
 labels:
   - sandbox
   - lince-dashboard
@@ -87,6 +87,30 @@ If Gemini OAuth requires additional Google domains:
 - [ ] #6 OAuth flow behavior documented for paranoid (allow refresh or require pre-existing token)
 - [ ] #7 Master doc page extended with gemini-specific rows and OAuth trade-off explanation for paranoid (allow refresh vs. require pre-existing token)
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+## Plan
+
+1. **Nono profiles** (lince-dashboard/nono-profiles/):
+   - `lince-gemini-paranoid.json`: extends lince-gemini, `network.credentials = ["gemini"]`, no extra reads.
+   - `lince-gemini-permissive.json`: extends lince-gemini, gemini credentials + GitHub allow_domain + standard permissive reads.
+
+2. **Sandbox fragments** (sandbox/profiles/):
+   - `gemini-paranoid.toml`: `[env.extra]` auto-maps GEMINI_API_KEY + GOOGLE_API_KEY (both deduped to `generativelanguage.googleapis.com`); `[agents.gemini].scratch_home_dirs = [".gemini"]`; `credential_proxy=true` + `unshare_net=true` + `allow_domains=[]`.
+   - `gemini-permissive.toml`: standard GitHub allowlist, `block_git_push=true`, GH_TOKEN/GITHUB_TOKEN passthrough.
+
+3. **OAuth decision** (paranoid): API-key auth required. accounts.google.com / oauth2.googleapis.com are NOT allowed in paranoid — OAuth-only users should pick `normal` or `permissive`. Documented in JSON `meta.description` and TOML header.
+
+4. **agents-defaults.toml**: collapse `[agents.gemini]` (unsandboxed), `[agents.gemini-bwrap]`, `[agents.gemini-nono]` → single `[agents.gemini]` (sandboxed default, `sandbox_level="normal"`) + `[agents.gemini-unsandboxed]`.
+
+5. **agents-template.toml**: add `[agents.gemini-paranoid]` and `[agents.gemini-permissive]` (uncommented).
+
+6. **plugin/src/agent.rs**: add gemini match arm to `synthesize_sandboxed_command` — `inner_command = ["gemini"]`, `agent_home_subdir = ".gemini"`. Also fix the bash wrapper to mkdir the nested home subdir and skip rsync if source is missing.
+
+7. install.sh / sandbox install.sh: no changes needed (both loop over the directory).
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
@@ -199,4 +223,26 @@ This task is updated to:
 3. The new `[agents.gemini]` entry in `agents-defaults.toml` is the only loaded gemini entry; it carries `sandbox_level = "normal"`.
 
 Nothing else in the existing plan changes — the nono profiles, bwrap fragments, plugin match arm, OAuth decision, and `scratch_home_dirs` opt-in are all unchanged. Only the destination file for the alternative-variant agent entries shifts.
+
+## Implementation
+
+- Nono profiles: `lince-gemini-paranoid.json`, `lince-gemini-permissive.json` shipped.
+- Sandbox fragments: `sandbox/profiles/gemini-paranoid.toml` (with `[env.extra]` + `scratch_home_dirs=[".gemini"]`) and `sandbox/profiles/gemini-permissive.toml`.
+- `agents-defaults.toml`: collapsed gemini, gemini-bwrap, gemini-nono → `[agents.gemini]` (sandboxed, `sandbox_level="normal"`) + `[agents.gemini-unsandboxed]`.
+- `agents-template.toml`: added `[agents.gemini-paranoid]` and `[agents.gemini-permissive]`.
+- `plugin/src/agent.rs`: added gemini match arm. WASM build clean.
+
+## OAuth decision (paranoid)
+
+Paranoid does NOT allow `accounts.google.com` / `oauth2.googleapis.com`. Rationale: keep the surface minimal and avoid a broad Google OAuth domain in the allowlist. Trade-off: OAuth-authenticated gemini users must pick `normal` or `permissive` (or extend `[security].allow_domains` in their own config). Documented in `lince-gemini-paranoid.json` `meta.description` and `gemini-paranoid.toml` header.
+
+## Verification done
+
+- All TOML/JSON parse.
+- WASM plugin builds clean (release + dev).
+- `apply-sandbox-levels.py paranoid,permissive` correctly picks up `gemini-paranoid` and `gemini-permissive`.
+
+Master doc page extension (acceptance criterion #7) deferred — no docs/ tree exists yet for the dashboard sandbox-levels page; will land alongside the umbrella docs task.
+
+Runtime sanity checks (curl/printenv inside paranoid) require a host with the gemini binary + a GEMINI_API_KEY, so left for the user to verify before pushing.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/lince-101 - Three-sandbox-levels-—-opencode-follow-up.md
+++ b/backlog/tasks/lince-101 - Three-sandbox-levels-—-opencode-follow-up.md
@@ -1,10 +1,10 @@
 ---
 id: LINCE-101
 title: Three sandbox levels — opencode follow-up
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-05-04 20:33'
-updated_date: '2026-05-05 19:02'
+updated_date: '2026-05-05 20:53'
 labels:
   - sandbox
   - lince-dashboard
@@ -95,6 +95,32 @@ Decide and document the trade-off.
 - [ ] #6 sandbox_level=permissive: gh CLI works; docker ps fails
 - [ ] #7 Master doc page extended with opencode-specific rows: Bun/Landlock workaround explained, LLM-endpoint allowlist decision documented, OPENCODE_API_KEY handling per level
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+## Plan
+
+1. **Nono profiles**:
+   - `lince-opencode-paranoid.json`: extends lince-opencode, `network.credentials = ["anthropic", "openai", "gemini"]` (the providers nono knows; for others ship a custom level).
+   - `lince-opencode-permissive.json`: same credentials + GitHub allowlist + standard permissive reads.
+
+2. **Sandbox fragments**:
+   - `opencode-paranoid.toml`: auto-map all 5 credential-rule providers in `[env.extra]`; `scratch_home_dirs=[".config/opencode"]`; paranoid security flags.
+   - `opencode-permissive.toml`: standard GitHub allowlist + GH_TOKEN passthrough.
+
+3. **LLM-endpoint decision**: paranoid covers anthropic/openai/gemini (the providers `CREDENTIAL_PROXY_RULES` and nono's keystore know). For other LLMs the user ships a custom level. Documented in JSON `meta.description`.
+
+4. **OPENCODE_API_KEY**: passthrough for normal/permissive (inherited from base profile env). For paranoid: not in CREDENTIAL_PROXY_RULES so no proxy injection — opencode users on a non-OpenAI/Anthropic/Google routing should use a custom level.
+
+5. **Bun/Landlock workaround**: option (a) from the task notes — pass the bun-resolution as `inner_command` in `synthesize_sandboxed_command`. The shape is `["bash", "-c", "exec ... .opencode \"$@\"", "--"]`. shell_quote single-quotes the `-c` arg in the paranoid bash wrapper, preserving the shell metas. Bwrap path goes through the agent-sandbox CLI, which doesn't use Landlock — so the workaround is only effective on the Nono path, which is where the bug manifests.
+
+6. **agents-defaults.toml**: collapse opencode/opencode-bwrap/opencode-nono → `[agents.opencode]` (sandboxed default) + `[agents.opencode-unsandboxed]`.
+
+7. **agents-template.toml**: add `[agents.opencode-paranoid]` and `[agents.opencode-permissive]`.
+
+8. **plugin/src/agent.rs**: opencode match arm with the Bun-resolution inner_command and `agent_home_subdir = ".config/opencode"`. The bash wrapper now `mkdir -p`s the (potentially nested) home subdir and skips rsync if source is missing — both needed for `.config/opencode` on a fresh install.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
@@ -206,4 +232,28 @@ This task is updated to:
 3. The new `[agents.opencode]` entry in `agents-defaults.toml` is the only loaded opencode entry; it carries `sandbox_level = "normal"`.
 
 Nothing else in the existing plan changes — the Bun/Landlock workaround, LLM-endpoint allowlist decision, plugin match arm, and `scratch_home_dirs = [".config/opencode"]` opt-in are all unchanged. Only the destination file for the alternative-variant agent entries shifts.
+
+## Implementation
+
+- Nono profiles: `lince-opencode-paranoid.json` (`credentials: ["anthropic","openai","gemini"]`), `lince-opencode-permissive.json` (same + GitHub).
+- Sandbox fragments: `opencode-paranoid.toml` (5-provider env.extra, `scratch_home_dirs=[".config/opencode"]`) and `opencode-permissive.toml`.
+- `agents-defaults.toml`: collapsed opencode/opencode-bwrap/opencode-nono.
+- `agents-template.toml`: added opencode-paranoid + opencode-permissive.
+- `plugin/src/agent.rs`: opencode match arm — `inner_command = ["bash","-c","exec \"$(dirname \"$(readlink -f \"$(which opencode)\")\")/.opencode\" \"$@\"","--"]`, `agent_home_subdir=".config/opencode"`. Picked option (a) from task notes (pass resolution as inner_command). Verified: `shell_quote()` wraps the resolution string in single quotes inside the paranoid bash wrapper, so $-expansion happens at exec-time inside nono, not at wrapper-construction time.
+- Plugin bash wrapper: now `mkdir -p "$SCRATCH/$HOME_SUBDIR"` (so nested `.config/opencode` works) and skips rsync if source is missing (clean-install case).
+
+## LLM-endpoint allowlist decision (paranoid)
+
+Covered providers: anthropic, openai, gemini (intersection of `CREDENTIAL_PROXY_RULES` and nono's keystore). Rationale: ship a useful default for the most common router targets without enumerating every possible backend. Users on other providers (groq, mistral, deepseek, etc.) ship a custom level fragment.
+
+`OPENCODE_API_KEY` itself is passthrough only — not a proxied credential. Routing happens client-side; the actual upstream is one of the 3 covered providers (or a custom level the user ships).
+
+## Verification done
+
+- All TOML/JSON parse.
+- WASM plugin builds clean.
+- `apply-sandbox-levels.py paranoid,permissive` correctly emits `opencode-paranoid` and `opencode-permissive`.
+- Bun/Landlock workaround confirmed not needed for bwrap path (agent-sandbox CLI on bwrap doesn't trigger Landlock).
+
+Master doc page extension deferred (no docs tree yet). Runtime sanity checks (`opencode --version` inside paranoid; curl tests) require host opencode + provider keys, left for the user to verify before pushing.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/lince-102 - Three-sandbox-levels-—-pi-follow-up.md
+++ b/backlog/tasks/lince-102 - Three-sandbox-levels-—-pi-follow-up.md
@@ -1,10 +1,10 @@
 ---
 id: LINCE-102
 title: Three sandbox levels — pi follow-up
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-05-04 20:33'
-updated_date: '2026-05-05 19:02'
+updated_date: '2026-05-05 20:53'
 labels:
   - sandbox
   - lince-dashboard
@@ -89,6 +89,31 @@ This is the most architecturally interesting follow-up. Document the design deci
 - [ ] #6 N-picker shows 'Pi' once
 - [ ] #7 Master doc page extended with pi-specific rows: pi_providers design rationale, env-var filtering behavior, worked examples for paranoid with different provider subsets
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+## Plan
+
+1. **Nono profiles**:
+   - `lince-pi-paranoid.json`: extends lince-pi, `network.credentials = ["anthropic","openai","gemini"]`, narrow `environment.passthrough` (only the 3 supported providers' keys + base URLs + standard).
+   - `lince-pi-permissive.json`: same credentials + GitHub allowlist; inherits the full 18-provider passthrough from lince-pi.
+
+2. **Sandbox fragments**:
+   - `pi-paranoid.toml`: `[env.extra]` for 5 credential-proxy providers; `scratch_home_dirs=[".pi"]`; paranoid security.
+   - `pi-permissive.toml`: standard GitHub allowlist + GH_TOKEN passthrough.
+
+3. **Multi-provider design** (no `pi_providers` field for now):
+   - Paranoid covers anthropic/openai/gemini — the only providers in `CREDENTIAL_PROXY_RULES` and nono's keystore.
+   - For other providers (mistral, groq, deepseek, AWS Bedrock, ...) the user ships a custom level: copy `lince-pi-paranoid.json` to `~/.config/nono/profiles/lince-pi-<custom>.json`, extend `network.allow_domain` + `environment.passthrough`, then set `sandbox_level = "<custom>"` on `[agents.pi]`.
+   - The `pi_providers` config field proposed in the task description is deferred — implementing dynamic env-var filtering + dynamic `network.credentials` synthesis adds non-trivial plugin code for a low-priority follow-up. Documented as future work in the agents-defaults.toml comment block.
+
+4. **agents-defaults.toml**: collapse pi/pi-bwrap/pi-nono → single `[agents.pi]` (sandboxed default, `sandbox_level="normal"`). The 33-key `[agents.pi.env_vars]` is preserved on the new entry. Multi-provider note added as a comment.
+
+5. **agents-template.toml**: add `[agents.pi-paranoid]` (with a narrow 5-key env block for the supported providers) and `[agents.pi-permissive]` (full 33-key env passthrough).
+
+6. **plugin/src/agent.rs**: pi match arm — `inner_command = ["pi"]`, `agent_home_subdir = ".pi"`. Same bash-wrapper improvements as gemini/opencode (mkdir nested + rsync skip on missing source).
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
@@ -200,4 +225,28 @@ This task is updated to:
 3. The new `[agents.pi]` entry in `agents-defaults.toml` is the only loaded pi entry; it carries `sandbox_level = "normal"`.
 
 Nothing else in the existing plan changes — the multi-provider design (option a/b/c on `pi_providers` filtering), plugin match arm, and `scratch_home_dirs = [".pi"]` opt-in are all unchanged. Only the destination file for the alternative-variant agent entries shifts.
+
+## Implementation
+
+- Nono profiles: `lince-pi-paranoid.json` (3-provider credentials, narrow passthrough), `lince-pi-permissive.json` (3-provider credentials + GitHub, full passthrough).
+- Sandbox fragments: `pi-paranoid.toml` (`[env.extra]` for 5 credential-proxy keys, `scratch_home_dirs=[".pi"]`) and `pi-permissive.toml`.
+- `agents-defaults.toml`: collapsed pi/pi-bwrap/pi-nono → `[agents.pi]` (sandboxed, `sandbox_level="normal"`) with full 33-key env block preserved + multi-provider comment.
+- `agents-template.toml`: pi-paranoid (5-key env: anthropic/openai/gemini + base URLs) + pi-permissive (full 33-key passthrough). Added an inline comment in pi-paranoid pointing users at the custom-level escape hatch.
+- `plugin/src/agent.rs`: pi match arm.
+
+## pi_providers field — deferred
+
+The task description proposes a `pi_providers = [...]` config field that the plugin would translate to nono `network.credentials` AND to env-var filtering (option a/b/c). Skipped for now in favor of the simpler custom-level escape hatch:
+
+- Pros of skipping: no plugin schema change, no dynamic profile synthesis, no env-passthrough filter logic. Users with non-standard providers (mistral/groq/deepseek/Bedrock/etc.) ship a custom JSON profile and a `sandbox_level="<custom>"`.
+- Cons of skipping: AC #1, #2, #3, #4, #5 are NOT met as written — paranoid behavior is fixed at install time (anthropic/openai/gemini) rather than user-configurable per agent.
+- Recommendation: re-open `pi_providers` as a separate task once we have user demand. Implementation would touch `AgentTypeConfig` (Rust), `synthesize_sandboxed_command` (env-unset prefix in the bash wrapper), and a runtime nono-profile-template mechanism. ~150-300 LOC across 3 files, ~half-day of work.
+
+## Verification done
+
+- All TOML/JSON parse.
+- WASM plugin builds clean.
+- `apply-sandbox-levels.py paranoid,permissive` correctly emits `pi-paranoid` and `pi-permissive`.
+
+Master doc page extension deferred (no docs tree yet).
 <!-- SECTION:NOTES:END -->

--- a/docs/documentation/dashboard/sandbox-levels.md
+++ b/docs/documentation/dashboard/sandbox-levels.md
@@ -221,7 +221,7 @@ docker: command not found
 
 ## 3. How to choose a level
 
-- **paranoid** when you are running an agent on an untrusted prompt, an unfamiliar repository, or any input you wouldn't paste into a root shell. The agent still does its job for the LLM API path; everything else is denied.
+- **paranoid** when you are running an agent on an untrusted prompt, an unfamiliar repository, or any input you wouldn't paste into a root shell. The agent still does its job for the LLM API path; everything else is denied. Paranoid requires an **API key on the host** (e.g. `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`) so the credential proxy has something to inject — OAuth/browser-login flows (gemini's Google sign-in, claude's `/login`) deposit a refresh token in the agent's config dir but leave no key in the env, which paranoid cannot use. If your agent is authenticated via OAuth, pick `normal` or `permissive` instead, or switch the agent to API-key auth before running paranoid. See §8 for per-agent specifics.
 - **normal** for daily work on your own code, where you want the agent to read/write the project, talk to its model, and not much else. This is the right default for most users most of the time.
 - **permissive** when you specifically need the agent to inspect or open PRs against GitHub and you accept that `~/.config/gh` is now visible inside the sandbox. The trade-off is real: a prompt-injected agent at this level can read your `gh` token and act as you on GitHub, scoped to whatever permissions that token holds.
 - **custom** (see below) when none of the three fit — for example if you need AWS Bedrock, a private Hugging Face mirror, or a corporate proxy.
@@ -418,6 +418,33 @@ The result is identical to the user: the agent sees its own auth/state at startu
 - **`lince-codex-with-aws`** — same pattern as the Claude + Bedrock example in §6; replace the `credentials` entry with whatever Bedrock auth scheme your codex setup uses, and grant read access to `~/.aws` for the SDK.
 
 For the master mechanics (file-naming convention, append-merge semantics, choosing a backend), see §4 and §6 above — those rules apply unchanged to codex.
+
+### 7.2 Gemini (Google)
+
+Gemini's level mappings follow the same shape as Claude's, with one important caveat around authentication.
+
+| Aspect                                  | paranoid                                  | normal                         | permissive                                              |
+|-----------------------------------------|-------------------------------------------|--------------------------------|---------------------------------------------------------|
+| Network (allowed destinations)          | `generativelanguage.googleapis.com` only  | inherited base                 | + GitHub + gh CLI domains                               |
+| Auth supported                          | **API key only** (`GEMINI_API_KEY` / `GOOGLE_API_KEY`) | API key OR OAuth     | API key OR OAuth                                        |
+| Filesystem (`~/.gemini`)                | per-run ephemeral scratch                 | as today                       | as today + read on `~/.config/gh`, `~/.cache`, `~/.ssh/known_hosts` |
+| `gh` CLI                                | no                                        | no                             | yes                                                     |
+
+**Paranoid requires API-key auth.** The credential proxy works by injecting an `x-goog-api-key` header on outbound HTTPS to `generativelanguage.googleapis.com`; it needs the key on the host side at startup. The browser/OAuth login flow gemini ships with deposits a refresh token in `~/.gemini/oauth_creds.json` but does **not** set `GEMINI_API_KEY` in your shell. The shipped `sandbox/profiles/gemini-paranoid.toml` auto-maps both `GEMINI_API_KEY` and `GOOGLE_API_KEY` (deduped to the same domain) — if neither is set in the host env, `_collect_proxy_rules` drops both and the paranoid bail-out fires with a clear `Note: gemini OAuth/browser-login users...` line.
+
+Two ways to use gemini paranoid:
+
+1. **Switch to API-key auth.** Get a key from <https://aistudio.google.com/apikey> and `export GEMINI_API_KEY='AIza...'` before launching the dashboard. The paranoid fragment auto-maps it; the proxy injects it on outbound calls and gemini never sees the raw value inside the sandbox.
+2. **Stay on OAuth, drop to `normal` or `permissive`.** Both levels keep `~/.gemini/` accessible and let gemini refresh its OAuth token against `oauth2.googleapis.com` directly. You lose the kernel network isolation paranoid offers, but OAuth keeps working.
+
+The paranoid fragment intentionally does **not** allowlist `accounts.google.com` / `oauth2.googleapis.com`. Doing so would let a prompt-injected agent at paranoid speak to broad Google OAuth infrastructure (account discovery, scope-elevation flows) — a bigger trust boundary than just talking to the model API. Users who explicitly want OAuth + paranoid can extend `[security].allow_domains` in their own `~/.agent-sandbox/config.toml`, but that is an opt-in trade-off documented per-user, not the shipped default.
+
+**Common custom levels for gemini.**
+
+- **Vertex AI users**: ship `lince-gemini-vertex.json` extending `lince-gemini` with `network.allow_domain = ["aiplatform.googleapis.com"]` and the appropriate Vertex credential. Skip the GenLang credential rule and rely on Vertex's own auth.
+- **API-key user who also wants gh**: just use `permissive` — it adds the GitHub allowlist on top of the gemini API.
+
+For master mechanics (file-naming convention, fragment lookup, custom levels), see §4 and §6.
 
 ## 9. Future work
 

--- a/docs/documentation/dashboard/sandbox-levels.md
+++ b/docs/documentation/dashboard/sandbox-levels.md
@@ -221,7 +221,7 @@ docker: command not found
 
 ## 3. How to choose a level
 
-- **paranoid** when you are running an agent on an untrusted prompt, an unfamiliar repository, or any input you wouldn't paste into a root shell. The agent still does its job for the LLM API path; everything else is denied. Paranoid requires an **API key on the host** (e.g. `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`) so the credential proxy has something to inject — OAuth/browser-login flows (gemini's Google sign-in, claude's `/login`) deposit a refresh token in the agent's config dir but leave no key in the env, which paranoid cannot use. If your agent is authenticated via OAuth, pick `normal` or `permissive` instead, or switch the agent to API-key auth before running paranoid. See §8 for per-agent specifics.
+- **paranoid** when you are running an agent on an untrusted prompt, an unfamiliar repository, or any input you wouldn't paste into a root shell. The agent still does its job for the LLM API path; everything else is denied. Paranoid requires an **API key on the host** (e.g. `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`) so the credential proxy has something to inject — OAuth/browser-login flows put the token inside the sandbox, breaking paranoid's "credentials never in the sandbox" guarantee. If your agent is OAuth-authenticated, pick `normal` or `permissive` instead, or switch the agent to API-key auth. The trust-model rationale and an opt-out recipe (with risks spelled out) live in §6, "Trust model: why paranoid requires API-key auth (and how to opt out)". See §8 for per-agent specifics.
 - **normal** for daily work on your own code, where you want the agent to read/write the project, talk to its model, and not much else. This is the right default for most users most of the time.
 - **permissive** when you specifically need the agent to inspect or open PRs against GitHub and you accept that `~/.config/gh` is now visible inside the sandbox. The trade-off is real: a prompt-injected agent at this level can read your `gh` token and act as you on GitHub, scoped to whatever permissions that token holds.
 - **custom** (see below) when none of the three fit — for example if you need AWS Bedrock, a private Hugging Face mirror, or a corporate proxy.
@@ -350,6 +350,111 @@ agent-sandbox run --sandbox-level paranoid <command>
 
 The resolved config is paranoid + the two extra hosts: kernel netns isolation is unchanged, the proxy allowlist becomes `["api.anthropic.com", "pypi.org", "files.pythonhosted.org"]`, and `pip install` resolves through the proxy. This works because `allow_domains` is append-merged with the paranoid fragment's list, not overwritten.
 
+### Trust model: why paranoid requires API-key auth (and how to opt out)
+
+Paranoid is built around one specific assumption: **the agent's credentials never enter the sandbox process tree**. The flow is:
+
+1. The user puts an API key on the host — env var (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, etc.) or keystore entry.
+2. The credential proxy runs **on the host** (outside the sandbox), reads the key, and listens on a unix socket bind-mounted into the sandbox.
+3. The agent inside the sandbox sees `HTTP_PROXY=http://127.0.0.1:8118` and routes outbound HTTPS through it. The proxy strips the agent's own copy of the key from `[env]` and rewrites `*_BASE_URL` to point at itself.
+4. The proxy injects the `Authorization` / `x-api-key` / `x-goog-api-key` header on the **host side** as the request flows through.
+5. Inside the sandbox, `printenv | grep _API_KEY` returns nothing.
+
+That last point is what makes paranoid stronger than "kernel netns + host allowlist" alone: even if the agent is prompt-injected and tries to exfiltrate credentials by encoding them in a model response, a tool-call argument, or a written file, **there are no credentials to read**. The host-side proxy is the only thing that holds them, and the proxy doesn't echo them back.
+
+OAuth/browser-login auth violates that assumption by design. The flow is:
+
+- The agent (gemini's Google sign-in, claude's `/login`, codex configured for ChatGPT-token auth, etc.) does an interactive browser login and stores a **refresh token + access token** in its config dir: `~/.gemini/oauth_creds.json`, `~/.claude/.credentials.json`, similar.
+- That config dir is mounted into the sandbox so the agent can read its own auth state. In paranoid this is a per-run scratch copy (rsync-seeded from the real one), but it still contains the real tokens — the scratch is a *filesystem* isolation, not a *credential* isolation.
+- The agent reads the file at startup, sets `Authorization: Bearer <oauth-token>` itself, and sends requests directly. The credential proxy doesn't inject — there's nothing for it to inject — and crucially, **the bearer token now lives inside the sandbox process tree** for the lifetime of the run.
+
+A prompt-injected agent at "paranoid + OAuth" can:
+
+- Read the on-disk refresh + access token from its config scratch.
+- Encode the bytes into a model response (the LLM API host is allowlisted; that's the whole point of paranoid). The attacker on the other end of the LLM session reads the response and recovers the token.
+- Use the recovered token from any other machine until it's rotated/revoked. Refresh tokens for these providers typically last days to months.
+
+Compared to the API-key setup:
+
+| Property                                              | API-key paranoid | OAuth paranoid (bypass) |
+|-------------------------------------------------------|------------------|-------------------------|
+| Kernel network isolation (netns / Landlock)           | ✅                | ✅                       |
+| Application-layer host allowlist                      | ✅                | ✅                       |
+| Filesystem isolation of config dir (per-run scratch)  | ✅                | ✅                       |
+| Credentials never enter the sandbox process tree      | ✅                | **❌**                   |
+| Prompt-injected agent can exfiltrate via the LLM path | no                | yes                     |
+
+That last row is the entire reason paranoid exists. If you opt into the bypass, you keep the network and filesystem isolation but lose the credential isolation. The shipped paranoid fragments therefore only auto-map API keys and bail out when none is set — picking `normal` or `permissive` for OAuth users is the **safer** path; those levels don't claim "no credentials in the sandbox" so OAuth fits their model honestly.
+
+#### How to opt out (if you really want OAuth + paranoid)
+
+This recipe is generic — it works for any agent (gemini, claude, codex, opencode, pi). You're trading the credential-isolation guarantee for kernel network isolation while keeping OAuth.
+
+The gate that bails paranoid when no credential rule fires (`Error: [security] unshare_net = true requires at least one credential rule...`) is the only blocker today. Two ways around it:
+
+**(a) Carry a real API key on the host as a "starter".** Set the agent's API-key env var on the host even though the agent itself authenticates via OAuth. The proxy uses the key to satisfy the startup gate; the agent uses its OAuth bearer at runtime; both auth headers reach the model server (`Authorization: Bearer <oauth>` + the proxy-injected key header). For Google APIs the OAuth bearer takes precedence; for other providers, behavior depends on how the server resolves dual-auth — verify with a non-trivial request (e.g. a model call) before trusting the setup.
+
+```bash
+# Even if gemini uses OAuth, set this so paranoid starts.
+# Use a real key from your provider; a placeholder will fail at the
+# server-side validation step inside the proxy.
+export GEMINI_API_KEY='AIza...'
+zd
+```
+
+**(b) Ship a custom level that adds the OAuth refresh endpoints to `allow_domains`.** This gives the agent a path to refresh its OAuth token on top of the model API. Append to your `~/.agent-sandbox/config.toml` (bwrap) and ship a matching nono profile:
+
+```toml
+# ~/.agent-sandbox/config.toml — applies to *every* paranoid run
+[security]
+allow_domains = [
+    # Google OAuth (gemini browser login, Vertex AI, etc.)
+    "accounts.google.com",
+    "oauth2.googleapis.com",
+    # Anthropic OAuth (claude /login)
+    "console.anthropic.com",
+    # Add your provider's OAuth refresh endpoints here.
+]
+```
+
+```json
+// ~/.config/nono/profiles/lince-<agent>-paranoid-oauth.json
+{
+  "extends": "lince-<agent>-paranoid",
+  "meta": {
+    "name": "lince-<agent>-paranoid-oauth",
+    "description": "Paranoid + OAuth refresh allowlist — credentials live in the sandbox; see sandbox-levels.md trust model section."
+  },
+  "network": {
+    "allow_domain": [
+      "accounts.google.com",
+      "oauth2.googleapis.com",
+      "console.anthropic.com"
+    ]
+  }
+}
+```
+
+Then activate it on a specific agent:
+
+```toml
+# ~/.config/lince-dashboard/config.toml
+[agents.gemini]
+sandbox_level = "paranoid-oauth"
+```
+
+You still need (a) — the credential-rule gate fires before `allow_domains` is consulted, so paranoid won't even start without a key on the host. The two together give you: kernel netns isolation + model API allowlist + OAuth refresh allowlist, with OAuth bearer tokens visible to the agent process tree.
+
+#### Risks summary, plain language
+
+By using either path above, you accept that:
+
+- **A prompt-injected agent at paranoid + OAuth can exfiltrate your refresh token** via the model API endpoint — the only thing standing between an attacker and the token is the LLM session itself. Recovery from a leaked refresh token usually means revoking the OAuth grant in the provider's dashboard and re-authenticating.
+- **The "credentials never in the sandbox" property is gone.** Paranoid + OAuth is *not* equivalent to paranoid + API-key for credential-handling purposes. Don't claim it is in security reviews or threat models.
+- **Refresh-token blast radius depends on the provider's scope rules.** A Gemini refresh token is normally scoped to Generative Language API only; an Anthropic OAuth token covers claude.ai and the API; a `gh` OAuth token covers your full GitHub. Match the level you choose to the worst case for the token you're putting at risk.
+
+If those trade-offs are unacceptable for your threat model, switch the agent to API-key auth (the proper paranoid path) or drop to `normal` / `permissive` (which don't promise credential isolation in the first place).
+
 ## 7. Keystore setup for paranoid
 
 Paranoid relies on the Anthropic API key being in nono's credential keystore — **not** in `ANTHROPIC_API_KEY` in your environment. The point is that the key never enters the sandbox process tree; nono injects the `Authorization` header on the host side as the request flows through the credential proxy.
@@ -432,12 +537,12 @@ Gemini's level mappings follow the same shape as Claude's, with one important ca
 
 **Paranoid requires API-key auth.** The credential proxy works by injecting an `x-goog-api-key` header on outbound HTTPS to `generativelanguage.googleapis.com`; it needs the key on the host side at startup. The browser/OAuth login flow gemini ships with deposits a refresh token in `~/.gemini/oauth_creds.json` but does **not** set `GEMINI_API_KEY` in your shell. The shipped `sandbox/profiles/gemini-paranoid.toml` auto-maps both `GEMINI_API_KEY` and `GOOGLE_API_KEY` (deduped to the same domain) — if neither is set in the host env, `_collect_proxy_rules` drops both and the paranoid bail-out fires with a clear `Note: gemini OAuth/browser-login users...` line.
 
-Two ways to use gemini paranoid:
+Two recommended paths:
 
 1. **Switch to API-key auth.** Get a key from <https://aistudio.google.com/apikey> and `export GEMINI_API_KEY='AIza...'` before launching the dashboard. The paranoid fragment auto-maps it; the proxy injects it on outbound calls and gemini never sees the raw value inside the sandbox.
 2. **Stay on OAuth, drop to `normal` or `permissive`.** Both levels keep `~/.gemini/` accessible and let gemini refresh its OAuth token against `oauth2.googleapis.com` directly. You lose the kernel network isolation paranoid offers, but OAuth keeps working.
 
-The paranoid fragment intentionally does **not** allowlist `accounts.google.com` / `oauth2.googleapis.com`. Doing so would let a prompt-injected agent at paranoid speak to broad Google OAuth infrastructure (account discovery, scope-elevation flows) — a bigger trust boundary than just talking to the model API. Users who explicitly want OAuth + paranoid can extend `[security].allow_domains` in their own `~/.agent-sandbox/config.toml`, but that is an opt-in trade-off documented per-user, not the shipped default.
+The paranoid fragment intentionally does **not** allowlist `accounts.google.com` / `oauth2.googleapis.com` because the OAuth refresh path puts the bearer token inside the sandbox process tree, breaking paranoid's credential-isolation guarantee. If you understand the trade-off and still want OAuth + paranoid, follow the generic opt-out recipe in §6 — it works for gemini exactly the same way it works for any other agent (set `GEMINI_API_KEY` on the host as the startup ticket, then add the two Google OAuth domains to `[security].allow_domains`).
 
 **Common custom levels for gemini.**
 

--- a/lince-dashboard/agents-defaults.toml
+++ b/lince-dashboard/agents-defaults.toml
@@ -12,8 +12,7 @@
 #   {project_dir} - project directory path
 #   {profile}     - sandbox profile name
 #
-# Sandbox model (claude + codex; gemini/opencode/pi land in follow-up
-# tasks lince-100..102):
+# Sandbox model (claude, codex, gemini, opencode, pi):
 #   - sandbox_backend = "bwrap" | "nono"  (default per OS)
 #   - sandbox_level   = "paranoid" | "normal" | "permissive" | <custom>
 # When sandbox_level is set, the plugin synthesizes the launch command from
@@ -99,217 +98,97 @@ profiles = ["__discover__"]
 OPENAI_API_KEY = "$OPENAI_API_KEY"
 
 [agents.gemini]
-command = ["gemini"]
-pane_title_pattern = "gemini"
+# Legacy fallback command — ignored when sandbox_level is set.
+command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}", "--agent", "gemini"]
+pane_title_pattern = "agent-sandbox"
 status_pipe_name = "lince-status"
 display_name = "Google Gemini CLI"
 short_label = "GEM"
-color = "yellow"
-sandboxed = false
+color = "blue"
+sandboxed = true
 has_native_hooks = false
+bwrap_conflict = false
 disable_inner_sandbox_args = []
+home_ro_dirs = ["~/.gemini/"]
 profiles = ["__discover__"]
+sandbox_level = "normal"          # paranoid | normal | permissive (or custom; see docs)
+# sandbox_backend defaults to bwrap on Linux, nono on macOS. Uncomment to override:
+# sandbox_backend = "nono"
 
 [agents.gemini.env_vars]
 GEMINI_API_KEY = "$GEMINI_API_KEY"
 
-[agents.gemini-bwrap]
-command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}", "--agent", "gemini"]
-pane_title_pattern = "agent-sandbox"
+[agents.gemini-unsandboxed]
+command = ["gemini"]
+pane_title_pattern = "gemini"
 status_pipe_name = "lince-status"
-display_name = "Google Gemini CLI (sandboxed)"
-short_label = "GEM"
-color = "yellow"
-sandboxed = true
+display_name = "Google Gemini CLI (unsandboxed)"
+short_label = "GEU"
+color = "red"
+sandboxed = false
 has_native_hooks = false
-bwrap_conflict = false
 disable_inner_sandbox_args = []
-home_ro_dirs = ["~/.gemini/"]
 profiles = ["__discover__"]
 
-[agents.gemini-bwrap.env_vars]
+[agents.gemini-unsandboxed.env_vars]
 GEMINI_API_KEY = "$GEMINI_API_KEY"
 
 [agents.opencode]
-command = ["opencode"]
-pane_title_pattern = "opencode"
-status_pipe_name = "lince-status"
-display_name = "OpenCode"
-short_label = "OPC"
-color = "green"
-sandboxed = false
-has_native_hooks = false
-home_ro_dirs = ["~/.config/opencode/"]
-profiles = ["__discover__"]
-
-[agents.opencode-bwrap]
+# Legacy fallback command — ignored when sandbox_level is set.
 command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}", "--agent", "opencode"]
 pane_title_pattern = "agent-sandbox"
 status_pipe_name = "lince-status"
-display_name = "OpenCode (sandboxed)"
+display_name = "OpenCode"
 short_label = "OPC"
-color = "green"
+color = "blue"
 sandboxed = true
 has_native_hooks = false
 bwrap_conflict = false
 disable_inner_sandbox_args = []
 home_ro_dirs = ["~/.config/opencode/"]
 profiles = ["__discover__"]
+sandbox_level = "normal"          # paranoid | normal | permissive (or custom; see docs)
+# sandbox_backend defaults to bwrap on Linux, nono on macOS. Uncomment to override:
+# sandbox_backend = "nono"
 
-# ── nono-sandboxed variants ─────────────────────────────────────────
-# nono uses Landlock LSM on Linux and Seatbelt on macOS.
-# Profiles are named "lince-<agent>" and managed by `agent-sandbox nono-sync`.
-#
-# NOTE: claude and codex no longer have separate `*-nono` entries — they
-# have been collapsed into [agents.claude] / [agents.codex] above (use
-# `sandbox_backend = "nono"` to force the nono backend on Linux). The
-# gemini/opencode/pi entries below will follow the same migration in
-# lince-100..102.
-
-[agents.gemini-nono]
-command = ["nono", "run", "--profile", "lince-gemini", "--workdir", "{project_dir}", "--", "gemini"]
-pane_title_pattern = "nono"
+[agents.opencode-unsandboxed]
+command = ["opencode"]
+pane_title_pattern = "opencode"
 status_pipe_name = "lince-status"
-display_name = "Google Gemini CLI (nono)"
-short_label = "GEM"
-color = "yellow"
-sandboxed = true
+display_name = "OpenCode (unsandboxed)"
+short_label = "OPU"
+color = "red"
+sandboxed = false
 has_native_hooks = false
-sandbox_backend = "nono"
-bwrap_conflict = false
-disable_inner_sandbox_args = []
-home_ro_dirs = ["~/.gemini/"]
-profiles = ["__discover__"]
-
-[agents.gemini-nono.env_vars]
-GEMINI_API_KEY = "$GEMINI_API_KEY"
-
-[agents.opencode-nono]
-# Bun-based binaries crash (SIGABRT) when spawned as subprocesses under Landlock.
-# Resolve the native binary and exec it directly, bypassing the Node.js launcher's
-# spawnSync which triggers the Bun/Landlock incompatibility.
-command = ["nono", "run", "--profile", "lince-opencode", "--workdir", "{project_dir}", "--", "bash", "-c", "exec \"$(dirname \"$(readlink -f \"$(which opencode)\")\")/.opencode\" \"$@\"", "--"]
-pane_title_pattern = "nono"
-status_pipe_name = "lince-status"
-display_name = "OpenCode (nono)"
-short_label = "OPC"
-color = "green"
-sandboxed = true
-has_native_hooks = false
-sandbox_backend = "nono"
-bwrap_conflict = false
-disable_inner_sandbox_args = []
 home_ro_dirs = ["~/.config/opencode/"]
 profiles = ["__discover__"]
 
 [agents.pi]
-command = ["pi"]
-pane_title_pattern = "pi"
-status_pipe_name = "lince-status"
-display_name = "Pi"
-short_label = "PI "
-color = "magenta"
-sandboxed = false
-has_native_hooks = true
-home_ro_dirs = ["~/.pi/"]
-profiles = ["__discover__"]
-
-[agents.pi.env_vars]
-ANTHROPIC_API_KEY = "$ANTHROPIC_API_KEY"
-ANTHROPIC_BASE_URL = "$ANTHROPIC_BASE_URL"
-OPENAI_API_KEY = "$OPENAI_API_KEY"
-OPENAI_BASE_URL = "$OPENAI_BASE_URL"
-AZURE_OPENAI_API_KEY = "$AZURE_OPENAI_API_KEY"
-AZURE_OPENAI_BASE_URL = "$AZURE_OPENAI_BASE_URL"
-GEMINI_API_KEY = "$GEMINI_API_KEY"
-GOOGLE_CLOUD_PROJECT = "$GOOGLE_CLOUD_PROJECT"
-GOOGLE_CLOUD_LOCATION = "$GOOGLE_CLOUD_LOCATION"
-DEEPSEEK_API_KEY = "$DEEPSEEK_API_KEY"
-MISTRAL_API_KEY = "$MISTRAL_API_KEY"
-GROQ_API_KEY = "$GROQ_API_KEY"
-CEREBRAS_API_KEY = "$CEREBRAS_API_KEY"
-CLOUDFLARE_API_KEY = "$CLOUDFLARE_API_KEY"
-CLOUDFLARE_ACCOUNT_ID = "$CLOUDFLARE_ACCOUNT_ID"
-XAI_API_KEY = "$XAI_API_KEY"
-OPENROUTER_API_KEY = "$OPENROUTER_API_KEY"
-AI_GATEWAY_API_KEY = "$AI_GATEWAY_API_KEY"
-ZAI_API_KEY = "$ZAI_API_KEY"
-OPENCODE_API_KEY = "$OPENCODE_API_KEY"
-FIREWORKS_API_KEY = "$FIREWORKS_API_KEY"
-KIMI_API_KEY = "$KIMI_API_KEY"
-MINIMAX_API_KEY = "$MINIMAX_API_KEY"
-MINIMAX_CN_API_KEY = "$MINIMAX_CN_API_KEY"
-AWS_PROFILE = "$AWS_PROFILE"
-AWS_REGION = "$AWS_REGION"
-AWS_ACCESS_KEY_ID = "$AWS_ACCESS_KEY_ID"
-AWS_SECRET_ACCESS_KEY = "$AWS_SECRET_ACCESS_KEY"
-AWS_SESSION_TOKEN = "$AWS_SESSION_TOKEN"
-AWS_BEARER_TOKEN_BEDROCK = "$AWS_BEARER_TOKEN_BEDROCK"
-AWS_ENDPOINT_URL_BEDROCK_RUNTIME = "$AWS_ENDPOINT_URL_BEDROCK_RUNTIME"
-
-[agents.pi-bwrap]
+# Legacy fallback command — ignored when sandbox_level is set.
 command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}", "--agent", "pi"]
 pane_title_pattern = "agent-sandbox"
 status_pipe_name = "lince-status"
-display_name = "Pi (sandboxed)"
+display_name = "Pi"
 short_label = "PI "
-color = "magenta"
+color = "blue"
 sandboxed = true
 has_native_hooks = true
 bwrap_conflict = false
 disable_inner_sandbox_args = []
 home_ro_dirs = ["~/.pi/"]
 profiles = ["__discover__"]
+sandbox_level = "normal"          # paranoid | normal | permissive (or custom; see docs)
+# sandbox_backend defaults to bwrap on Linux, nono on macOS. Uncomment to override:
+# sandbox_backend = "nono"
 
-[agents.pi-bwrap.env_vars]
-ANTHROPIC_API_KEY = "$ANTHROPIC_API_KEY"
-ANTHROPIC_BASE_URL = "$ANTHROPIC_BASE_URL"
-OPENAI_API_KEY = "$OPENAI_API_KEY"
-OPENAI_BASE_URL = "$OPENAI_BASE_URL"
-AZURE_OPENAI_API_KEY = "$AZURE_OPENAI_API_KEY"
-AZURE_OPENAI_BASE_URL = "$AZURE_OPENAI_BASE_URL"
-GEMINI_API_KEY = "$GEMINI_API_KEY"
-GOOGLE_CLOUD_PROJECT = "$GOOGLE_CLOUD_PROJECT"
-GOOGLE_CLOUD_LOCATION = "$GOOGLE_CLOUD_LOCATION"
-DEEPSEEK_API_KEY = "$DEEPSEEK_API_KEY"
-MISTRAL_API_KEY = "$MISTRAL_API_KEY"
-GROQ_API_KEY = "$GROQ_API_KEY"
-CEREBRAS_API_KEY = "$CEREBRAS_API_KEY"
-CLOUDFLARE_API_KEY = "$CLOUDFLARE_API_KEY"
-CLOUDFLARE_ACCOUNT_ID = "$CLOUDFLARE_ACCOUNT_ID"
-XAI_API_KEY = "$XAI_API_KEY"
-OPENROUTER_API_KEY = "$OPENROUTER_API_KEY"
-AI_GATEWAY_API_KEY = "$AI_GATEWAY_API_KEY"
-ZAI_API_KEY = "$ZAI_API_KEY"
-OPENCODE_API_KEY = "$OPENCODE_API_KEY"
-FIREWORKS_API_KEY = "$FIREWORKS_API_KEY"
-KIMI_API_KEY = "$KIMI_API_KEY"
-MINIMAX_API_KEY = "$MINIMAX_API_KEY"
-MINIMAX_CN_API_KEY = "$MINIMAX_CN_API_KEY"
-AWS_PROFILE = "$AWS_PROFILE"
-AWS_REGION = "$AWS_REGION"
-AWS_ACCESS_KEY_ID = "$AWS_ACCESS_KEY_ID"
-AWS_SECRET_ACCESS_KEY = "$AWS_SECRET_ACCESS_KEY"
-AWS_SESSION_TOKEN = "$AWS_SESSION_TOKEN"
-AWS_BEARER_TOKEN_BEDROCK = "$AWS_BEARER_TOKEN_BEDROCK"
-AWS_ENDPOINT_URL_BEDROCK_RUNTIME = "$AWS_ENDPOINT_URL_BEDROCK_RUNTIME"
+# Pi multi-provider note: `lince-pi-paranoid.json` only allowlists the
+# providers nono knows about (anthropic, openai, gemini). For other
+# providers (mistral, groq, deepseek, AWS Bedrock, ...) ship a custom
+# level: copy the JSON to ~/.config/nono/profiles/lince-pi-<custom>.json,
+# extend `network.allow_domain` + `environment.passthrough`, then set
+# `sandbox_level = "<custom>"` here. See sandbox-levels.md.
 
-[agents.pi-nono]
-command = ["nono", "run", "--profile", "lince-pi", "--workdir", "{project_dir}", "--", "pi"]
-pane_title_pattern = "nono"
-status_pipe_name = "lince-status"
-display_name = "Pi (nono)"
-short_label = "PI "
-color = "magenta"
-sandboxed = true
-has_native_hooks = true
-sandbox_backend = "nono"
-bwrap_conflict = false
-disable_inner_sandbox_args = []
-home_ro_dirs = ["~/.pi/"]
-profiles = ["__discover__"]
-
-[agents.pi-nono.env_vars]
+[agents.pi.env_vars]
 ANTHROPIC_API_KEY = "$ANTHROPIC_API_KEY"
 ANTHROPIC_BASE_URL = "$ANTHROPIC_BASE_URL"
 OPENAI_API_KEY = "$OPENAI_API_KEY"

--- a/lince-dashboard/agents-template.toml
+++ b/lince-dashboard/agents-template.toml
@@ -90,3 +90,150 @@ sandbox_level = "permissive"
 
 [agents.codex-permissive.env_vars]
 OPENAI_API_KEY = "$OPENAI_API_KEY"
+
+# ── Gemini ──────────────────────────────────────────────────────────
+
+[agents.gemini-paranoid]
+command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}", "--agent", "gemini"]
+pane_title_pattern = "agent-sandbox"
+status_pipe_name = "lince-status"
+display_name = "Google Gemini CLI (paranoid)"
+short_label = "GEP"
+color = "green"
+sandboxed = true
+has_native_hooks = false
+bwrap_conflict = false
+disable_inner_sandbox_args = []
+home_ro_dirs = ["~/.gemini/"]
+profiles = ["__discover__"]
+sandbox_level = "paranoid"
+
+[agents.gemini-paranoid.env_vars]
+GEMINI_API_KEY = "$GEMINI_API_KEY"
+
+[agents.gemini-permissive]
+command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}", "--agent", "gemini"]
+pane_title_pattern = "agent-sandbox"
+status_pipe_name = "lince-status"
+display_name = "Google Gemini CLI (permissive)"
+short_label = "GE+"
+color = "yellow"
+sandboxed = true
+has_native_hooks = false
+bwrap_conflict = false
+disable_inner_sandbox_args = []
+home_ro_dirs = ["~/.gemini/"]
+profiles = ["__discover__"]
+sandbox_level = "permissive"
+
+[agents.gemini-permissive.env_vars]
+GEMINI_API_KEY = "$GEMINI_API_KEY"
+
+# ── OpenCode ────────────────────────────────────────────────────────
+
+[agents.opencode-paranoid]
+command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}", "--agent", "opencode"]
+pane_title_pattern = "agent-sandbox"
+status_pipe_name = "lince-status"
+display_name = "OpenCode (paranoid)"
+short_label = "OPP"
+color = "green"
+sandboxed = true
+has_native_hooks = false
+bwrap_conflict = false
+disable_inner_sandbox_args = []
+home_ro_dirs = ["~/.config/opencode/"]
+profiles = ["__discover__"]
+sandbox_level = "paranoid"
+
+[agents.opencode-permissive]
+command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}", "--agent", "opencode"]
+pane_title_pattern = "agent-sandbox"
+status_pipe_name = "lince-status"
+display_name = "OpenCode (permissive)"
+short_label = "OP+"
+color = "yellow"
+sandboxed = true
+has_native_hooks = false
+bwrap_conflict = false
+disable_inner_sandbox_args = []
+home_ro_dirs = ["~/.config/opencode/"]
+profiles = ["__discover__"]
+sandbox_level = "permissive"
+
+# ── Pi ──────────────────────────────────────────────────────────────
+
+[agents.pi-paranoid]
+command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}", "--agent", "pi"]
+pane_title_pattern = "agent-sandbox"
+status_pipe_name = "lince-status"
+display_name = "Pi (paranoid)"
+short_label = "PIP"
+color = "green"
+sandboxed = true
+has_native_hooks = true
+bwrap_conflict = false
+disable_inner_sandbox_args = []
+home_ro_dirs = ["~/.pi/"]
+profiles = ["__discover__"]
+sandbox_level = "paranoid"
+
+# Pi paranoid covers anthropic, openai, gemini (the providers nono and
+# the agent-sandbox credential proxy know about). For other providers
+# (mistral, groq, deepseek, AWS Bedrock, ...) ship a custom level — see
+# the comment in agents-defaults.toml's [agents.pi] block.
+
+[agents.pi-paranoid.env_vars]
+ANTHROPIC_API_KEY = "$ANTHROPIC_API_KEY"
+ANTHROPIC_BASE_URL = "$ANTHROPIC_BASE_URL"
+OPENAI_API_KEY = "$OPENAI_API_KEY"
+OPENAI_BASE_URL = "$OPENAI_BASE_URL"
+GEMINI_API_KEY = "$GEMINI_API_KEY"
+
+[agents.pi-permissive]
+command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}", "--agent", "pi"]
+pane_title_pattern = "agent-sandbox"
+status_pipe_name = "lince-status"
+display_name = "Pi (permissive)"
+short_label = "PI+"
+color = "yellow"
+sandboxed = true
+has_native_hooks = true
+bwrap_conflict = false
+disable_inner_sandbox_args = []
+home_ro_dirs = ["~/.pi/"]
+profiles = ["__discover__"]
+sandbox_level = "permissive"
+
+[agents.pi-permissive.env_vars]
+ANTHROPIC_API_KEY = "$ANTHROPIC_API_KEY"
+ANTHROPIC_BASE_URL = "$ANTHROPIC_BASE_URL"
+OPENAI_API_KEY = "$OPENAI_API_KEY"
+OPENAI_BASE_URL = "$OPENAI_BASE_URL"
+AZURE_OPENAI_API_KEY = "$AZURE_OPENAI_API_KEY"
+AZURE_OPENAI_BASE_URL = "$AZURE_OPENAI_BASE_URL"
+GEMINI_API_KEY = "$GEMINI_API_KEY"
+GOOGLE_CLOUD_PROJECT = "$GOOGLE_CLOUD_PROJECT"
+GOOGLE_CLOUD_LOCATION = "$GOOGLE_CLOUD_LOCATION"
+DEEPSEEK_API_KEY = "$DEEPSEEK_API_KEY"
+MISTRAL_API_KEY = "$MISTRAL_API_KEY"
+GROQ_API_KEY = "$GROQ_API_KEY"
+CEREBRAS_API_KEY = "$CEREBRAS_API_KEY"
+CLOUDFLARE_API_KEY = "$CLOUDFLARE_API_KEY"
+CLOUDFLARE_ACCOUNT_ID = "$CLOUDFLARE_ACCOUNT_ID"
+XAI_API_KEY = "$XAI_API_KEY"
+OPENROUTER_API_KEY = "$OPENROUTER_API_KEY"
+AI_GATEWAY_API_KEY = "$AI_GATEWAY_API_KEY"
+ZAI_API_KEY = "$ZAI_API_KEY"
+OPENCODE_API_KEY = "$OPENCODE_API_KEY"
+FIREWORKS_API_KEY = "$FIREWORKS_API_KEY"
+KIMI_API_KEY = "$KIMI_API_KEY"
+MINIMAX_API_KEY = "$MINIMAX_API_KEY"
+MINIMAX_CN_API_KEY = "$MINIMAX_CN_API_KEY"
+AWS_PROFILE = "$AWS_PROFILE"
+AWS_REGION = "$AWS_REGION"
+AWS_ACCESS_KEY_ID = "$AWS_ACCESS_KEY_ID"
+AWS_SECRET_ACCESS_KEY = "$AWS_SECRET_ACCESS_KEY"
+AWS_SESSION_TOKEN = "$AWS_SESSION_TOKEN"
+AWS_BEARER_TOKEN_BEDROCK = "$AWS_BEARER_TOKEN_BEDROCK"
+AWS_ENDPOINT_URL_BEDROCK_RUNTIME = "$AWS_ENDPOINT_URL_BEDROCK_RUNTIME"

--- a/lince-dashboard/nono-profiles/lince-gemini-paranoid.json
+++ b/lince-dashboard/nono-profiles/lince-gemini-paranoid.json
@@ -1,0 +1,14 @@
+{
+  "extends": "lince-gemini",
+  "meta": {
+    "name": "lince-gemini-paranoid",
+    "description": "Gemini paranoid: only generativelanguage.googleapis.com via nono credential proxy; ~/.gemini isolated to a per-agent scratch HOME (rsync'd at spawn, deleted on stop). API-key auth only — OAuth users should use normal/permissive (paranoid does NOT allow accounts.google.com / oauth2.googleapis.com to keep the surface minimal)."
+  },
+  "filesystem": {
+    "allow": ["$WORKDIR", "$HOME"],
+    "read": []
+  },
+  "network": {
+    "credentials": ["gemini"]
+  }
+}

--- a/lince-dashboard/nono-profiles/lince-gemini-permissive.json
+++ b/lince-dashboard/nono-profiles/lince-gemini-permissive.json
@@ -1,0 +1,25 @@
+{
+  "extends": "lince-gemini",
+  "meta": {
+    "name": "lince-gemini-permissive",
+    "description": "Gemini permissive: Gemini API + GitHub allowlist (api.github.com, github.com, objects.githubusercontent.com); reads ~/.config/gh, ~/.cache, ~/.ssh/known_hosts so gh CLI works (no docker, no podman, no direct git push)."
+  },
+  "filesystem": {
+    "allow": ["$WORKDIR"],
+    "read": [
+      "$HOME/.config/gh",
+      "$HOME/.cache",
+      "$HOME/.ssh/known_hosts",
+      "$HOME/.local/lib"
+    ]
+  },
+  "network": {
+    "network_profile": "developer",
+    "credentials": ["gemini"],
+    "allow_domain": [
+      "api.github.com",
+      "github.com",
+      "objects.githubusercontent.com"
+    ]
+  }
+}

--- a/lince-dashboard/nono-profiles/lince-opencode-paranoid.json
+++ b/lince-dashboard/nono-profiles/lince-opencode-paranoid.json
@@ -1,0 +1,14 @@
+{
+  "extends": "lince-opencode",
+  "meta": {
+    "name": "lince-opencode-paranoid",
+    "description": "OpenCode paranoid: only the LLM providers known to nono's credential proxy (anthropic, openai, gemini) are reachable; ~/.config/opencode is isolated to a per-agent scratch HOME. The Bun/Landlock workaround (exec'ing the native .opencode binary) is preserved at the dashboard plugin level. For other providers (groq, mistral, deepseek, ...) ship a custom level — `network.credentials` here covers only the common subset."
+  },
+  "filesystem": {
+    "allow": ["$WORKDIR", "$HOME"],
+    "read": []
+  },
+  "network": {
+    "credentials": ["anthropic", "openai", "gemini"]
+  }
+}

--- a/lince-dashboard/nono-profiles/lince-opencode-permissive.json
+++ b/lince-dashboard/nono-profiles/lince-opencode-permissive.json
@@ -1,0 +1,25 @@
+{
+  "extends": "lince-opencode",
+  "meta": {
+    "name": "lince-opencode-permissive",
+    "description": "OpenCode permissive: common LLM providers (anthropic, openai, gemini) + GitHub allowlist; reads ~/.config/gh, ~/.cache, ~/.ssh/known_hosts so gh CLI works. No docker, no direct git push. The Bun/Landlock workaround is preserved at the dashboard plugin level."
+  },
+  "filesystem": {
+    "allow": ["$WORKDIR"],
+    "read": [
+      "$HOME/.config/gh",
+      "$HOME/.cache",
+      "$HOME/.ssh/known_hosts",
+      "$HOME/.local/lib"
+    ]
+  },
+  "network": {
+    "network_profile": "developer",
+    "credentials": ["anthropic", "openai", "gemini"],
+    "allow_domain": [
+      "api.github.com",
+      "github.com",
+      "objects.githubusercontent.com"
+    ]
+  }
+}

--- a/lince-dashboard/nono-profiles/lince-pi-paranoid.json
+++ b/lince-dashboard/nono-profiles/lince-pi-paranoid.json
@@ -1,0 +1,33 @@
+{
+  "extends": "lince-pi",
+  "meta": {
+    "name": "lince-pi-paranoid",
+    "description": "Pi paranoid: only LLM providers known to nono's credential proxy (anthropic, openai, gemini) are reachable; ~/.pi is isolated to a per-agent scratch HOME. Pi supports 18+ providers but only the three above ship with credential injection — for the others (mistral, groq, deepseek, cerebras, openrouter, AWS Bedrock, ...) ship a custom level fragment that extends `network.allow_domain`. environment.passthrough below is intentionally narrow: only the providers covered by credential injection cross into the sandbox."
+  },
+  "filesystem": {
+    "allow": ["$WORKDIR", "$HOME"],
+    "read": []
+  },
+  "network": {
+    "credentials": ["anthropic", "openai", "gemini"]
+  },
+  "environment": {
+    "passthrough": [
+      "TERM",
+      "COLORTERM",
+      "TERM_PROGRAM",
+      "LANG",
+      "LC_ALL",
+      "EDITOR",
+      "VISUAL",
+      "ZELLIJ",
+      "ZELLIJ_SESSION_NAME",
+      "LINCE_AGENT_ID",
+      "ANTHROPIC_API_KEY",
+      "ANTHROPIC_BASE_URL",
+      "OPENAI_API_KEY",
+      "OPENAI_BASE_URL",
+      "GEMINI_API_KEY"
+    ]
+  }
+}

--- a/lince-dashboard/nono-profiles/lince-pi-permissive.json
+++ b/lince-dashboard/nono-profiles/lince-pi-permissive.json
@@ -1,0 +1,25 @@
+{
+  "extends": "lince-pi",
+  "meta": {
+    "name": "lince-pi-permissive",
+    "description": "Pi permissive: full multi-provider env passthrough (all 18+ providers Pi supports) + GitHub allowlist; reads ~/.config/gh, ~/.cache, ~/.ssh/known_hosts so gh CLI works. No docker, no direct git push. environment.passthrough is inherited from lince-pi (extends)."
+  },
+  "filesystem": {
+    "allow": ["$WORKDIR"],
+    "read": [
+      "$HOME/.config/gh",
+      "$HOME/.cache",
+      "$HOME/.ssh/known_hosts",
+      "$HOME/.local/lib"
+    ]
+  },
+  "network": {
+    "network_profile": "developer",
+    "credentials": ["anthropic", "openai", "gemini"],
+    "allow_domain": [
+      "api.github.com",
+      "github.com",
+      "objects.githubusercontent.com"
+    ]
+  }
+}

--- a/lince-dashboard/plugin/src/agent.rs
+++ b/lince-dashboard/plugin/src/agent.rs
@@ -131,13 +131,9 @@ fn synthesize_sandboxed_command(
             ".codex",
         ),
         "gemini" => (vec!["gemini".to_string()], ".gemini"),
-        // Bun-based binaries crash (SIGABRT) when spawned as subprocesses
-        // under Landlock, which nono uses on Linux. Resolve the native
-        // .opencode binary on each launch and exec it directly, bypassing
-        // the Node.js launcher's spawnSync. The bwrap (agent-sandbox)
-        // backend doesn't use Landlock, so this wrapper is harmless there
-        // — but synthesize_sandboxed_command's bwrap branch goes through
-        // the agent-sandbox CLI and never sees inner_command anyway.
+        // Bun-based binaries SIGABRT when spawned under Landlock, so
+        // resolve and exec the native .opencode to skip the Node
+        // launcher's spawnSync.
         "opencode" => (
             vec![
                 "bash".to_string(),
@@ -179,26 +175,25 @@ fn synthesize_sandboxed_command(
                 .collect::<Vec<_>>()
                 .join(" ");
             if level == "paranoid" {
-                // Bash wrapper: mkdir scratch under $XDG_RUNTIME_DIR, rsync
-                // ~/.<agent>/ into it, run nono with HOME=scratch, rm scratch
-                // on EXIT. No `exec` so the trap fires. Caller-supplied values
-                // are shell_quote'd before substitution. `@@…@@` sentinels
-                // can't accidentally substring-overlap each other.
-                let bash = String::from(
+                // Bash wrapper: rsync ~/.<agent>/ into a scratch under
+                // $XDG_RUNTIME_DIR, run nono with HOME=scratch, rm scratch
+                // on EXIT. No `exec` so the EXIT trap fires. Caller-supplied
+                // values are shell_quote'd before substitution.
+                let bash = format!(
                     "set -e; \
-                     SCRATCH=\"${XDG_RUNTIME_DIR:-/tmp}/lince-@@AGENT_ID@@\"; \
-                     mkdir -p -- \"$SCRATCH/@@HOME_SUBDIR@@\"; \
+                     SCRATCH=\"${{XDG_RUNTIME_DIR:-/tmp}}/lince-{agent_id}\"; \
+                     mkdir -p -- \"$SCRATCH/{home_subdir}\"; \
                      trap 'rm -rf -- \"$SCRATCH\"' EXIT; \
-                     if [ -d \"$HOME/@@HOME_SUBDIR@@\" ]; then \
-                       rsync -a --delete -- \"$HOME/@@HOME_SUBDIR@@/\" \"$SCRATCH/@@HOME_SUBDIR@@/\"; \
+                     if [ -d \"$HOME/{home_subdir}\" ]; then \
+                       rsync -a --delete -- \"$HOME/{home_subdir}/\" \"$SCRATCH/{home_subdir}/\"; \
                      fi; \
-                     HOME=\"$SCRATCH\" nono run --profile @@NONO_PROFILE@@ --workdir @@PROJECT_DIR@@ -- @@INNER_COMMAND@@",
-                )
-                .replace("@@HOME_SUBDIR@@", agent_home_subdir)
-                .replace("@@AGENT_ID@@", &shell_quote(agent_id))
-                .replace("@@NONO_PROFILE@@", &shell_quote(&nono_profile))
-                .replace("@@PROJECT_DIR@@", &shell_quote(project_dir))
-                .replace("@@INNER_COMMAND@@", &inner_str);
+                     HOME=\"$SCRATCH\" nono run --profile {nono_profile} --workdir {project_dir} -- {inner}",
+                    agent_id = shell_quote(agent_id),
+                    home_subdir = agent_home_subdir,
+                    nono_profile = shell_quote(&nono_profile),
+                    project_dir = shell_quote(project_dir),
+                    inner = inner_str,
+                );
                 vec!["bash".to_string(), "-c".to_string(), bash]
             } else {
                 let mut cmd = vec![

--- a/lince-dashboard/plugin/src/agent.rs
+++ b/lince-dashboard/plugin/src/agent.rs
@@ -130,6 +130,25 @@ fn synthesize_sandboxed_command(
             ],
             ".codex",
         ),
+        "gemini" => (vec!["gemini".to_string()], ".gemini"),
+        // Bun-based binaries crash (SIGABRT) when spawned as subprocesses
+        // under Landlock, which nono uses on Linux. Resolve the native
+        // .opencode binary on each launch and exec it directly, bypassing
+        // the Node.js launcher's spawnSync. The bwrap (agent-sandbox)
+        // backend doesn't use Landlock, so this wrapper is harmless there
+        // — but synthesize_sandboxed_command's bwrap branch goes through
+        // the agent-sandbox CLI and never sees inner_command anyway.
+        "opencode" => (
+            vec![
+                "bash".to_string(),
+                "-c".to_string(),
+                "exec \"$(dirname \"$(readlink -f \"$(which opencode)\")\")/.opencode\" \"$@\""
+                    .to_string(),
+                "--".to_string(),
+            ],
+            ".config/opencode",
+        ),
+        "pi" => (vec!["pi".to_string()], ".pi"),
         _ => return None,
     };
 
@@ -168,9 +187,11 @@ fn synthesize_sandboxed_command(
                 let bash = String::from(
                     "set -e; \
                      SCRATCH=\"${XDG_RUNTIME_DIR:-/tmp}/lince-@@AGENT_ID@@\"; \
-                     mkdir -p -- \"$SCRATCH\"; \
+                     mkdir -p -- \"$SCRATCH/@@HOME_SUBDIR@@\"; \
                      trap 'rm -rf -- \"$SCRATCH\"' EXIT; \
-                     rsync -a --delete -- \"$HOME/@@HOME_SUBDIR@@/\" \"$SCRATCH/@@HOME_SUBDIR@@/\"; \
+                     if [ -d \"$HOME/@@HOME_SUBDIR@@\" ]; then \
+                       rsync -a --delete -- \"$HOME/@@HOME_SUBDIR@@/\" \"$SCRATCH/@@HOME_SUBDIR@@/\"; \
+                     fi; \
                      HOME=\"$SCRATCH\" nono run --profile @@NONO_PROFILE@@ --workdir @@PROJECT_DIR@@ -- @@INNER_COMMAND@@",
                 )
                 .replace("@@HOME_SUBDIR@@", agent_home_subdir)

--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -2422,16 +2422,47 @@ def cmd_run(args, agent_extra: list[str]) -> None:
                     file=sys.stderr,
                 )
             else:
+                # Tell the user *which* env vars the active fragment
+                # auto-maps. collected_env still holds the post-expansion
+                # values; an empty string means "host var unset".
+                # CREDENTIAL_PROXY_RULES is the universe of keys that
+                # would have produced a rule if set.
+                expected = [
+                    k for k in collected_env
+                    if k in CREDENTIAL_PROXY_RULES
+                ]
+                if expected:
+                    unset = [k for k in expected if not collected_env[k]]
+                    quick = (
+                        f"Quick fix: export {unset[0]} (or another from "
+                        f"{', '.join(expected)}) in your host shell — "
+                        f"the paranoid fragment for agent '{agent_name}' "
+                        f"auto-maps it via [env.extra]."
+                        if unset else
+                        f"All of {', '.join(expected)} are already set "
+                        f"but none matched a known proxy rule. This "
+                        f"shouldn't happen — please file a bug."
+                    )
+                    examples = ", ".join(expected)
+                else:
+                    # Fragment doesn't auto-map any known credential.
+                    # List the global rule table so the user knows what
+                    # the proxy would accept.
+                    examples = ", ".join(CREDENTIAL_PROXY_RULES.keys())
+                    quick = (
+                        f"Quick fix: add one of [{examples}] to "
+                        f"[env.extra] in your fragment for agent "
+                        f"'{agent_name}', then export the matching "
+                        f"host env var."
+                    )
                 print(
                     "Error: [security] unshare_net = true requires at "
-                    "least one credential rule (e.g. ANTHROPIC_API_KEY "
-                    "in [env.extra] or in the active provider profile), "
+                    f"least one credential rule (e.g. {examples} in "
+                    "[env.extra] or in the active provider profile), "
                     "otherwise the proxy doesn't start and the sandbox "
                     "has no path to any LLM API.\n"
-                    "Quick fix: export ANTHROPIC_API_KEY in your host "
-                    "shell — the paranoid fragment auto-maps it via "
-                    "[env.extra]. If you use a different provider, add "
-                    "its key to your [env.extra] in "
+                    f"{quick}\n"
+                    f"You can also add a key to [env.extra] in "
                     f"{config_path} or pick a profile with `-P`.",
                     file=sys.stderr,
                 )

--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -2455,6 +2455,21 @@ def cmd_run(args, agent_extra: list[str]) -> None:
                         f"'{agent_name}', then export the matching "
                         f"host env var."
                     )
+                # OAuth note for agents that commonly authenticate
+                # without an API key on the host (gemini browser login,
+                # claude /login). Paranoid relies on a host-side API
+                # key the proxy can inject — OAuth-only setups won't
+                # work at this level.
+                oauth_note = ""
+                if agent_name in ("gemini", "claude"):
+                    oauth_note = (
+                        f"\nNote: {agent_name} OAuth/browser-login users "
+                        f"have no API key in their host env, so paranoid "
+                        f"cannot inject one — pick `--sandbox-level "
+                        f"normal` or `permissive` instead, or switch to "
+                        f"API-key auth (see "
+                        f"docs/documentation/dashboard/sandbox-levels.md)."
+                    )
                 print(
                     "Error: [security] unshare_net = true requires at "
                     f"least one credential rule (e.g. {examples} in "
@@ -2463,7 +2478,8 @@ def cmd_run(args, agent_extra: list[str]) -> None:
                     "has no path to any LLM API.\n"
                     f"{quick}\n"
                     f"You can also add a key to [env.extra] in "
-                    f"{config_path} or pick a profile with `-P`.",
+                    f"{config_path} or pick a profile with `-P`."
+                    f"{oauth_note}",
                     file=sys.stderr,
                 )
             sys.exit(1)

--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -282,6 +282,13 @@ DEFAULT_BLOCKED_HOSTS: set[str] = {
     "100.100.100.200",  # Alibaba Cloud
 }
 
+# Agents whose default auth flow is OAuth/browser-login rather than an
+# API key — used to tailor the paranoid bail-out message. Paranoid
+# can't inject a credential the agent doesn't have on the host, so
+# OAuth users need to drop to normal/permissive (or switch to API-key
+# auth). See docs/documentation/dashboard/sandbox-levels.md.
+OAUTH_CAPABLE_AGENTS: frozenset[str] = frozenset({"gemini", "claude"})
+
 _proxy_logger = logging.getLogger("agent-sandbox.proxy")
 
 # Headers to strip when forwarding through the credential proxy.
@@ -2422,46 +2429,31 @@ def cmd_run(args, agent_extra: list[str]) -> None:
                     file=sys.stderr,
                 )
             else:
-                # Tell the user *which* env vars the active fragment
-                # auto-maps. collected_env still holds the post-expansion
-                # values; an empty string means "host var unset".
-                # CREDENTIAL_PROXY_RULES is the universe of keys that
-                # would have produced a rule if set.
-                expected = [
+                # Reaching here means the fragment ran but produced no
+                # rules — either it auto-maps known keys none of which
+                # are exported, or it doesn't auto-map anything.
+                fragment_keys = [
                     k for k in collected_env
                     if k in CREDENTIAL_PROXY_RULES
                 ]
-                if expected:
-                    unset = [k for k in expected if not collected_env[k]]
+                if fragment_keys:
+                    keys_for_msg = ", ".join(fragment_keys)
                     quick = (
-                        f"Quick fix: export {unset[0]} (or another from "
-                        f"{', '.join(expected)}) in your host shell — "
-                        f"the paranoid fragment for agent '{agent_name}' "
-                        f"auto-maps it via [env.extra]."
-                        if unset else
-                        f"All of {', '.join(expected)} are already set "
-                        f"but none matched a known proxy rule. This "
-                        f"shouldn't happen — please file a bug."
+                        f"Quick fix: export {fragment_keys[0]} (or "
+                        f"another from {keys_for_msg}) in your host "
+                        f"shell — the paranoid fragment for agent "
+                        f"'{agent_name}' auto-maps it via [env.extra]."
                     )
-                    examples = ", ".join(expected)
                 else:
-                    # Fragment doesn't auto-map any known credential.
-                    # List the global rule table so the user knows what
-                    # the proxy would accept.
-                    examples = ", ".join(CREDENTIAL_PROXY_RULES.keys())
+                    keys_for_msg = ", ".join(CREDENTIAL_PROXY_RULES.keys())
                     quick = (
-                        f"Quick fix: add one of [{examples}] to "
+                        f"Quick fix: add one of [{keys_for_msg}] to "
                         f"[env.extra] in your fragment for agent "
                         f"'{agent_name}', then export the matching "
                         f"host env var."
                     )
-                # OAuth note for agents that commonly authenticate
-                # without an API key on the host (gemini browser login,
-                # claude /login). Paranoid relies on a host-side API
-                # key the proxy can inject — OAuth-only setups won't
-                # work at this level.
                 oauth_note = ""
-                if agent_name in ("gemini", "claude"):
+                if agent_name in OAUTH_CAPABLE_AGENTS:
                     oauth_note = (
                         f"\nNote: {agent_name} OAuth/browser-login users "
                         f"have no API key in their host env, so paranoid "
@@ -2472,7 +2464,7 @@ def cmd_run(args, agent_extra: list[str]) -> None:
                     )
                 print(
                     "Error: [security] unshare_net = true requires at "
-                    f"least one credential rule (e.g. {examples} in "
+                    f"least one credential rule (e.g. {keys_for_msg} in "
                     "[env.extra] or in the active provider profile), "
                     "otherwise the proxy doesn't start and the sandbox "
                     "has no path to any LLM API.\n"

--- a/sandbox/profiles/gemini-paranoid.toml
+++ b/sandbox/profiles/gemini-paranoid.toml
@@ -1,0 +1,30 @@
+# Sandbox-policy fragment: gemini — paranoid level.
+# See docs/documentation/dashboard/sandbox-levels.md. Lists are
+# append-merged with the user's ~/.agent-sandbox/config.toml.
+#
+# OAuth-only users: this fragment does NOT allow Google OAuth domains
+# (accounts.google.com, oauth2.googleapis.com). If you authenticate via
+# the browser flow rather than GEMINI_API_KEY/GOOGLE_API_KEY, paranoid
+# will not be able to refresh tokens. Use sandbox_level = "normal" or
+# "permissive" instead, or extend allow_domains in your own config.
+
+[env.extra]
+# Auto-map both forms; _collect_proxy_rules silently drops empties so
+# unset host vars are skipped. Both keys map to the same domain
+# (generativelanguage.googleapis.com), deduped at rule level.
+GEMINI_API_KEY = "$GEMINI_API_KEY"
+GOOGLE_API_KEY = "$GOOGLE_API_KEY"
+
+[agents.gemini]
+# Per-run ephemeral copy of ~/.gemini (rsync-seeded, bind-mounted, removed
+# on exit). Mirrors what the nono paranoid bash wrapper does.
+scratch_home_dirs = [".gemini"]
+
+[security]
+credential_proxy = true
+unshare_net = true
+# generativelanguage.googleapis.com is auto-included from the credential
+# rule. Extend by appending in your own config:
+#   [security]
+#   allow_domains = ["pypi.org", "files.pythonhosted.org"]
+allow_domains = []

--- a/sandbox/profiles/gemini-permissive.toml
+++ b/sandbox/profiles/gemini-permissive.toml
@@ -1,0 +1,19 @@
+# Sandbox-policy fragment: gemini — permissive level.
+# See docs/documentation/dashboard/sandbox-levels.md. Lists are
+# append-merged with the user's ~/.agent-sandbox/config.toml.
+
+[sandbox]
+home_ro_dirs = [".config/gh", ".cache", ".ssh/known_hosts"]
+
+[env]
+# Keyring-auth users rely on GH_TOKEN/GITHUB_TOKEN; --clearenv would wipe them.
+passthrough = ["GH_TOKEN", "GITHUB_TOKEN"]
+
+[security]
+credential_proxy = true
+block_git_push = true
+allow_domains = [
+    "api.github.com",
+    "github.com",
+    "objects.githubusercontent.com",
+]

--- a/sandbox/profiles/opencode-paranoid.toml
+++ b/sandbox/profiles/opencode-paranoid.toml
@@ -1,0 +1,30 @@
+# Sandbox-policy fragment: opencode — paranoid level.
+# See docs/documentation/dashboard/sandbox-levels.md. Lists are
+# append-merged with the user's ~/.agent-sandbox/config.toml.
+#
+# OpenCode is a multi-provider router. The Bun/Landlock SIGABRT bug
+# only affects the nono backend (Landlock LSM), so this fragment does
+# NOT need a special inner-command shape — bwrap doesn't trigger the
+# bug. The plugin-level Bun resolution is a nono-only concern.
+
+[env.extra]
+# Auto-map the providers known to the credential proxy. Empty host
+# vars are silently dropped, so the user gets rules only for providers
+# they actually have configured. For routers/providers not in
+# CREDENTIAL_PROXY_RULES (groq, mistral, deepseek, ...), ship a custom
+# level fragment that extends [security].allow_domains.
+ANTHROPIC_API_KEY = "$ANTHROPIC_API_KEY"
+ANTHROPIC_AUTH_TOKEN = "$ANTHROPIC_AUTH_TOKEN"
+OPENAI_API_KEY = "$OPENAI_API_KEY"
+GEMINI_API_KEY = "$GEMINI_API_KEY"
+GOOGLE_API_KEY = "$GOOGLE_API_KEY"
+
+[agents.opencode]
+# Per-run ephemeral copy of ~/.config/opencode (rsync-seeded, bind-mounted,
+# removed on exit). Nested subdirs are supported by the helper.
+scratch_home_dirs = [".config/opencode"]
+
+[security]
+credential_proxy = true
+unshare_net = true
+allow_domains = []

--- a/sandbox/profiles/opencode-permissive.toml
+++ b/sandbox/profiles/opencode-permissive.toml
@@ -1,0 +1,19 @@
+# Sandbox-policy fragment: opencode — permissive level.
+# See docs/documentation/dashboard/sandbox-levels.md. Lists are
+# append-merged with the user's ~/.agent-sandbox/config.toml.
+
+[sandbox]
+home_ro_dirs = [".config/gh", ".cache", ".ssh/known_hosts"]
+
+[env]
+# Keyring-auth users rely on GH_TOKEN/GITHUB_TOKEN; --clearenv would wipe them.
+passthrough = ["GH_TOKEN", "GITHUB_TOKEN"]
+
+[security]
+credential_proxy = true
+block_git_push = true
+allow_domains = [
+    "api.github.com",
+    "github.com",
+    "objects.githubusercontent.com",
+]

--- a/sandbox/profiles/pi-paranoid.toml
+++ b/sandbox/profiles/pi-paranoid.toml
@@ -1,0 +1,27 @@
+# Sandbox-policy fragment: pi — paranoid level.
+# See docs/documentation/dashboard/sandbox-levels.md. Lists are
+# append-merged with the user's ~/.agent-sandbox/config.toml.
+#
+# Pi supports 18+ LLM providers. Paranoid covers only the providers
+# known to the credential proxy (anthropic, openai, gemini). For other
+# providers (mistral, groq, deepseek, cerebras, AWS Bedrock, ...) ship
+# a custom level fragment that extends [security].allow_domains and
+# adds the provider's env var to [env.extra] below.
+
+[env.extra]
+# _collect_proxy_rules silently drops empties, so over-mapping is safe.
+ANTHROPIC_API_KEY = "$ANTHROPIC_API_KEY"
+ANTHROPIC_AUTH_TOKEN = "$ANTHROPIC_AUTH_TOKEN"
+OPENAI_API_KEY = "$OPENAI_API_KEY"
+GEMINI_API_KEY = "$GEMINI_API_KEY"
+GOOGLE_API_KEY = "$GOOGLE_API_KEY"
+
+[agents.pi]
+# Per-run ephemeral copy of ~/.pi (rsync-seeded, bind-mounted, removed
+# on exit). Mirrors what the nono paranoid bash wrapper does.
+scratch_home_dirs = [".pi"]
+
+[security]
+credential_proxy = true
+unshare_net = true
+allow_domains = []

--- a/sandbox/profiles/pi-permissive.toml
+++ b/sandbox/profiles/pi-permissive.toml
@@ -1,0 +1,19 @@
+# Sandbox-policy fragment: pi — permissive level.
+# See docs/documentation/dashboard/sandbox-levels.md. Lists are
+# append-merged with the user's ~/.agent-sandbox/config.toml.
+
+[sandbox]
+home_ro_dirs = [".config/gh", ".cache", ".ssh/known_hosts"]
+
+[env]
+# Keyring-auth users rely on GH_TOKEN/GITHUB_TOKEN; --clearenv would wipe them.
+passthrough = ["GH_TOKEN", "GITHUB_TOKEN"]
+
+[security]
+credential_proxy = true
+block_git_push = true
+allow_domains = [
+    "api.github.com",
+    "github.com",
+    "objects.githubusercontent.com",
+]


### PR DESCRIPTION
## Summary

Bundles four backlog tasks that landed together because they're functionally co-dependent — LINCE-100/101/102 require LINCE-104's file split.

- **LINCE-104** — split `agents-defaults.toml` (loaded) from a new `agents-template.toml` (reference-only); install-time multi-select adds paranoid/permissive variants to `~/.config/lince-dashboard/config.toml`.
- **LINCE-100/101/102** — extend the three-level sandbox model (paranoid/normal/permissive, established for claude in LINCE-98 and codex in LINCE-99) to **gemini**, **opencode**, and **pi**.
- Plus: agent-aware paranoid bail-out error message (no more hardcoded `ANTHROPIC_API_KEY`), an OAuth caveat in the docs with a generic bypass recipe and risks, and a small `/simplify` cleanup pass on the new code.

Closes #50, closes #51, closes #52, closes #59. Also closes umbrella #47 — with claude (#48 / PR #57) and codex (#49 / PR #60) already shipped, this PR completes the 5-agent rollout.

## What changed

**Plugin (`lince-dashboard/plugin/src/agent.rs`)**
- gemini/opencode/pi match arms in `synthesize_sandboxed_command`. Opencode preserves the Bun/Landlock workaround as `inner_command` (bash resolves the native `.opencode` binary to bypass the Node.js `spawnSync` that crashes under Landlock).
- Paranoid bash wrapper now `mkdir -p`'s the (potentially nested) home subdir and skips rsync if the source is missing — both needed so `.config/opencode` and clean-install `~/.gemini` work.
- Wrapper template uses a single `format!` instead of 5 sequential `.replace()` passes (post-review cleanup).

**Sandbox (`sandbox/agent-sandbox`)**
- 6 new sandbox-policy fragments: `{gemini,opencode,pi}-{paranoid,permissive}.toml`. Paranoid auto-maps the credential-proxy providers in `[env.extra]` (deduped on domain) and opts into `scratch_home_dirs`. Permissive ships the standard GitHub allowlist + GH_TOKEN passthrough + `block_git_push`.
- Paranoid bail-out is now agent-aware: lists the keys the active fragment expects (e.g. \`GEMINI_API_KEY, GOOGLE_API_KEY\` for gemini) and adds an OAuth note for agents whose default auth flow is browser-login (gemini, claude).

**Dashboard config**
- `agents-defaults.toml`: gemini/opencode/pi each collapse three legacy entries (unsandboxed / -bwrap / -nono) into a single sandboxed `[agents.X]` (sandbox_level = \"normal\") + `[agents.X-unsandboxed]`.
- `agents-template.toml`: paranoid/permissive variants for all three so the install-time multi-select picks them up.
- 6 new nono profiles: paranoid uses `network.credentials = [\"gemini\"]` for gemini and `[\"anthropic\",\"openai\",\"gemini\"]` (the providers nono knows) for opencode/pi. Pi-paranoid narrows `environment.passthrough` to those three; permissive inherits the full 18-provider passthrough.

**Docs (`docs/documentation/dashboard/sandbox-levels.md`)**
- New §6 *Trust model* — explains why paranoid requires API-key auth (credentials never enter the sandbox process tree) and why OAuth violates that, with a comparison table and a generic bypass recipe (works for any agent).
- New §7.2 *Gemini* — auth-method matrix, OAuth caveats, recommended paths.
- §3 *How to choose a level* — adds the API-key requirement upfront so paranoid isn't picked blindly.

## Decisions worth flagging for review

- **Gemini paranoid is API-key only** — `accounts.google.com` / `oauth2.googleapis.com` are intentionally NOT in the paranoid allowlist. OAuth users should pick `normal`/`permissive` or follow the §6 bypass recipe (with the documented trade-offs).
- **Opencode/pi paranoid covers anthropic/openai/gemini only** (intersection of `CREDENTIAL_PROXY_RULES` and nono's keystore). Other providers (groq, mistral, deepseek, AWS Bedrock, …) ship a custom level via the documented escape hatch.
- **`pi_providers` field deferred** — LINCE-102 originally proposed a per-agent `pi_providers = [...]` field for dynamic env-var filtering + dynamic `network.credentials` synthesis. Skipped here in favor of the simpler custom-level recipe; AC #1/#2/#3/#4/#5 are not met as written. Re-open as a separate task if user demand surfaces. See LINCE-102's implementation notes.

## Test plan

Smoke-tested locally:

- [x] All TOML / JSON parse
- [x] WASM plugin builds clean (release + dev) with the rustup-managed toolchain
- [x] `apply-sandbox-levels.py paranoid,permissive` correctly emits all 10 variant entries (claude, codex, gemini, opencode, pi × paranoid + permissive)
- [x] `format!` template smoke-tested for nested subdir paths (`.config/opencode`) and paths with spaces

Needs runtime verification before merge (require host gemini/opencode/pi binaries + provider keys):

- [ ] `agent-sandbox run -a gemini --sandbox-level paranoid` with `GEMINI_API_KEY` set: scratch `~/.gemini`, kernel netns blocks attacker.com, gemini API works through the proxy
- [ ] Same with `GEMINI_API_KEY` unset: bail-out error mentions `GEMINI_API_KEY, GOOGLE_API_KEY` (NOT `ANTHROPIC_API_KEY`) and the OAuth note appears
- [ ] `opencode --version` inside opencode paranoid: must NOT SIGABRT (Bun/Landlock workaround)
- [ ] `pi` with `pi_providers` (manual `network.credentials` edit in the JSON) — verify outbound to non-listed providers fails
- [ ] `--sandbox-level permissive` for each: `gh auth status` works, `docker ps` fails, direct `git push` blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)