### PR TITLE
fix: emit valid gitconfig for dotted-section overrides

### DIFF
--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -1660,7 +1660,15 @@ def sanitize_gitconfig(source: Path, dest: Path,
         for key, val in overrides.items():
             section, _, name = key.rpartition(".")
             if section and name:
-                out.append(f"[{section}]")
+                # Gitconfig dotted sections use [section "subsection"] syntax.
+                # rpartition always gives us (everything-before-last-dot, ., name).
+                # If *section* contains dots (e.g. "credential.https://github.com")
+                # we must split it into section + quoted subsection.
+                parts = section.split(".", 1)
+                if len(parts) == 2:
+                    out.append(f'[{parts[0]} "{parts[1]}"]')
+                else:
+                    out.append(f"[{section}]")
                 out.append(f"\t{name} = {val}")
 
     dest.write_text("\n".join(out) + "\n")


### PR DESCRIPTION
## Summary

Fixes #69

`sanitize_gitconfig()` override rendering produced invalid gitconfig when the section name contains dots (e.g. `credential.https://github.com.helper` → `[credential.https://github.com]` instead of `[credential "https://github.com"]`).

**Fix**: Split the section on the first dot. If two parts → `[section "subsection"]`, else → `[section]` (unchanged behavior).

### Before (broken)

```gitconfig
[credential.https://github.com]
    helper = !/usr/bin/gh auth git-credential
```

Git: `fatal: bad config line N`

### After (correct)

```gitconfig
[credential "https://github.com"]
    helper = !/usr/bin/gh auth git-credential
```

Git parses correctly, credential resolution works.

### Verification

All key patterns tested:

| Key | Output |
|---|---|
| `push.default` | `[push]` (unchanged) |
| `credential.helper` | `[credential]` (unchanged) |
| `credential.https://github.com.helper` | `[credential "https://github.com"]` (fixed) |
| `remote.origin.url` | `[remote "origin"]` (fixed) |
| `branch.main.remote` | `[branch "main"]` (fixed) |

## Test plan

- [x] Verified `git config --get-regexp` parses all generated section formats
- [x] Verified `git credential fill` resolves credentials with the fixed output
- [x] Backwards-compatible: simple keys (`push.default`, `credential.helper`) produce identical output

🤖 Generated with [Claude Code](https://claude.com/claude-code)