### PR TITLE
dashboard: color-code agent panes and wizard by sandbox level

### DIFF
--- a/docs/documentation/dashboard/sandbox-levels.md
+++ b/docs/documentation/dashboard/sandbox-levels.md
@@ -8,6 +8,37 @@ Sandboxing isolates an AI coding agent from the rest of your machine: the agent 
 
 Until recently each combination of "agent type + isolation tightness" required its own entry in `agents-defaults.toml`. The three shipped levels collapse that: every agent type can be launched at any of the three levels through a single `sandbox_level` knob. `paranoid` keeps the agent on a strict diet (one API endpoint, scratch config), `normal` is the default daily-work setting, and `permissive` opens up GitHub and the `gh` CLI for users who need to push branches and open PRs from inside the sandbox.
 
+### 1.1 Visual indicators
+
+The dashboard tags each agent pane and the wizard's profile-selection step with a per-level color cue, so the level you're running at is visible at a glance.
+
+**Pane title.** Sandboxed agent panes carry a fixed glyph + bracketed level name in their pane title:
+
+| Level        | Pane title prefix     |
+|--------------|-----------------------|
+| `paranoid`   | 🟢 `[paranoid] <name>` |
+| `normal`     | 🔵 `[normal] <name>`   |
+| `permissive` | 🟡 `[permissive] <name>` |
+| custom       | ⚪ `[<level>] <name>`  |
+
+Non-sandboxed agents keep their existing `[NON-SANDBOXED] <name>` prefix. Agents on the legacy command-template path (no `sandbox_level` set) are not tagged.
+
+**Wizard.** The "N" wizard's *Profile* step colors each profile name using the same palette: `paranoid=green`, `normal=blue`, `permissive=yellow`, anything else falls back to the configurable default.
+
+**Customising the colors.** The palette is configurable in `~/.config/lince-dashboard/config.toml`:
+
+```toml
+[dashboard.sandbox_colors]
+paranoid   = "green"     # ANSI color name
+normal     = "blue"
+permissive = "yellow"
+default    = "white"     # used for any custom sandbox_level
+```
+
+Valid color names are the standard ANSI palette: `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, `white`. The pane-title glyph mapping (🟢🔵🟡⚪) is fixed by design — the color knob only affects the wizard so the title stays consistent across users with different palettes.
+
+If you disable Zellij pane frames, the title indicator is hidden — agents continue to run normally and the dashboard table and wizard still convey the level.
+
 ## 2. The three shipped levels
 
 The table below summarises the differences. Sections after it give the concrete config snippets and behavior for each level.

--- a/lince-dashboard/agents-defaults.toml
+++ b/lince-dashboard/agents-defaults.toml
@@ -37,6 +37,10 @@ display_name = "Claude Code"
 short_label = "CLA"
 # Color follows the sandbox-level gradient (basic ANSI palette):
 #   paranoid=green, normal=blue, permissive=yellow, unsandboxed=red
+# The same palette drives the per-pane title indicator and the "N" wizard's
+# profile-selection step (gh#63). Override via [dashboard.sandbox_colors] in
+# ~/.config/lince-dashboard/config.toml — see docs/documentation/dashboard/
+# sandbox-levels.md §1.1.
 color = "blue"
 sandboxed = true
 has_native_hooks = true

--- a/lince-dashboard/plugin/src/agent.rs
+++ b/lince-dashboard/plugin/src/agent.rs
@@ -33,13 +33,35 @@ pub fn agent_type_base_name(agent_type: &str) -> &str {
     agent_type
 }
 
-/// Build pane title, prefixing with `[UNSANDBOXED]` for non-sandboxed agent types.
+/// Glyph for a sandbox isolation level. Fixed mapping (not user-overridable),
+/// kept stable so the visual cue on a pane title stays consistent even when
+/// the wizard's color palette is customized. Unknown levels get a neutral
+/// square so custom levels don't break the layout.
+pub fn sandbox_level_glyph(level: &str) -> &'static str {
+    match level {
+        "paranoid" => "\u{1F7E2}",   // 🟢
+        "normal" => "\u{1F535}",     // 🔵
+        "permissive" => "\u{1F7E1}", // 🟡
+        _ => "\u{26AA}",             // ⚪
+    }
+}
+
+/// Build pane title with a sandbox-level indicator.
+///
+/// - Non-sandboxed agent types: `[NON-SANDBOXED] <name>` (unchanged).
+/// - Sandboxed with a known `sandbox_level`: `<glyph> [<level>] <name>`,
+///   e.g. `🟢 [paranoid] agent-1`.
+/// - Sandboxed with `sandbox_level = None` (legacy static command path):
+///   `<name>` (unchanged).
 pub fn pane_title(name: &str, agent_type: &str, agent_types: &HashMap<String, AgentTypeConfig>) -> String {
-    let sandboxed = agent_types.get(agent_type).map_or(true, |c| c.sandboxed);
-    if sandboxed {
-        name.to_string()
-    } else {
-        format!("[NON-SANDBOXED] {}", name)
+    let cfg = agent_types.get(agent_type);
+    let sandboxed = cfg.map_or(true, |c| c.sandboxed);
+    if !sandboxed {
+        return format!("[NON-SANDBOXED] {}", name);
+    }
+    match cfg.and_then(|c| c.sandbox_level.as_deref()) {
+        Some(level) => format!("{} [{}] {}", sandbox_level_glyph(level), level, name),
+        None => name.to_string(),
     }
 }
 

--- a/lince-dashboard/plugin/src/config.rs
+++ b/lince-dashboard/plugin/src/config.rs
@@ -139,6 +139,59 @@ fn default_sandbox_command() -> String {
     DEFAULT_SANDBOX_COMMAND.to_string()
 }
 
+fn default_paranoid_color() -> String {
+    "green".to_string()
+}
+fn default_normal_color() -> String {
+    "blue".to_string()
+}
+fn default_permissive_color() -> String {
+    "yellow".to_string()
+}
+fn default_sandbox_default_color() -> String {
+    "white".to_string()
+}
+
+/// Color mapping for sandbox isolation levels.
+///
+/// Drives both the per-pane title indicator and the wizard's profile-selection
+/// step. ANSI color names (e.g. `"green"`, `"blue"`, `"magenta"`). Sandbox
+/// levels other than the three built-ins fall back to `default`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SandboxColors {
+    #[serde(default = "default_paranoid_color")]
+    pub paranoid: String,
+    #[serde(default = "default_normal_color")]
+    pub normal: String,
+    #[serde(default = "default_permissive_color")]
+    pub permissive: String,
+    #[serde(default = "default_sandbox_default_color")]
+    pub default: String,
+}
+
+impl Default for SandboxColors {
+    fn default() -> Self {
+        Self {
+            paranoid: default_paranoid_color(),
+            normal: default_normal_color(),
+            permissive: default_permissive_color(),
+            default: default_sandbox_default_color(),
+        }
+    }
+}
+
+impl SandboxColors {
+    /// Resolve the color name for a sandbox level. Custom levels return `default`.
+    pub fn for_level(&self, level: &str) -> &str {
+        match level {
+            "paranoid" => &self.paranoid,
+            "normal" => &self.normal,
+            "permissive" => &self.permissive,
+            _ => &self.default,
+        }
+    }
+}
+
 fn default_status_file_dir() -> String {
     "/tmp/lince-dashboard".to_string()
 }
@@ -196,6 +249,11 @@ pub struct DashboardConfig {
     #[allow(dead_code)]
     #[serde(default)]
     pub sandbox_backend: BackendConfig,
+    /// Color mapping for sandbox isolation levels (`paranoid` / `normal` /
+    /// `permissive` / fallback). Configurable via `[dashboard.sandbox_colors]`
+    /// in `~/.config/lince-dashboard/config.toml`.
+    #[serde(default)]
+    pub sandbox_colors: SandboxColors,
 }
 
 impl Default for DashboardConfig {
@@ -214,6 +272,7 @@ impl Default for DashboardConfig {
             max_agents: default_max_agents(),
             agent_types: HashMap::new(),
             sandbox_backend: BackendConfig::default(),
+            sandbox_colors: SandboxColors::default(),
         }
     }
 }

--- a/lince-dashboard/plugin/src/dashboard.rs
+++ b/lince-dashboard/plugin/src/dashboard.rs
@@ -19,6 +19,24 @@ fn color_name_to_ansi(name: &str) -> &'static str {
     }
 }
 
+/// ANSI background sequence for the wizard's selection block.
+///
+/// Forces a black foreground for light backgrounds (yellow/cyan/white) so
+/// the highlighted text stays readable. Dark backgrounds keep the default
+/// foreground.
+fn selection_bg_for_color(name: &str) -> &'static str {
+    match name {
+        "red" => "\x1b[41m",
+        "green" => "\x1b[42m",
+        "yellow" => "\x1b[30;43m",
+        "blue" => "\x1b[44m",
+        "magenta" => "\x1b[45m",
+        "cyan" => "\x1b[30;46m",
+        "white" => "\x1b[30;47m",
+        _ => "\x1b[30;47m",
+    }
+}
+
 const RESET: &str = "\x1b[0m";
 const BOLD: &str = "\x1b[1m";
 const REVERSE: &str = "\x1b[7m";
@@ -685,8 +703,16 @@ pub fn render_wizard(
                 };
                 let label = format!("{}{}", display_name, backend_suffix);
                 if is_selected {
-                    // Green background for sandboxed, red for non-sandboxed
-                    let bg = if sandboxed { "\x1b[42m" } else { "\x1b[41m" }; // bg green / bg red
+                    // Selection background follows the sandbox-level palette:
+                    // paranoid/normal/permissive/custom each get their configured
+                    // color. Non-sandboxed stays red. Sandboxed entries with no
+                    // sandbox_level (legacy templates) fall back to the default.
+                    let bg = if !sandboxed {
+                        "\x1b[41m"
+                    } else {
+                        let level = cfg.and_then(|c| c.sandbox_level.as_deref()).unwrap_or("");
+                        selection_bg_for_color(sandbox_colors.for_level(level))
+                    };
                     push_box_line(&mut lines, &format!("  {}> {}{}", bg, label, RESET), box_width);
                 } else {
                     push_box_line(&mut lines, &format!("    {}", label), box_width);

--- a/lince-dashboard/plugin/src/dashboard.rs
+++ b/lince-dashboard/plugin/src/dashboard.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::config::AgentTypeConfig;
+use crate::config::{AgentTypeConfig, SandboxColors};
 use crate::types::{
     AgentInfo, AgentStatus, NamePromptState, WizardState, WizardStep,
 };
@@ -632,7 +632,13 @@ fn render_status_bar(
 
 // ── Overlay: Wizard (LINCE-47) ─────────────────────────────────────
 
-pub fn render_wizard(wizard: &WizardState, rows: usize, cols: usize, agent_types: &HashMap<String, AgentTypeConfig>) {
+pub fn render_wizard(
+    wizard: &WizardState,
+    rows: usize,
+    cols: usize,
+    agent_types: &HashMap<String, AgentTypeConfig>,
+    sandbox_colors: &SandboxColors,
+) {
     if rows == 0 || cols == 0 {
         return;
     }
@@ -702,10 +708,18 @@ pub fn render_wizard(wizard: &WizardState, rows: usize, cols: usize, agent_types
             push_box_line(&mut lines, "  [Enter] Create  [Bksp] Back  [Esc] Cancel", box_width);
         }
         WizardStep::Profile => {
-            // Render profile list with selection marker
+            // Render profile list with selection marker.
+            // Profiles named after sandbox levels (paranoid/normal/permissive)
+            // pick up the configured palette; custom profile names get the
+            // default color. Matches the per-pane title indicator (gh#63).
             for (i, name) in wizard.available_profiles.iter().enumerate() {
                 let marker = if i == wizard.profile_index { ">" } else { " " };
-                push_box_line(&mut lines, &format!("  {} {}", marker, name), box_width);
+                let color = color_name_to_ansi(sandbox_colors.for_level(name));
+                push_box_line(
+                    &mut lines,
+                    &format!("  {} {}{}{}", marker, color, name, RESET),
+                    box_width,
+                );
             }
             push_box_line(&mut lines, "", box_width);
             push_box_line(&mut lines, "  [j/k] Select  [Enter] Next  [Esc] Cancel", box_width);

--- a/lince-dashboard/plugin/src/main.rs
+++ b/lince-dashboard/plugin/src/main.rs
@@ -383,7 +383,13 @@ impl ZellijPlugin for State {
 
         // If wizard is active, render the wizard overlay instead of the dashboard
         if let Some(ref wizard) = self.wizard {
-            dashboard::render_wizard(wizard, rows, cols, &self.config.agent_types);
+            dashboard::render_wizard(
+                wizard,
+                rows,
+                cols,
+                &self.config.agent_types,
+                &self.config.sandbox_colors,
+            );
             return;
         }
 


### PR DESCRIPTION
## Summary

Closes #63.

Adds a per-pane title indicator and matching wizard colors so the sandbox isolation level (`paranoid` / `normal` / `permissive` / custom) is visible at a glance.

- **Pane title.** `pane_title()` (`agent.rs`) prefixes sandboxed agents with a fixed glyph + bracketed level name: 🟢 `[paranoid]` / 🔵 `[normal]` / 🟡 `[permissive]` / ⚪ `[<custom>]`. Unsandboxed agents keep `[NON-SANDBOXED]`; legacy no-`sandbox_level` paths are unchanged.
- **Wizard.** The "N" wizard's *Profile* step now colors profile names using the sandbox-level palette (per the issue comment).
- **Configurable.** New `[dashboard.sandbox_colors]` block in `~/.config/lince-dashboard/config.toml` overrides the wizard color mapping. Defaults: `paranoid=green, normal=blue, permissive=yellow, default=white`.
- **Custom levels** fall back to the configurable default color and a neutral glyph — no layout breakage.
- **Frame-disabled regression.** No-op: when frames are off Zellij hides the title, agent runs unchanged. Wizard color and dashboard table still convey the level.

## Why title-prefix instead of true frame color

`zellij-tile 0.44.0` does not expose a per-pane frame *border* color API. `set_pane_color` exists but tints the pane's content fg/bg, which would clobber agent output. The issue's Notes section anticipated this (*"a tab/title indicator could be an acceptable alternative"*); the title path also reuses the existing `rename_pane_with_id` plumbing.

## Test plan

- [ ] Build: `cd lince-dashboard/plugin && PATH="$HOME/.cargo/bin:$PATH" $HOME/.cargo/bin/cargo build --target wasm32-wasip1` — passes locally with no new warnings.
- [ ] Press `N`, walk through the wizard. The Profile step shows `paranoid` in green, `normal` in blue, `permissive` in yellow.
- [ ] Spawn one agent at each level. Each pane title reads `🟢 [paranoid] <name>` / `🔵 [normal] <name>` / `🟡 [permissive] <name>`.
- [ ] Override `[dashboard.sandbox_colors] paranoid = "magenta"`, restart — wizard shows magenta; pane glyph unchanged (intentional).
- [ ] Define a custom agent with `sandbox_level = "fortress"` — title is `⚪ [fortress] <name>`; layout intact.
- [ ] Toggle Zellij pane frames off — agent runs normally, no error.

## Out of scope

- Per-pane frame *border* color (would need a new zellij-tile API).
- Themable glyphs in TOML (deliberate — the color is the customization knob, the glyph stays stable across users).
- Unit tests: the dashboard plugin has no host-target test scaffolding today, and `zellij_tile` imports make adding it non-trivial. Worth a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)