### PR TITLE
fix: treat rsync exit 23 (partial transfer) as non-fatal

### DIFF
--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -3300,7 +3300,10 @@ def create_snapshot(
     rsync_cmd.append(str(dest) + "/")
 
     result = subprocess.run(rsync_cmd, capture_output=True, text=True)
-    if result.returncode != 0:
+    # rsync exit 23 = partial transfer (some files/attrs not transferred).
+    # This commonly happens with --link-dest when symlinks in node_modules
+    # cannot be hard-linked.  The snapshot is still usable — treat as warning.
+    if result.returncode not in (0, 23):
         print(
             f"Error: rsync failed (exit {result.returncode}): "
             f"{result.stderr.strip()}",
@@ -3309,6 +3312,12 @@ def create_snapshot(
         if dest.exists():
             shutil.rmtree(dest)
         sys.exit(1)
+    if result.returncode == 23 and result.stderr.strip():
+        print(
+            f"  rsync: minor copy issues (non-fatal): "
+            f"{result.stderr.strip()[:200]}",
+            file=sys.stderr,
+        )
 
     return dest
 


### PR DESCRIPTION
## Summary

- Treat rsync exit code 23 (partial transfer) as a non-fatal warning in `create_snapshot()` instead of deleting the snapshot and failing
- The snapshot is preserved since the vast majority of files are copied successfully; only a warning is printed with the truncated stderr

## Context

When `rsync --link-dest=...` encounters symlinks it can't hardlink (e.g. `node_modules/.bin/` entries), it exits with code 23. This is documented as a non-fatal partial transfer in rsync's man page, but the current code treats it the same as a real failure.

Closes #72

## Test plan

- [ ] Run `agent-sandbox` with a project containing `node_modules/.bin` symlinks
- [ ] Verify config snapshot is created despite rsync exit 23
- [ ] Verify warning message is printed to stderr
- [ ] Verify that a genuine rsync failure (e.g. exit 1, 2) still deletes the snapshot and fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)