### PR TITLE
docs: align documentation with three-level sandbox model

### DIFF
--- a/docs/documentation/README.md
+++ b/docs/documentation/README.md
@@ -17,6 +17,7 @@ Multi-agent TUI dashboard for Zellij. Spawn, monitor, and switch between multipl
 - [Usage Guide](dashboard/usage-guide.md) -- keybindings, wizard, features
 - [Configuration Reference](dashboard/config-reference.md) -- dashboard and agent type config
 - [Agent Examples](dashboard/agent-examples.md) -- defaults, custom agents, advanced setups
+- [Sandbox Levels](dashboard/sandbox-levels.md) -- paranoid / normal / permissive: what each level does and how to ship a custom one
 
 ## Quick Links
 

--- a/docs/documentation/_sidebar.md
+++ b/docs/documentation/_sidebar.md
@@ -10,3 +10,4 @@
   - [Usage Guide](dashboard/usage-guide.md)
   - [Configuration Reference](dashboard/config-reference.md)
   - [Agent Examples](dashboard/agent-examples.md)
+  - [Sandbox Levels](dashboard/sandbox-levels.md)

--- a/docs/documentation/dashboard/agent-examples.md
+++ b/docs/documentation/dashboard/agent-examples.md
@@ -6,30 +6,33 @@ Preset agent types, configuration patterns, and examples for adding custom agent
 
 The following agent types ship in `agents-defaults.toml` and are available in the wizard out of the box.
 
-| Key | Display Name | Short | Sandboxed | Backend | Native Hooks | Notes |
-|-----|-------------|-------|-----------|---------|--------------|-------|
-| `claude` | Claude Code | CLA | Yes | agent-sandbox | Yes | Default. Rich status via `claude-status` pipe. |
-| `claude-unsandboxed` | Claude Code (unsandboxed) | CLU | No | -- | Yes | Red `CLU!` label. Supports profile-based provider switching. |
-| `claude-nono` | Claude Code (nono) | CLA | Yes | nono | Yes | Landlock/Seatbelt sandbox. |
-| `codex` | OpenAI Codex (unsandboxed) | CDX | No | -- | No | Runs with Codex's own sandbox. |
-| `codex-bwrap` | OpenAI Codex (sandboxed) | CDX | Yes | agent-sandbox | No | bwrap isolation. `bwrap_conflict` handled automatically. |
-| `codex-nono` | OpenAI Codex (nono) | CDX | Yes | nono | No | Landlock/Seatbelt sandbox. |
-| `gemini` | Google Gemini CLI | GEM | No | -- | No | Runs directly without sandbox. |
-| `gemini-bwrap` | Google Gemini CLI (sandboxed) | GEM | Yes | agent-sandbox | No | bwrap isolation. |
-| `gemini-nono` | Google Gemini CLI (nono) | GEM | Yes | nono | No | Landlock/Seatbelt sandbox. |
-| `opencode` | OpenCode | OPC | No | -- | No | Runs directly without sandbox. |
-| `opencode-bwrap` | OpenCode (sandboxed) | OPC | Yes | agent-sandbox | No | bwrap isolation. |
-| `opencode-nono` | OpenCode (nono) | OPC | Yes | nono | No | Landlock/Seatbelt sandbox. |
+| Key | Display Name | Short | Sandboxed | Native Hooks | Notes |
+|-----|-------------|-------|-----------|--------------|-------|
+| `claude` | Claude Code | CLA | Yes | Yes | Default. Rich status via `claude-status` pipe. |
+| `claude-unsandboxed` | Claude Code (unsandboxed) | CLU | No | Yes | Red `CLU!` label. |
+| `codex` | OpenAI Codex | CDX | Yes | No | `bwrap_conflict` handled automatically. |
+| `gemini` | Google Gemini CLI | GEM | Yes | No | |
+| `opencode` | OpenCode | OPC | Yes | No | |
+| `pi` | Pi (multi-provider) | PI  | Yes | No | Provider env vars passed through (`OPENAI_API_KEY`, etc.). |
 
-## Understanding the Variants
+Each sandboxed agent ships at `sandbox_level = "normal"` by default. `paranoid` and `permissive` variants are available as commented blocks in `agents-defaults.toml` — uncomment to add them as separate entries to the N-picker. See [Sandbox Levels](dashboard/sandbox-levels.md) for what each level enforces.
 
-Most agents come in up to three variants: **direct**, **-bwrap**, and **-nono**.
+## Backend and Level Selection
 
-- **Direct** (e.g. `codex`, `gemini`) runs the agent binary as-is, relying on whatever sandbox the agent provides natively -- or no sandbox at all.
-- **-bwrap** (e.g. `codex-bwrap`, `gemini-bwrap`) wraps the agent inside `agent-sandbox` using bubblewrap for filesystem isolation. Linux only.
-- **-nono** (e.g. `codex-nono`, `gemini-nono`) wraps the agent inside `nono` using Landlock (Linux) or Seatbelt (macOS) for filesystem isolation. Cross-platform.
+Each agent is configured with two attributes that select its sandbox behavior at runtime:
 
-Choose `-bwrap` or `-nono` when you want LINCE-managed isolation regardless of the agent's own sandbox capabilities.
+- `sandbox_backend` — `"bwrap"` (Linux) or `"nono"` (macOS, also available on Linux). Defaults to bwrap on Linux and nono on macOS; can be overridden per agent.
+- `sandbox_level` — `"paranoid"` | `"normal"` | `"permissive"` (or any custom name backed by a `<name>.toml` profile fragment). Defaults to `"normal"`.
+
+```toml
+[agents.claude]
+sandbox_level = "normal"
+# sandbox_backend = "nono"   # uncomment to force nono on Linux
+```
+
+The dashboard plugin synthesizes the launch command from `(agent_type, sandbox_backend, sandbox_level)` — the legacy `command` field is kept as a fallback for entries without `sandbox_level`.
+
+The `-unsandboxed` variants (e.g. `claude-unsandboxed`) bypass agent-sandbox entirely. Use them only in trusted environments.
 
 ## Unsandboxed Mode
 
@@ -137,17 +140,17 @@ For sandboxed agents, `env_unset` is a no-op because `agent-sandbox` uses `--cle
 
 ## Handling bwrap Conflicts
 
-Some agents (like Codex) use bubblewrap internally. Nesting bwrap fails. The `-bwrap` variants handle this automatically:
+Some agents (like Codex) use bubblewrap internally. Nesting bwrap fails, so the agent's inner sandbox must be disabled before wrapping it in the LINCE bwrap jail. The default `[agents.codex]` entry handles this automatically:
 
 1. Set `bwrap_conflict = true` on the agent type.
 2. Set `disable_inner_sandbox_args` to the arguments that disable the agent's internal sandbox.
 
 ```toml
-[agents.codex-bwrap]
-command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}", "--agent", "codex"]
+[agents.codex]
 sandboxed = true
 bwrap_conflict = true
 disable_inner_sandbox_args = ["--sandbox", "danger-full-access"]
+sandbox_level = "normal"
 ```
 
 The sandbox injects `--sandbox danger-full-access` into the Codex command, disabling its internal bwrap before wrapping it in the LINCE bwrap jail.
@@ -155,7 +158,7 @@ The sandbox injects `--sandbox danger-full-access` into the Codex command, disab
 **Dry-run verification**: Always verify the final command with `--dry-run` before first use:
 
 ```bash
-agent-sandbox run -a codex-bwrap -p ~/project --dry-run
+agent-sandbox run -a codex -p ~/project --dry-run
 # Output shows: ... codex --full-auto --sandbox danger-full-access
 ```
 

--- a/docs/documentation/dashboard/config-reference.md
+++ b/docs/documentation/dashboard/config-reference.md
@@ -116,7 +116,8 @@ Each agent type is defined as a `[agents.<name>]` TOML table.
 | `home_rw_dirs` | array of strings | No | `[]` | Home subdirectories to bind read-write in the sandbox. |
 | `env_vars` | table | No | `{}` | Environment variables to set for the agent. Applied for both sandboxed and non-sandboxed agents. See [Environment Variable Resolution](#environment-variable-resolution). |
 | `event_map` | table | No | `{}` | Custom mapping from agent-specific event strings to LINCE status strings. See [Agent Examples](dashboard/agent-examples.md#custom-event-map). |
-| `sandbox_backend` | string | No | (global default) | Per-agent sandbox backend override. `"agent-sandbox"` or `"nono"`. Overrides the global `[dashboard].sandbox_backend`. |
+| `sandbox_backend` | string | No | (global default) | Per-agent sandbox backend override. `"bwrap"` (a.k.a. `"agent-sandbox"`) or `"nono"`. Overrides the global `[dashboard].sandbox_backend`. |
+| `sandbox_level` | string | No | `"normal"` | Sandbox isolation level: `"paranoid"`, `"normal"`, `"permissive"`, or any custom name backed by a `<name>.toml` policy fragment. The plugin synthesizes the launch command from `(agent_type, sandbox_backend, sandbox_level)`; when set, the entry's legacy `command` field is ignored. See [Sandbox Levels](dashboard/sandbox-levels.md). |
 
 ### Environment Variable Resolution
 

--- a/docs/documentation/sandbox/cli-reference.md
+++ b/docs/documentation/sandbox/cli-reference.md
@@ -32,8 +32,9 @@ Creates `~/.agent-sandbox/`, copies `~/.claude/` into an isolated config directo
 ### run
 
 ```
-agent-sandbox run [-p DIR] [-a AGENT] [-P PROFILE] [--log | --no-log]
-                  [--safe] [--dry-run] [--rw DIR] [--ro DIR] [--id ID]
+agent-sandbox run [-p DIR] [-a AGENT] [-P PROFILE] [--sandbox-level NAME]
+                  [--log | --no-log] [--safe] [--dry-run]
+                  [--rw DIR] [--ro DIR] [--id ID]
                   [-- <agent-args>]
 ```
 
@@ -48,6 +49,7 @@ On launch, a banner displays active protections (profile, project path, filesyst
 | `-p`, `--project` | `.` (cwd) | Project directory to mount writable |
 | `-a`, `--agent` | `claude` | Agent to run (looks up `[agents.<name>]` in config) |
 | `-P`, `--profile` | config default | Provider profile name (defined in `config.toml`) |
+| `--sandbox-level NAME` | per-agent default | Sandbox isolation level: `paranoid`, `normal`, `permissive`, or any custom name. Loads `sandbox/profiles/<NAME>.toml` (built-in) or `~/.agent-sandbox/profiles/<NAME>.toml` (user-supplied) and deep-merges it into the config. See [Configuration Reference](sandbox/config-reference.md#sandbox-levels) |
 | `--log` | config value | Enable session transcript logging |
 | `--no-log` | config value | Disable session transcript logging |
 | `--safe` | off | Disable `--dangerously-skip-permissions` for this run |
@@ -286,6 +288,12 @@ Enable credential proxy and verify:
 ```bash
 agent-sandbox run -P anthropic    # proxy starts automatically if configured
 agent-sandbox proxy-status
+```
+
+Run at a tighter sandbox level (kernel-enforced network isolation + credential proxy):
+```bash
+agent-sandbox run --sandbox-level paranoid
+agent-sandbox run --sandbox-level paranoid -a codex
 ```
 
 Snapshot workflow (before and after a risky session):

--- a/docs/documentation/sandbox/config-reference.md
+++ b/docs/documentation/sandbox/config-reference.md
@@ -190,6 +190,8 @@ Security features and hardening options.
 | `new_session` | bool | `false` | New terminal session: prevents terminal escape-sequence attacks. May interfere with Ctrl+C propagation |
 | `block_git_push` | bool | `true` | Block `git push` via a wrapper script placed first in `$PATH` |
 | `credential_proxy` | bool | `false` | Credential proxy: intercept API calls and inject credentials on the host side so API keys never enter the sandbox |
+| `unshare_net` | bool | `false` | Network namespace: run the agent inside a fresh network namespace (`bwrap --unshare-net`). Combined with `credential_proxy`, the proxy is reached via a unix socket bind-mounted into the sandbox. Set automatically by the `paranoid` sandbox level |
+| `allow_domains` | list of strings | `[]` | Extra hosts the credential proxy is allowed to forward to, on top of those covered by credential rules. Anything off-list returns `403`. Append-merged with sandbox level fragments |
 
 ```toml
 [security]
@@ -197,6 +199,8 @@ unshare_pid = true
 new_session = false
 block_git_push = true
 credential_proxy = false
+unshare_net = false
+allow_domains = []
 ```
 
 ---
@@ -213,6 +217,26 @@ Optional configuration for the credential proxy (only relevant when `[security].
 [credential_proxy]
 blocked_hosts = ["169.254.169.254", "metadata.google.internal", "metadata.azure.internal"]
 ```
+
+---
+
+## Sandbox Levels
+
+Three named levels package the security keys above into ready-made policies, selected per run with `agent-sandbox run --sandbox-level <name>`:
+
+- `paranoid` — kernel-level network isolation (`unshare_net = true`) plus auto-enabled credential proxy. The agent's only path to the network is the bind-mounted proxy socket.
+- `normal` — the default. Network is open, credential proxy is opt-in.
+- `permissive` — adds extra read-only host paths on top of `normal`.
+
+Levels are loaded from policy fragments in `sandbox/profiles/<level>.toml` (built-in) or `~/.agent-sandbox/profiles/<level>.toml` (user-supplied) and deep-merged on top of the resolved config. List keys (`home_ro_dirs`, `allow_domains`) are append-merged, so extending a level doesn't require forking the file:
+
+```toml
+# ~/.agent-sandbox/config.toml
+[security]
+allow_domains = ["pypi.org", "files.pythonhosted.org"]
+```
+
+For the full level matrix, per-backend behavior, and custom-level recipes, see [Sandbox Levels](dashboard/sandbox-levels.md).
 
 ---
 

--- a/docs/documentation/sandbox/security-model.md
+++ b/docs/documentation/sandbox/security-model.md
@@ -17,7 +17,7 @@ Four threat categories, ordered by likelihood:
 
 ## Defense Layers
 
-Nine layers of defense, most enabled by default:
+Ten layers of defense, most enabled by default:
 
 | Layer | Feature | Default |
 |-------|---------|---------|
@@ -25,11 +25,26 @@ Nine layers of defense, most enabled by default:
 | PID namespace | Host processes invisible to sandbox | On |
 | Env var clearing | Only whitelisted vars pass through | Always on |
 | Git push blocking | Wrapper script + sanitized gitconfig | On |
-| Credential proxy | API keys never enter sandbox | Opt-in |
+| Network namespace | Block all outbound network at the kernel (`bwrap --unshare-net`) | Opt-in (auto-on in `paranoid`) |
+| Credential proxy | API keys never enter sandbox | Opt-in (auto-on in `paranoid`) |
 | Cloud SSRF blocking | Metadata endpoints blocked by proxy | On (when proxy enabled) |
 | Config snapshots | Auto-snapshot before each run | On |
 | Project snapshots | Snapshot writable project directory | Opt-in |
 | Learn mode | Discover actual access needs via strace | On-demand |
+
+---
+
+## Sandbox Levels
+
+Defense layers compose into three named **sandbox levels**, selected per run with `--sandbox-level`:
+
+- `paranoid` — kernel-level network isolation (`unshare_net = true`) plus auto-enabled credential proxy reached via a unix socket bind-mounted into the sandbox. Only allowlisted hosts are reachable.
+- `normal` — the default. Network is open; credential proxy is opt-in.
+- `permissive` — `normal` plus extra host paths exposed read-only (e.g. `~/.config/gh`, `~/.cache`) for `gh` CLI workflows.
+
+Levels are loaded from policy fragments in `sandbox/profiles/<level>.toml` (built-in) or `~/.agent-sandbox/profiles/<level>.toml` (user-supplied) and deep-merged on top of the resolved config. List keys (`home_ro_dirs`, `allow_domains`) are append-merged so extending a level doesn't require forking the file.
+
+For the full level matrix, per-backend behavior, and how to ship a custom level, see [Sandbox Levels](dashboard/sandbox-levels.md).
 
 ---
 
@@ -58,7 +73,7 @@ Nine layers of defense, most enabled by default:
 |------------|-----|-----|
 | Read/write project directory | Agent needs to edit your code | `--bind $PWD $PWD` (writable) |
 | Read other projects | Agent may reference sibling repos | `--ro-bind ~/project ~/project` (configurable) |
-| Network access | Needed for API calls, pip, npm, git clone | No `--unshare-net` |
+| Network access | Open in `normal` and `permissive` for API calls, pip, npm, git clone. In `paranoid` only the credential proxy is reachable | No `--unshare-net` in `normal`/`permissive`; `bwrap --unshare-net` set in `paranoid` |
 | Build tools | python, node, cargo, make, gcc, etc. | System dirs read-only + `$HOME` PATH dirs auto-detected (including deep subdirectories) |
 | Agent config | Settings, MCP servers, skills | Isolated copy in `~/.agent-sandbox/claude-config` |
 | Package caches | cargo, npm, go can download dependencies | Persistent writable dirs for registry/cache subdirectories |
@@ -107,7 +122,9 @@ The `push.default` git option is forced to `nothing`, so even a bare `git push` 
 
 ## Credential Proxy
 
-The credential proxy keeps API keys outside the sandbox entirely. Instead of passing `ANTHROPIC_API_KEY` into the sandbox environment, a localhost HTTP proxy runs on the host, intercepts API calls, and injects the correct authentication header. A prompt-injected agent cannot exfiltrate the key because it never exists in the sandbox's memory.
+The credential proxy keeps API keys outside the sandbox entirely. Instead of passing `ANTHROPIC_API_KEY` into the sandbox environment, a proxy runs on the host, intercepts API calls, and injects the correct authentication header. A prompt-injected agent cannot exfiltrate the key because it never exists in the sandbox's memory.
+
+In `normal` and `permissive` levels the proxy is reached via TCP loopback (`http://localhost:PORT`) and the agent's `*_BASE_URL` is rewritten to point at it. In `paranoid` the proxy is reached via a unix socket bind-mounted into the sandbox; an in-sandbox `socat` bridge presents that socket as plain TCP localhost so any SDK that uses `*_BASE_URL` works unchanged.
 
 Enable it in `config.toml`:
 
@@ -115,6 +132,8 @@ Enable it in `config.toml`:
 [security]
 credential_proxy = true
 ```
+
+`paranoid` enables `credential_proxy = true` automatically and also sets `unshare_net = true` so the agent can only reach the proxy.
 
 ### How it works
 
@@ -161,7 +180,7 @@ Static variables can also be set via `[env.extra]` for every run regardless of p
 
 | Limitation | Details |
 |------------|---------|
-| **Network is open** | Without the credential proxy, the agent can make outbound HTTP requests. This is necessary for API calls, package managers, and git clone. A prompt injection could exfiltrate project source code over the network. Enable `credential_proxy = true` to at least block API key exfiltration and cloud SSRF |
+| **Network is open in `normal`** | The default level (`normal`) leaves the network open: the agent can make outbound HTTP for API calls, package managers, and git clone. A prompt injection could exfiltrate project source code. Mitigations: enable `credential_proxy = true` to block API key exfiltration and cloud SSRF, or run with `--sandbox-level paranoid` which sets `unshare_net = true` and forces all egress through an allowlisted credential proxy |
 | **Git push bypass** | The agent could call `/usr/bin/git push` directly, bypassing the wrapper. However, without SSH keys or credential helpers, authentication fails. The wrapper is defense-in-depth |
 | **Not a VM** | bubblewrap uses Linux namespaces, a kernel feature. A kernel vulnerability in namespace handling could theoretically allow escape. For higher assurance, run the sandbox inside a VM |
 | **Linux only** | agent-sandbox requires bubblewrap, which depends on Linux kernel namespaces. macOS users can use the [nono](https://github.com/always-further/nono) backend (Landlock/Seatbelt) |


### PR DESCRIPTION
## Summary

The published docs predated the paranoid/normal/permissive rollout (LINCE-98 / 99 / 100 / 101 / 102 / 104) and still claimed the network was always open and the credential proxy was purely opt-in. This PR updates the docs to match what actually ships today and surfaces the canonical \`dashboard/sandbox-levels.md\` page that was already in the repo but missing from the sidebar.

### Changes

- **\`docs/documentation/_sidebar.md\`** + **\`README.md\`** — link \`dashboard/sandbox-levels.md\` so it's reachable from the docs nav.
- **\`sandbox/security-model.md\`** — add Network namespace defense layer, mark credential proxy as auto-on in paranoid, scope the "Network is open" caveat to the \`normal\` level, document unix-socket+socat transport for the proxy under paranoid, add a Sandbox Levels teaser linking to the canonical page.
- **\`sandbox/config-reference.md\`** — document \`unshare_net\` and \`allow_domains\` keys in \`[security]\`, add Sandbox Levels section.
- **\`sandbox/cli-reference.md\`** — document \`--sandbox-level\` on \`agent-sandbox run\`, add paranoid usage examples.
- **\`dashboard/agent-examples.md\`** — replace the stale \`-bwrap\`/\`-nono\` variant table with the single-entry-per-agent + \`sandbox_level\`/\`sandbox_backend\` model; fix the bwrap-conflict example to use \`[agents.codex]\`.
- **\`dashboard/config-reference.md\`** — add \`sandbox_level\` to the Agent Type Fields table; clarify \`sandbox_backend\` accepts both \`bwrap\` and \`agent-sandbox\`.

No new top-level pages — the canonical \`dashboard/sandbox-levels.md\` already exists; this PR just makes it discoverable and stops other pages from contradicting it.

## Test plan

- [ ] Build / preview the docs site, verify Sandbox Levels appears in the sidebar under Dashboard
- [ ] \`/documentation/sandbox/security-model\` — Defense Layers table shows the Network namespace row; "Network is open" caveat references \`normal\` level with paranoid mitigation
- [ ] \`/documentation/sandbox/config-reference\` — \`[security]\` table includes \`unshare_net\` and \`allow_domains\`; Sandbox Levels section renders with the \`allow_domains\` extension example
- [ ] \`/documentation/sandbox/cli-reference\` — \`run\` synopsis and flag table include \`--sandbox-level\`
- [ ] \`/documentation/dashboard/agent-examples\` — Default Agent Types table lists single \`claude\`, \`codex\`, \`gemini\`, \`opencode\`, \`pi\` rows (no \`-bwrap\`/\`-nono\` variants)
- [ ] \`/documentation/dashboard/config-reference\` — Agent Type Fields table has \`sandbox_level\`
- [ ] All cross-links to \`dashboard/sandbox-levels.md\` resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)