### PR TITLE
docs: document Terminator+Zellij Ctrl+Shift+C SIGINT workaround

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -146,6 +146,21 @@ export PATH="$HOME/.local/bin:$PATH"
    alias zd
    ```
 
+### Ctrl+Shift+C kills agent (Terminator + Zellij)
+
+When running agents inside the LINCE Dashboard (Zellij) on **Terminator**, pressing **Ctrl+Shift+C** to copy also delivers a SIGINT to the agent in the focused pane, interrupting it. The same key combo works fine in Terminator without Zellij — the issue only appears with the Terminator + Zellij combination.
+
+**Fix**: remap Terminator's copy shortcut to a key that doesn't include Ctrl+C.
+
+Option 1 — Edit `~/.config/terminator/config`:
+```ini
+[keybindings]
+copy = <Primary>Insert
+```
+Then restart Terminator. Ctrl+Insert now copies without sending SIGINT.
+
+Option 2 — Via GUI: open **Terminator → Preferences → Keybindings**, find **copy_clipboard**, and bind it to `Ctrl+Insert` or another key that doesn't include Ctrl+C.
+
 ---
 
 ## Requirements Summary

--- a/docs/documentation/dashboard/usage-guide.md
+++ b/docs/documentation/dashboard/usage-guide.md
@@ -239,6 +239,23 @@ passthrough = ["ZELLIJ", "ZELLIJ_SESSION_NAME", "LINCE_AGENT_ID"]
 
 Agent-specific environment variables (e.g. `OPENAI_API_KEY` for Codex) are set via the `env_vars` field in the agent type configuration and passed through automatically.
 
+## Troubleshooting
+
+### Ctrl+Shift+C kills agent (Terminator + Zellij)
+
+When running agents inside the dashboard on **Terminator**, pressing **Ctrl+Shift+C** to copy also delivers a SIGINT to the agent in the focused pane, interrupting it. The same key combo behaves correctly in Terminator without Zellij — the conflict only appears in the Terminator + Zellij combination.
+
+**Fix**: remap Terminator's copy shortcut to a key that doesn't include Ctrl+C.
+
+Option 1 — Edit `~/.config/terminator/config`:
+```ini
+[keybindings]
+copy = <Primary>Insert
+```
+Restart Terminator. `Ctrl+Insert` will copy without sending SIGINT.
+
+Option 2 — Via GUI: **Terminator → Preferences → Keybindings → copy_clipboard**, bind it to `Ctrl+Insert` or another shortcut that doesn't include Ctrl+C.
+
 ## See Also
 
 - [Configuration Reference](dashboard/config-reference.md) -- all config keys and their defaults


### PR DESCRIPTION
## Summary

- Adds a troubleshooting entry in `QUICKSTART.md` for users hit by Ctrl+Shift+C sending SIGINT to agents when using Terminator + Zellij
- Adds the same entry under a new **Troubleshooting** section in `docs/documentation/dashboard/usage-guide.md`
- Notes that the conflict only appears in the Terminator+Zellij combination (Terminator alone is fine)
- Provides two fix paths: editing `~/.config/terminator/config` directly or using the Terminator Preferences GUI

Closes #71

## Test plan

- [ ] Read the QUICKSTART.md troubleshooting section and verify the steps are clear
- [ ] Read the usage-guide Troubleshooting section and verify formatting renders correctly
- [ ] Apply the keybinding change in Terminator and confirm Ctrl+Insert copies without interrupting the agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)