### PR TITLE
dashboard: pick sandbox backend + level at spawn time (gh#53)

### DIFF
--- a/docs/documentation/dashboard/sandbox-levels.md
+++ b/docs/documentation/dashboard/sandbox-levels.md
@@ -317,8 +317,16 @@ The plugin synthesizes the launch command from `(agent_type, sandbox_backend, sa
 
 File-naming convention:
 
-- **nono**: `~/.config/nono/profiles/lince-<agent>-<level>.json`
-- **agent-sandbox**: `~/.agent-sandbox/profiles/<level>.toml` (or in-repo `sandbox/profiles/<level>.toml` for built-ins)
+- **nono**: `~/.config/nono/profiles/lince-<agent>-<level>.json` (always agent-specific)
+- **agent-sandbox**: either form is supported, agent-sandbox tries them in this order:
+  - `~/.agent-sandbox/profiles/<agent>-<level>.toml` (agent-specific override)
+  - `~/.agent-sandbox/profiles/<level>.toml` (agent-agnostic — applies to every agent)
+
+> **Wizard auto-discovery.** The `N` wizard's *Sandbox Level* step scans both
+> directories above and lists every level it finds, in addition to the shipped
+> `paranoid` / `normal` / `permissive` defaults. Drop a profile file in either
+> path and re-open the wizard — your custom level shows up. Removing a file
+> removes the level on the next wizard open. No config edit needed.
 
 ### Worked example: a custom level for AWS Bedrock
 

--- a/lince-dashboard/agents-defaults.toml
+++ b/lince-dashboard/agents-defaults.toml
@@ -21,11 +21,25 @@
 #   docs/documentation/dashboard/sandbox-levels.md
 #   https://lince.sh/documentation/#/dashboard/sandbox-levels
 #
-# Alternative paranoid / permissive variants live in `agents-template.toml`
-# (sibling file, NOT loaded by the dashboard). To enable them, either re-run
-# install.sh and pick the levels in the prompt, or copy the desired blocks
-# from `~/.config/lince-dashboard/agents-template.toml` into your own
-# `~/.config/lince-dashboard/config.toml`.
+# sandbox_level here is the *default selection* in the wizard's SandboxLevel
+# step. Users can override it per-spawn via the [N] wizard — no need to
+# maintain separate paranoid/permissive agent-type entries any more.
+#
+# Custom sandbox levels are auto-discovered by the wizard — drop a profile
+# file under one of these paths and it will appear in the SandboxLevel step:
+#   - nono backend (always agent-specific):
+#       ~/.config/nono/profiles/lince-<agent>-<level>.json
+#       (e.g. lince-claude-strict.json adds "strict" for claude only)
+#   - agent-sandbox backend (either form is supported):
+#       ~/.agent-sandbox/profiles/<agent>-<level>.toml   (agent-specific)
+#       ~/.agent-sandbox/profiles/<level>.toml           (applies to all agents)
+# The shipped defaults paranoid/normal/permissive always appear regardless of
+# what's on disk.
+#
+# Alternative paranoid / permissive variants in `agents-template.toml`
+# (sibling file, NOT loaded by the dashboard) are now redundant with the
+# wizard. They continue to work if already present in config.toml, but
+# new installs need only this file.
 
 [agents.claude]
 # Legacy fallback command — ignored when sandbox_level is set (the plugin
@@ -193,6 +207,50 @@ sandbox_level = "normal"          # paranoid | normal | permissive (or custom; s
 # `sandbox_level = "<custom>"` here. See sandbox-levels.md.
 
 [agents.pi.env_vars]
+ANTHROPIC_API_KEY = "$ANTHROPIC_API_KEY"
+ANTHROPIC_BASE_URL = "$ANTHROPIC_BASE_URL"
+OPENAI_API_KEY = "$OPENAI_API_KEY"
+OPENAI_BASE_URL = "$OPENAI_BASE_URL"
+AZURE_OPENAI_API_KEY = "$AZURE_OPENAI_API_KEY"
+AZURE_OPENAI_BASE_URL = "$AZURE_OPENAI_BASE_URL"
+GEMINI_API_KEY = "$GEMINI_API_KEY"
+GOOGLE_CLOUD_PROJECT = "$GOOGLE_CLOUD_PROJECT"
+GOOGLE_CLOUD_LOCATION = "$GOOGLE_CLOUD_LOCATION"
+DEEPSEEK_API_KEY = "$DEEPSEEK_API_KEY"
+MISTRAL_API_KEY = "$MISTRAL_API_KEY"
+GROQ_API_KEY = "$GROQ_API_KEY"
+CEREBRAS_API_KEY = "$CEREBRAS_API_KEY"
+CLOUDFLARE_API_KEY = "$CLOUDFLARE_API_KEY"
+CLOUDFLARE_ACCOUNT_ID = "$CLOUDFLARE_ACCOUNT_ID"
+XAI_API_KEY = "$XAI_API_KEY"
+OPENROUTER_API_KEY = "$OPENROUTER_API_KEY"
+AI_GATEWAY_API_KEY = "$AI_GATEWAY_API_KEY"
+ZAI_API_KEY = "$ZAI_API_KEY"
+OPENCODE_API_KEY = "$OPENCODE_API_KEY"
+FIREWORKS_API_KEY = "$FIREWORKS_API_KEY"
+KIMI_API_KEY = "$KIMI_API_KEY"
+MINIMAX_API_KEY = "$MINIMAX_API_KEY"
+MINIMAX_CN_API_KEY = "$MINIMAX_CN_API_KEY"
+AWS_PROFILE = "$AWS_PROFILE"
+AWS_REGION = "$AWS_REGION"
+AWS_ACCESS_KEY_ID = "$AWS_ACCESS_KEY_ID"
+AWS_SECRET_ACCESS_KEY = "$AWS_SECRET_ACCESS_KEY"
+AWS_SESSION_TOKEN = "$AWS_SESSION_TOKEN"
+AWS_BEARER_TOKEN_BEDROCK = "$AWS_BEARER_TOKEN_BEDROCK"
+AWS_ENDPOINT_URL_BEDROCK_RUNTIME = "$AWS_ENDPOINT_URL_BEDROCK_RUNTIME"
+
+[agents.pi-unsandboxed]
+command = ["pi"]
+pane_title_pattern = "pi"
+status_pipe_name = "lince-status"
+display_name = "Pi (unsandboxed)"
+short_label = "PIU"
+color = "red"
+sandboxed = false
+has_native_hooks = true
+profiles = ["__discover__"]
+
+[agents.pi-unsandboxed.env_vars]
 ANTHROPIC_API_KEY = "$ANTHROPIC_API_KEY"
 ANTHROPIC_BASE_URL = "$ANTHROPIC_BASE_URL"
 OPENAI_API_KEY = "$OPENAI_API_KEY"

--- a/lince-dashboard/plugin/src/agent.rs
+++ b/lince-dashboard/plugin/src/agent.rs
@@ -49,17 +49,24 @@ pub fn sandbox_level_glyph(level: &str) -> &'static str {
 /// Build pane title with a sandbox-level indicator.
 ///
 /// - Non-sandboxed agent types: `[NON-SANDBOXED] <name>` (unchanged).
-/// - Sandboxed with a known `sandbox_level`: `<glyph> [<level>] <name>`,
-///   e.g. `🟢 [paranoid] agent-1`.
-/// - Sandboxed with `sandbox_level = None` (legacy static command path):
-///   `<name>` (unchanged).
-pub fn pane_title(name: &str, agent_type: &str, agent_types: &HashMap<String, AgentTypeConfig>) -> String {
+/// - Sandboxed with a known level: `<glyph> [<level>] <name>`, e.g. `🟢 [paranoid] agent-1`.
+///   The level is taken from `sandbox_level_override` (runtime wizard selection) first,
+///   then falls back to the TOML-pinned `sandbox_level` for the agent type.
+/// - Sandboxed with no level anywhere (legacy static command): `<name>` (unchanged).
+pub fn pane_title(
+    name: &str,
+    agent_type: &str,
+    agent_types: &HashMap<String, AgentTypeConfig>,
+    sandbox_level_override: Option<&str>,
+) -> String {
     let cfg = agent_types.get(agent_type);
     let sandboxed = cfg.map_or(true, |c| c.sandboxed);
     if !sandboxed {
         return format!("[NON-SANDBOXED] {}", name);
     }
-    match cfg.and_then(|c| c.sandbox_level.as_deref()) {
+    let level = sandbox_level_override
+        .or_else(|| cfg.and_then(|c| c.sandbox_level.as_deref()));
+    match level {
         Some(level) => format!("{} [{}] {}", sandbox_level_glyph(level), level, name),
         None => name.to_string(),
     }
@@ -262,6 +269,8 @@ fn spawn_inner(
     profile: Option<String>,
     project_dir: String,
     group: Option<String>,
+    sandbox_level_override: Option<String>,
+    sandbox_backend_override: Option<SandboxBackend>,
 ) -> Result<AgentInfo, String> {
     if agents.len() >= config.max_agents {
         return Err(format!(
@@ -325,10 +334,17 @@ fn spawn_inner(
         // final and skips expand_command_template. The legacy/static path
         // (no sandbox_level set, or agent type not yet covered) goes
         // through the placeholder-substitution helper as before.
-        let synthesized = type_config.sandbox_level.as_deref().and_then(|level| {
+        // Runtime override takes precedence over the TOML-pinned sandbox_level.
+        let effective_level = sandbox_level_override.as_deref()
+            .or_else(|| type_config.sandbox_level.as_deref());
+        // Same precedence rule for sandbox_backend.
+        let effective_backend = sandbox_backend_override
+            .as_ref()
+            .unwrap_or(&type_config.sandbox_backend);
+        let synthesized = effective_level.and_then(|level| {
             synthesize_sandboxed_command(
                 agent_type,
-                &type_config.sandbox_backend,
+                effective_backend,
                 level,
                 &id,
                 &project_dir,
@@ -354,7 +370,7 @@ fn spawn_inner(
         // For agent-sandbox (bwrap) agents, pass the profile via -P flag so
         // agent-sandbox can resolve the profile's env vars internally.
         // Nono agents already have --profile baked into their command template.
-        if type_config.sandboxed && type_config.sandbox_backend == SandboxBackend::AgentSandbox {
+        if type_config.sandboxed && *effective_backend == SandboxBackend::AgentSandbox {
             if let Some(ref p) = profile {
                 if !p.is_empty() {
                     expanded.push("-P".to_string());
@@ -398,6 +414,13 @@ fn spawn_inner(
 
     let started_at = now_secs();
 
+    // Resolve the effective sandbox level to store on AgentInfo for color-coding and save/restore.
+    let resolved_sandbox_level = sandbox_level_override
+        .or_else(|| config.agent_types.get(agent_type).and_then(|c| c.sandbox_level.clone()));
+    // Resolved backend for save/restore + dashboard table label override.
+    let resolved_sandbox_backend = sandbox_backend_override
+        .or_else(|| config.agent_types.get(agent_type).map(|c| c.sandbox_backend.clone()));
+
     Ok(AgentInfo {
         id,
         name,
@@ -416,10 +439,16 @@ fn spawn_inner(
         running_subagents: 0,
         model: None,
         last_polled_event: None,
+        sandbox_level: resolved_sandbox_level,
+        sandbox_backend: resolved_sandbox_backend,
     })
 }
 
-/// Spawn a new agent with custom name, profile, and project directory.
+/// Spawn a new agent with custom name, profile, project directory, and optional sandbox overrides.
+///
+/// `sandbox_level_override` / `sandbox_backend_override` are the runtime values selected in the
+/// wizard (or restored from saved state). When `None`, `spawn_inner` falls back to the
+/// TOML-pinned values for the agent type.
 pub fn spawn_agent_custom(
     config: &DashboardConfig,
     next_id: &mut u32,
@@ -429,6 +458,8 @@ pub fn spawn_agent_custom(
     custom_profile: Option<String>,
     custom_project_dir: String,
     launch_dir: Option<&str>,
+    sandbox_level_override: Option<String>,
+    sandbox_backend_override: Option<SandboxBackend>,
 ) -> Result<AgentInfo, String> {
     let profile = match custom_profile {
         Some(ref p) if p.is_empty() => None,
@@ -441,7 +472,18 @@ pub fn spawn_agent_custom(
         crate::config::expand_tilde(&custom_project_dir)
     };
 
-    spawn_inner(config, next_id, agents, custom_name, agent_type, profile, project_dir, None)
+    spawn_inner(
+        config,
+        next_id,
+        agents,
+        custom_name,
+        agent_type,
+        profile,
+        project_dir,
+        None,
+        sandbox_level_override,
+        sandbox_backend_override,
+    )
 }
 
 /// Stop an agent by closing its pane.
@@ -493,23 +535,34 @@ pub fn reconcile_panes(
                 }
             }
         } else if agent.status == AgentStatus::Starting {
-            // Resolve the pane title pattern for this agent's type.
-            // Falls back to "agent-sandbox" if the agent type is not in config.
-            let pattern = agent_types
-                .get(&agent.agent_type)
+            // Resolve pane title patterns for this agent's type. For sandboxed
+            // agents the actual title varies by backend (agent-sandbox / nono /
+            // bash wrapper), so we accept any of: the TOML-configured pattern,
+            // "nono" (for nono backend), and the agent's base name (e.g. "claude"
+            // — the inner command Zellij ends up showing for some launchers).
+            // Unsandboxed agents only match the TOML pattern (usually the binary name).
+            let cfg = agent_types.get(&agent.agent_type);
+            let primary_pattern = cfg
                 .map(|c| c.pane_title_pattern.as_str())
                 .unwrap_or(DEFAULT_SANDBOX_COMMAND);
+            let base = agent_type_base_name(&agent.agent_type);
+            let sandboxed = cfg.map_or(true, |c| c.sandboxed);
+            let patterns: Vec<&str> = if sandboxed {
+                vec![primary_pattern, "nono", base]
+            } else {
+                vec![primary_pattern]
+            };
             for pane in &all_panes {
                 if pane.is_floating == expect_floating
                     && !pane.is_suppressed
                     && !pane.exited
                     && !assigned_ids.contains(&pane.id)
-                    && pane.title.contains(pattern)
+                    && patterns.iter().any(|p| pane.title.contains(p))
                 {
                     agent.pane_id = Some(pane.id);
                     assigned_ids.insert(pane.id);
                     agent.status = AgentStatus::WaitingForInput;
-                    let title = pane_title(&agent.name, &agent.agent_type, agent_types);
+                    let title = pane_title(&agent.name, &agent.agent_type, agent_types, agent.sandbox_level.as_deref());
                     rename_pane_with_id(PaneId::Terminal(pane.id), &title);
                     if expect_floating {
                         hide_pane_with_id(PaneId::Terminal(pane.id));

--- a/lince-dashboard/plugin/src/config.rs
+++ b/lince-dashboard/plugin/src/config.rs
@@ -254,6 +254,14 @@ pub struct DashboardConfig {
     /// in `~/.config/lince-dashboard/config.toml`.
     #[serde(default)]
     pub sandbox_colors: SandboxColors,
+    /// Custom sandbox levels discovered from the filesystem, keyed by
+    /// `<backend>:<base>` (e.g. `"nono:claude"` or `"agent-sandbox:claude"`).
+    /// Populated asynchronously by `discover_sandbox_levels_async()` reading
+    /// profile files matching `~/.config/nono/profiles/lince-<base>-*.json` and
+    /// `~/.agent-sandbox/profiles/<base>-*.toml`. Combined with the shipped
+    /// `paranoid`/`normal`/`permissive` defaults by `supported_sandbox_levels()`.
+    #[serde(skip)]
+    pub discovered_sandbox_levels: HashMap<String, Vec<String>>,
 }
 
 impl Default for DashboardConfig {
@@ -273,6 +281,7 @@ impl Default for DashboardConfig {
             agent_types: HashMap::new(),
             sandbox_backend: BackendConfig::default(),
             sandbox_colors: SandboxColors::default(),
+            discovered_sandbox_levels: HashMap::new(),
         }
     }
 }
@@ -376,6 +385,11 @@ pub fn run_typed_command_with(args: &[&str], cmd_type: &str, extra: &[(&str, &st
 
 /// Command type for async path tab-completion via `run_command`.
 pub const CMD_PATH_COMPLETE: &str = "path_complete";
+
+/// Command type for async discovery of custom sandbox-level profiles.
+/// Output format: lines of `<backend>:<base>:<level>` (or `<backend>:<base>:` for the
+/// suffix-less "normal" profile). See `discover_sandbox_levels_async()`.
+pub const CMD_DISCOVER_SANDBOX_LEVELS: &str = "discover_sandbox_levels";
 
 /// Extract profile details from a TOML table (the value side of a `[*.profiles.<name>]` entry).
 fn parse_profile_details(profile_table: &toml::Table) -> ProfileDetails {
@@ -503,6 +517,83 @@ pub fn discover_profiles_async(sandbox_config_path: Option<&str>, launch_dir: Op
     }
 
     run_typed_command(&["sh", "-c", &script], CMD_DISCOVER_PROFILES);
+}
+
+/// Kick off async discovery of custom sandbox-level profile files.
+///
+/// Globs:
+/// - `~/.config/nono/profiles/lince-<base>-*.json` (nono: per-agent only)
+/// - `~/.agent-sandbox/profiles/<base>-<level>.toml` (agent-sandbox: per-agent)
+/// - `~/.agent-sandbox/profiles/<level>.toml` (agent-sandbox: agent-agnostic,
+///   matches agent-sandbox's own resolution order — see its source for the
+///   comment "tried as <agent>-<level>.toml then <level>.toml"). Agent-agnostic
+///   levels are emitted once per known base so the cache is populated uniformly.
+///
+/// Filenames are emitted as `<backend>:<base>:<level>` lines on stdout.
+/// Result arrives in `Event::RunCommandResult` with context
+/// `type=discover_sandbox_levels`; the handler parses and populates
+/// `DashboardConfig.discovered_sandbox_levels`.
+pub fn discover_sandbox_levels_async(bases: &[String]) {
+    if bases.is_empty() {
+        return;
+    }
+    let mut script = String::new();
+    // Per-base globs: nono (always per-agent) + agent-sandbox <base>-<level>.toml.
+    for base in bases {
+        let b = shell_escape(base);
+        script.push_str(&format!(
+            "find \"$HOME/.config/nono/profiles\" -maxdepth 1 -type f \
+                -name 'lince-{base}-*.json' 2>/dev/null \
+                | sed -n 's|.*/lince-{base}-\\(.*\\)\\.json$|nono:{base}:\\1|p';\n",
+            base = b,
+        ));
+        script.push_str(&format!(
+            "find \"$HOME/.agent-sandbox/profiles\" -maxdepth 1 -type f \
+                -name '{base}-*.toml' 2>/dev/null \
+                | sed -n 's|.*/{base}-\\(.*\\)\\.toml$|agent-sandbox:{base}:\\1|p';\n",
+            base = b,
+        ));
+    }
+    // Agent-agnostic agent-sandbox profiles: any *.toml whose stem doesn't start
+    // with `<known-base>-`. Each such level applies to ALL bases, so we emit one
+    // line per base. Skip-patterns are quoted shell `case` patterns built from
+    // the same base list to avoid double-counting per-base files.
+    let bases_quoted: Vec<String> = bases.iter().map(|b| format!("'{}'", shell_escape(b))).collect();
+    let skip_patterns: Vec<String> = bases.iter().map(|b| format!("{}-*", shell_escape(b))).collect();
+    script.push_str(&format!(
+        "find \"$HOME/.agent-sandbox/profiles\" -maxdepth 1 -type f -name '*.toml' 2>/dev/null \
+         | while IFS= read -r f; do \
+             name=$(basename \"$f\" .toml); \
+             case \"$name\" in {skip}) continue;; esac; \
+             for base in {bases}; do \
+                 printf 'agent-sandbox:%s:%s\\n' \"$base\" \"$name\"; \
+             done; \
+         done\n",
+        skip = skip_patterns.join("|"),
+        bases = bases_quoted.join(" "),
+    ));
+    run_typed_command(&["sh", "-c", &script], CMD_DISCOVER_SANDBOX_LEVELS);
+}
+
+/// Parse the stdout of `discover_sandbox_levels_async()` into a
+/// `<backend>:<base> -> [level, ...]` map. Empty / malformed lines are skipped.
+pub fn parse_discovered_sandbox_levels(stdout: &[u8]) -> HashMap<String, Vec<String>> {
+    let output = String::from_utf8_lossy(stdout);
+    let mut out: HashMap<String, Vec<String>> = HashMap::new();
+    for line in output.lines() {
+        // Format: backend:base:level — parse from the right so base names with
+        // `-` (none today, future-proofing) survive.
+        let mut parts = line.splitn(3, ':');
+        let backend = match parts.next() { Some(s) if !s.is_empty() => s, _ => continue };
+        let base = match parts.next() { Some(s) if !s.is_empty() => s, _ => continue };
+        let level = match parts.next() { Some(s) if !s.is_empty() => s, _ => continue };
+        let key = format!("{}:{}", backend, base);
+        let bucket = out.entry(key).or_default();
+        if !bucket.iter().any(|l| l == level) {
+            bucket.push(level.to_string());
+        }
+    }
+    out
 }
 
 /// Kick off async loading of agent type defaults from
@@ -676,6 +767,149 @@ impl DashboardConfig {
             .filter(|p| disc.contains(p))
             .cloned()
             .collect()
+    }
+
+    /// Return the supported sandbox levels for a given agent type and backend.
+    ///
+    /// Combines the shipped defaults (`paranoid`, `normal`, `permissive`) with
+    /// custom levels discovered from the filesystem (see
+    /// `discover_sandbox_levels_async()`). The standard order is preserved;
+    /// custom levels are appended in alphabetical order. Duplicates are
+    /// removed.
+    ///
+    /// Returns an empty vec for unsandboxed agents or when the agent type has
+    /// no `sandbox_level` field — the wizard uses that as the skip signal.
+    /// `backend == None` returns just the standard defaults (no per-backend
+    /// custom merge), used when the backend hasn't been picked yet.
+    pub fn supported_sandbox_levels(
+        &self,
+        agent_type: &str,
+        backend: Option<&crate::sandbox_backend::SandboxBackend>,
+    ) -> Vec<String> {
+        let cfg = match self.agent_types.get(agent_type) {
+            Some(c) => c,
+            None => return Vec::new(),
+        };
+        if !cfg.sandboxed || cfg.sandbox_level.is_none() {
+            return Vec::new();
+        }
+        let mut levels: Vec<String> = vec![
+            "paranoid".to_string(),
+            "normal".to_string(),
+            "permissive".to_string(),
+        ];
+        if let Some(b) = backend {
+            // Cache key MUST match the prefix that `discover_sandbox_levels_async`
+            // emits ("agent-sandbox:" / "nono:") — NOT `display_name()`, which
+            // returns "bwrap" for AgentSandbox and would silently miss the cache.
+            // `None` has no custom-profile concept (no fs lookup), so skip.
+            use crate::sandbox_backend::SandboxBackend;
+            let backend_key = match b {
+                SandboxBackend::AgentSandbox => "agent-sandbox",
+                SandboxBackend::Nono => "nono",
+                SandboxBackend::None => return levels,
+            };
+            let base = crate::agent::agent_type_base_name(agent_type);
+            let key = format!("{}:{}", backend_key, base);
+            if let Some(custom) = self.discovered_sandbox_levels.get(&key) {
+                let mut extras: Vec<String> = custom
+                    .iter()
+                    .filter(|l| !levels.iter().any(|s| s == *l))
+                    .cloned()
+                    .collect();
+                extras.sort();
+                levels.extend(extras);
+            }
+        }
+        levels
+    }
+
+    /// Enumerate unique *base* agent names with display names, sorted alphabetically.
+    /// Variants like `<base>-unsandboxed` / `<base>-paranoid` collapse into one
+    /// entry per base — the wizard recovers backend / level via subsequent steps.
+    ///
+    /// Display name preference: canonical sandboxed entry's `display_name` first,
+    /// then fall back to the unsandboxed variant with `" (unsandboxed)"` stripped,
+    /// finally to the bare base name.
+    pub fn base_agents(&self) -> Vec<(String, String)> {
+        use std::collections::BTreeSet;
+        let mut bases: BTreeSet<String> = BTreeSet::new();
+        for key in self.agent_types.keys() {
+            bases.insert(crate::agent::agent_type_base_name(key).to_string());
+        }
+        bases
+            .into_iter()
+            .map(|base| {
+                let display = if let Some(cfg) = self.agent_types.get(&base) {
+                    cfg.display_name.clone()
+                } else if let Some(cfg) = self.agent_types.get(&format!("{}-unsandboxed", base)) {
+                    cfg.display_name.replace(" (unsandboxed)", "")
+                } else {
+                    base.clone()
+                };
+                (base, display)
+            })
+            .collect()
+    }
+
+    /// Return the available sandbox backends for a base agent on this host.
+    ///
+    /// - When detection has completed: include only backends actually installed.
+    /// - When detection is pending (`detected = None`): fall back to the agent's
+    ///   TOML-pinned `sandbox_backend` only, so the wizard never offers a
+    ///   non-existent backend during the boot race. The wizard refreshes its
+    ///   list when `CMD_DETECT_BACKEND` resolves (see `main.rs` event handler).
+    /// - `None` is included whenever a `<base>-unsandboxed` entry exists,
+    ///   independent of detection state (no host check needed for "no sandbox").
+    pub fn available_backends_for_base(
+        &self,
+        base: &str,
+        detected: Option<&crate::sandbox_backend::DetectedBackends>,
+    ) -> Vec<crate::sandbox_backend::SandboxBackend> {
+        use crate::sandbox_backend::SandboxBackend;
+        let mut out = Vec::with_capacity(3);
+        let has_sandboxed = self.agent_types.get(base).map_or(false, |c| c.sandboxed);
+        let has_unsandboxed = self
+            .agent_types
+            .get(&format!("{}-unsandboxed", base))
+            .map_or(false, |c| !c.sandboxed);
+        if has_sandboxed {
+            match detected {
+                Some(d) => {
+                    if d.has_agent_sandbox {
+                        out.push(SandboxBackend::AgentSandbox);
+                    }
+                    if d.has_nono {
+                        out.push(SandboxBackend::Nono);
+                    }
+                }
+                None => {
+                    if let Some(cfg) = self.agent_types.get(base) {
+                        out.push(cfg.sandbox_backend.clone());
+                    }
+                }
+            }
+        }
+        if has_unsandboxed {
+            out.push(SandboxBackend::None);
+        }
+        out
+    }
+
+    /// Resolve the index of the preferred default backend for a base agent.
+    /// Preference order: TOML-pinned `sandbox_backend` on the canonical entry,
+    /// then first available (which is OS-aware via detection).
+    pub fn default_backend_index_for_base(
+        &self,
+        base: &str,
+        available: &[crate::sandbox_backend::SandboxBackend],
+    ) -> usize {
+        if let Some(cfg) = self.agent_types.get(base) {
+            if let Some(idx) = available.iter().position(|b| b == &cfg.sandbox_backend) {
+                return idx;
+            }
+        }
+        0
     }
 
     /// Look up profile details for a given agent type and profile name.

--- a/lince-dashboard/plugin/src/dashboard.rs
+++ b/lince-dashboard/plugin/src/dashboard.rs
@@ -195,6 +195,7 @@ pub fn render_dashboard(
     status_message: Option<&str>,
     name_prompt: Option<&NamePromptState>,
     agent_types: &HashMap<String, AgentTypeConfig>,
+    sandbox_colors: &SandboxColors,
 ) {
     if rows == 0 || cols == 0 {
         return;
@@ -225,7 +226,7 @@ pub fn render_dashboard(
     if agents.is_empty() {
         render_empty_state(table_rows, cols);
     } else {
-        render_agent_table(agents, selected, focused, table_rows, cols, agent_types);
+        render_agent_table(agents, selected, focused, table_rows, cols, agent_types, sandbox_colors);
     }
 
     if let Some(detail_id) = detail {
@@ -284,6 +285,7 @@ fn render_agent_table(
     table_rows: usize,
     cols: usize,
     agent_types: &HashMap<String, AgentTypeConfig>,
+    sandbox_colors: &SandboxColors,
 ) {
     let col_idx: usize = 3;
     let col_type: usize = 5;  // 3 chars label + "!" marker + space
@@ -383,25 +385,34 @@ fn render_agent_table(
                     AgentStatus::WaitingForInput | AgentStatus::PermissionRequired
                 );
 
-                // Build type label column — always visible
+                // Build type label column — always visible.
+                // Color comes from the runtime sandbox_level (wizard selection) when set,
+                // mapped through sandbox_colors; falls back to the per-type config color.
                 let type_col = if let Some(cfg) = agent_types.get(&agent.agent_type) {
                     if !cfg.sandboxed {
                         format!(" \x1b[1;31m{}!{}", pad_left(&cfg.short_label, col_type.saturating_sub(2)), RESET)
                     } else {
-                        format!(" {}{} {}", color_name_to_ansi(&cfg.color), pad_left(&cfg.short_label, col_type.saturating_sub(2)), RESET)
+                        let color_name = if let Some(ref level) = agent.sandbox_level {
+                            sandbox_colors.for_level(level)
+                        } else {
+                            &cfg.color
+                        };
+                        format!(" {}{} {}", color_name_to_ansi(color_name), pad_left(&cfg.short_label, col_type.saturating_sub(2)), RESET)
                     }
                 } else {
                     format!(" {}??? {}", RESET, RESET)
                 };
 
-                // Build optional sandbox backend column string
+                // Build optional sandbox backend column string.
+                // Same override-vs-pin pattern as the level color: prefer the runtime
+                // wizard choice on AgentInfo, fall back to the agent type's TOML pin.
                 let sandbox_col = if show_sandbox {
                     if let Some(cfg) = agent_types.get(&agent.agent_type) {
                         if !cfg.sandboxed {
                             format!("\x1b[1;31m{}{} ", pad_left("NOSB", col_sandbox), RESET)
                         } else {
-                            let bname = cfg.sandbox_backend.display_name();
-                            format!("\x1b[2m{}{} ", pad_left(bname, col_sandbox), RESET)
+                            let backend = agent.sandbox_backend.as_ref().unwrap_or(&cfg.sandbox_backend);
+                            format!("\x1b[2m{}{} ", pad_left(backend.display_name(), col_sandbox), RESET)
                         }
                     } else {
                         format!("{} ", pad_left("-", col_sandbox))
@@ -489,8 +500,8 @@ fn render_detail_panel(agent: &AgentInfo, cols: usize, max_rows: usize, agent_ty
                 let sandbox_str = if !cfg.sandboxed {
                     " \x1b[1;31m[UNSANDBOXED]\x1b[0m".to_string()
                 } else {
-                    let backend_name = cfg.sandbox_backend.display_name();
-                    format!(" \x1b[2m[{}]\x1b[0m", backend_name)
+                    let backend = agent.sandbox_backend.as_ref().unwrap_or(&cfg.sandbox_backend);
+                    format!(" \x1b[2m[{}]\x1b[0m", backend.display_name())
                 };
                 (
                     cfg.display_name.as_str(),
@@ -654,7 +665,7 @@ pub fn render_wizard(
     wizard: &WizardState,
     rows: usize,
     cols: usize,
-    agent_types: &HashMap<String, AgentTypeConfig>,
+    _agent_types: &HashMap<String, AgentTypeConfig>,
     sandbox_colors: &SandboxColors,
 ) {
     if rows == 0 || cols == 0 {
@@ -667,20 +678,20 @@ pub fn render_wizard(
     push_title_border(&mut lines, " New Agent Wizard ", box_width);
     push_box_line(&mut lines, "", box_width);
 
-    let has_profiles = wizard.has_profiles();
-    let has_agent_types = wizard.has_agent_types();
-    let base: usize = 1;
-    let at_step = if has_agent_types { base } else { 0 };
-    let name_step = at_step + 1;
-    let profile_step = if has_profiles { name_step + 1 } else { 0 };
-    let dir_step = if has_profiles { profile_step + 1 } else { name_step + 1 };
-    let total_steps = dir_step + 1;
-    let (step_num, step_label) = match wizard.step {
-        WizardStep::AgentType => (at_step, "Agent Type"),
-        WizardStep::Name => (name_step, "Agent Name"),
-        WizardStep::Profile => (profile_step, "Profile"),
-        WizardStep::ProjectDir => (dir_step, "Project Directory"),
-        WizardStep::Confirm => (total_steps, "Confirm"),
+    // Compute step number / total from the active-steps list so the counter
+    // honors all skip rules (single agent type, unsandboxed, no profiles, ...)
+    // without nested conditionals.
+    let active = wizard.active_steps();
+    let total_steps = active.len();
+    let step_num = active.iter().position(|s| s == &wizard.step).map(|i| i + 1).unwrap_or(0);
+    let step_label = match wizard.step {
+        WizardStep::AgentType => "Agent Type",
+        WizardStep::SandboxBackend => "Sandbox Backend",
+        WizardStep::SandboxLevel => "Sandbox Level",
+        WizardStep::Name => "Agent Name",
+        WizardStep::Profile => "Profile",
+        WizardStep::ProjectDir => "Project Directory",
+        WizardStep::Confirm => "Confirm",
     };
 
     let header = format!("  Step {}/{}: {}", step_num, total_steps, step_label);
@@ -688,44 +699,82 @@ pub fn render_wizard(
 
     match wizard.step {
         WizardStep::AgentType => {
-            for (i, (key, display_name)) in wizard.available_agent_types.iter().enumerate() {
+            // Step 1 lists deduplicated *base* agents (e.g., "Claude Code"). All rows
+            // share the "normal" sandbox-level color so the wizard's palette stays
+            // consistent with the runtime indicator and the table coloring (gh#63):
+            // backend and level are picked in steps 2 and 3, where the palette reveals
+            // its meaning. Avoids per-agent colors flickering between this step and
+            // the table when an agent's `cfg.color` differs from the level palette.
+            let normal_color = sandbox_colors.for_level("normal");
+            for (i, (_key, display_name)) in wizard.available_agent_types.iter().enumerate() {
                 let is_selected = i == wizard.agent_type_index;
-                let cfg = agent_types.get(key.as_str());
-                let sandboxed = cfg.map_or(true, |c| c.sandboxed);
-                let backend_suffix = if let Some(c) = cfg {
-                    if c.sandboxed {
-                        format!(" [{}]", c.sandbox_backend.display_name())
-                    } else {
-                        " (non-sandboxed)".to_string()
-                    }
-                } else {
-                    String::new()
-                };
-                let label = format!("{}{}", display_name, backend_suffix);
                 if is_selected {
-                    // Selection background follows the sandbox-level palette:
-                    // paranoid/normal/permissive/custom each get their configured
-                    // color. Non-sandboxed stays red. Sandboxed entries with no
-                    // sandbox_level (legacy templates) fall back to the default.
-                    let bg = if !sandboxed {
+                    let bg = selection_bg_for_color(normal_color);
+                    push_box_line(&mut lines, &format!("  {}> {}{}", bg, display_name, RESET), box_width);
+                } else {
+                    let color = color_name_to_ansi(normal_color);
+                    push_box_line(&mut lines, &format!("    {}{}{}", color, display_name, RESET), box_width);
+                }
+            }
+            push_box_line(&mut lines, "", box_width);
+            push_box_line(&mut lines, "  [j/k] Select  [Enter] Next  [Esc] Cancel", box_width);
+        }
+        WizardStep::SandboxBackend => {
+            for (i, backend) in wizard.available_sandbox_backends.iter().enumerate() {
+                let is_selected = i == wizard.sandbox_backend_index;
+                // Use red as a visual cue for the unsandboxed (None) choice; sandboxed
+                // backends use neutral default styling — the color reveal comes in step 3.
+                let label = backend.display_name();
+                if is_selected {
+                    let bg = if matches!(backend, crate::sandbox_backend::SandboxBackend::None) {
                         "\x1b[41m"
                     } else {
-                        let level = cfg.and_then(|c| c.sandbox_level.as_deref()).unwrap_or("");
-                        selection_bg_for_color(sandbox_colors.for_level(level))
+                        REVERSE
                     };
                     push_box_line(&mut lines, &format!("  {}> {}{}", bg, label, RESET), box_width);
                 } else {
-                    push_box_line(&mut lines, &format!("    {}", label), box_width);
+                    let prefix = if matches!(backend, crate::sandbox_backend::SandboxBackend::None) {
+                        "\x1b[31m"
+                    } else {
+                        ""
+                    };
+                    push_box_line(&mut lines, &format!("    {}{}{}", prefix, label, RESET), box_width);
+                }
+            }
+            push_box_line(&mut lines, "", box_width);
+            push_box_line(&mut lines, "  [j/k] Select  [Enter] Next  [Bksp] Back  [Esc] Cancel", box_width);
+        }
+        WizardStep::SandboxLevel => {
+            for (i, level) in wizard.available_sandbox_levels.iter().enumerate() {
+                let is_selected = i == wizard.sandbox_level_index;
+                let color_name = sandbox_colors.for_level(level);
+                if is_selected {
+                    let bg = selection_bg_for_color(color_name);
+                    push_box_line(&mut lines, &format!("  {}> {}{}", bg, level, RESET), box_width);
+                } else {
+                    let color = color_name_to_ansi(color_name);
+                    push_box_line(&mut lines, &format!("    {}{}{}", color, level, RESET), box_width);
                 }
             }
             push_box_line(&mut lines, "", box_width);
             push_box_line(&mut lines, "  [j/k] Select  [Enter] Next  [Esc] Cancel", box_width);
         }
         WizardStep::Confirm => {
-            let at_display = wizard.selected_agent_type();
+            let base_display = wizard.selected_base_agent();
             let profile_display = wizard.selected_profile().unwrap_or("(none)");
             let dir_display = if wizard.project_dir.is_empty() { "(current dir)" } else { &wizard.project_dir };
-            push_box_line(&mut lines, &format!("  Type:    {}", at_display), box_width);
+            // Show base agent + backend separately rather than the resolved
+            // `<base>-unsandboxed` key — matches the user's mental model.
+            push_box_line(&mut lines, &format!("  Type:    {}", base_display), box_width);
+            if let Some(backend) = wizard.selected_sandbox_backend() {
+                push_box_line(&mut lines, &format!("  Backend: {}", backend.display_name()), box_width);
+            }
+            // Level is meaningful only when a sandboxed backend is selected.
+            if !wizard.is_unsandboxed_choice() {
+                if let Some(level) = wizard.selected_sandbox_level() {
+                    push_box_line(&mut lines, &format!("  Level:   {}", level), box_width);
+                }
+            }
             let effective_name = if wizard.name.is_empty() { &wizard.default_name } else { &wizard.name };
             push_box_line(&mut lines, &format!("  Name:    {}", effective_name), box_width);
             push_box_line(&mut lines, &format!("  Profile: {}", profile_display), box_width);

--- a/lince-dashboard/plugin/src/main.rs
+++ b/lince-dashboard/plugin/src/main.rs
@@ -321,9 +321,50 @@ impl ZellijPlugin for State {
                             self.config.agent_types = agent_types;
                         }
                         self.agent_types_loaded = true;
+                        // Pre-warm the custom sandbox-level cache now that we know the
+                        // bases. Discovery is async and idempotent — the wizard re-fires
+                        // it on open as a refresh, but doing it here means the cache is
+                        // usually populated before the user ever presses N.
+                        let bases: Vec<String> = self.config.base_agents()
+                            .into_iter().map(|(b, _)| b).collect();
+                        config::discover_sandbox_levels_async(&bases);
                         // Flush any buffered restore that was waiting for agent types.
                         if let Some(saved_agents) = self.pending_restore.take() {
                             self.restore_agents(saved_agents);
+                        }
+                        true
+                    }
+                    Some(config::CMD_DISCOVER_SANDBOX_LEVELS) => {
+                        if exit_code == Some(0) {
+                            // Replace entire cache: each discovery call covers all
+                            // bases × both backends atomically. A profile removed
+                            // since the last run won't appear in the new map and
+                            // would otherwise stick around as a stale level.
+                            self.config.discovered_sandbox_levels =
+                                config::parse_discovered_sandbox_levels(&stdout);
+                            // Refresh the wizard's level list ONLY if the user hasn't
+                            // moved past SandboxLevel yet — otherwise we'd risk
+                            // clobbering an already-confirmed choice if discovery
+                            // shifted the list (e.g., file removed mid-wizard).
+                            if let Some(ref mut wizard) = self.wizard {
+                                let on_or_before_level = matches!(
+                                    wizard.step,
+                                    WizardStep::AgentType
+                                        | WizardStep::SandboxBackend
+                                        | WizardStep::SandboxLevel
+                                );
+                                if on_or_before_level {
+                                    let base = wizard.selected_base_agent().to_string();
+                                    let backend = wizard.selected_sandbox_backend();
+                                    let preserved = wizard.selected_sandbox_level().map(|s| s.to_string());
+                                    wizard.available_sandbox_levels = self.config
+                                        .supported_sandbox_levels(&base, backend.as_ref());
+                                    wizard.sandbox_level_index = preserved
+                                        .as_deref()
+                                        .and_then(|p| wizard.available_sandbox_levels.iter().position(|l| l == p))
+                                        .unwrap_or(0);
+                                }
+                            }
                         }
                         true
                     }
@@ -331,6 +372,19 @@ impl ZellijPlugin for State {
                         if exit_code == Some(0) {
                             let detected = DetectedBackends::from_stdout(&stdout);
                             self.detected_backends = Some(detected);
+                            // If a wizard is open, its `available_sandbox_backends` was
+                            // computed against `None` detection (TOML-pin fallback) — refresh
+                            // it now that we know what's actually installed. Re-clamp the
+                            // selected index to keep it valid if the list shape changed.
+                            if let Some(ref mut wizard) = self.wizard {
+                                let base = wizard.selected_base_agent().to_string();
+                                wizard.available_sandbox_backends = self.config
+                                    .available_backends_for_base(&base, self.detected_backends.as_ref());
+                                if wizard.sandbox_backend_index >= wizard.available_sandbox_backends.len() {
+                                    wizard.sandbox_backend_index = self.config
+                                        .default_backend_index_for_base(&base, &wizard.available_sandbox_backends);
+                                }
+                            }
                         }
                         true
                     }
@@ -412,6 +466,7 @@ impl ZellijPlugin for State {
             effective_status,
             self.name_prompt.as_ref(),
             &self.config.agent_types,
+            &self.config.sandbox_colors,
         );
     }
 
@@ -501,34 +556,63 @@ impl State {
             BareKey::Char('N') => {
                 let default_dir = self.config.default_project_dir.clone()
                     .unwrap_or_default();
-                // Build sorted list of available agent types from config
-                let mut agent_type_list: Vec<(String, String)> = self.config.agent_types.iter()
-                    .map(|(k, v)| (k.clone(), v.display_name.clone()))
-                    .collect();
-                agent_type_list.sort_by(|a, b| a.0.cmp(&b.0));
+                // Step 1 list: deduplicated base agents (e.g. "claude", not "claude-unsandboxed").
+                let agent_type_list = self.config.base_agents();
                 let default_at_index = agent_type_list.iter()
                     .position(|(k, _)| k == DEFAULT_AGENT_TYPE)
                     .unwrap_or(0);
-                // Resolve profiles for the default agent type
-                let default_at_key = agent_type_list.get(default_at_index)
+                let default_base = agent_type_list.get(default_at_index)
                     .map(|(k, _)| k.as_str())
                     .unwrap_or(DEFAULT_AGENT_TYPE);
-                let available_profiles = self.config.profiles_for_agent_type(default_at_key);
+                // Step 2 list: backends available for the default base on this host.
+                let available_sandbox_backends = self.config.available_backends_for_base(
+                    default_base,
+                    self.detected_backends.as_ref(),
+                );
+                let sandbox_backend_index = self.config
+                    .default_backend_index_for_base(default_base, &available_sandbox_backends);
+                // Resolve initial effective agent_type (depends on backend choice).
+                let effective_type = if available_sandbox_backends
+                    .get(sandbox_backend_index)
+                    .map_or(false, |b| matches!(b, sandbox_backend::SandboxBackend::None))
+                {
+                    format!("{}-unsandboxed", default_base)
+                } else {
+                    default_base.to_string()
+                };
+                let available_profiles = self.config.profiles_for_agent_type(&effective_type);
                 let default_profile_index = self.config.default_profile.as_ref()
                     .and_then(|dp| available_profiles.iter().position(|p| p == dp))
                     .unwrap_or(0);
-                // Skip agent type step if only one type available
-                let first_step = if agent_type_list.len() <= 1 {
-                    WizardStep::Name
-                } else {
-                    WizardStep::AgentType
+                // Sandbox levels follow the canonical sandboxed entry (skipped when backend = None).
+                // Levels are backend-aware: discovered custom levels from
+                // `~/.config/nono/profiles/` and `~/.agent-sandbox/profiles/` are merged with
+                // the standard 3. Discovery is async — the cache may be empty at this point;
+                // CMD_DISCOVER_SANDBOX_LEVELS handler refreshes the wizard when results arrive.
+                let default_backend = available_sandbox_backends.get(sandbox_backend_index);
+                let available_sandbox_levels = self.config.supported_sandbox_levels(default_base, default_backend);
+                let sandbox_level_index = {
+                    let pinned = self.config.agent_types.get(default_base)
+                        .and_then(|c| c.sandbox_level.as_deref());
+                    pinned
+                        .and_then(|p| available_sandbox_levels.iter().position(|l| l == p))
+                        .unwrap_or(0)
                 };
-                let base = agent::agent_type_base_name(default_at_key);
-                let default_name = format!("{}-{}", base, self.next_agent_id + 1);
-                self.wizard = Some(WizardState {
-                    step: first_step,
+                // Kick off async discovery for ALL bases (cache covers any future wizard moves).
+                let discover_bases: Vec<String> = self.config.base_agents()
+                    .into_iter().map(|(b, _)| b).collect();
+                config::discover_sandbox_levels_async(&discover_bases);
+                let default_name = format!("{}-{}", default_base, self.next_agent_id + 1);
+                // Build state, then derive the first step from active_steps() so the
+                // skip rules don't drift between init and key handlers.
+                let mut state = WizardState {
+                    step: WizardStep::AgentType, // placeholder — replaced below
                     available_agent_types: agent_type_list,
                     agent_type_index: default_at_index,
+                    available_sandbox_backends,
+                    sandbox_backend_index,
+                    available_sandbox_levels,
+                    sandbox_level_index,
                     name: String::new(),
                     default_name,
                     available_profiles,
@@ -536,7 +620,9 @@ impl State {
                     project_dir: default_dir,
                     completions: Vec::new(),
                     completion_index: None,
-                });
+                };
+                state.step = state.active_steps().into_iter().next().unwrap_or(WizardStep::Name);
+                self.wizard = Some(state);
                 true
             }
             BareKey::Char('x') => {
@@ -657,14 +743,14 @@ impl State {
                     if let Some(agent) = self.agents.iter_mut().find(|a| a.id == agent_id) {
                         agent.name = name.clone();
                         if let Some(pid) = agent.pane_id {
-                            let title = agent::pane_title(&name, &agent.agent_type, &self.config.agent_types);
+                            let title = agent::pane_title(&name, &agent.agent_type, &self.config.agent_types, agent.sandbox_level.as_deref());
                             rename_pane_with_id(PaneId::Terminal(pid), &title);
                         }
                         self.status_message = Some(format!("Renamed to {}", name));
                     }
                     self.sort_agents_by_dir();
                 } else {
-                    // New agent mode: spawn.
+                    // New agent mode: spawn (no wizard, no sandbox overrides).
                     let effective_type = self.effective_default_agent_type().to_string();
                     match agent::spawn_agent_custom(
                         &self.config,
@@ -678,6 +764,8 @@ impl State {
                             .clone()
                             .unwrap_or_default(),
                         self.launch_dir.as_deref(),
+                        None,
+                        None,
                     ) {
                         Ok(info) => {
                             self.status_message = Some(format!("Spawned {}", info.name));
@@ -735,14 +823,40 @@ impl State {
         match wizard.step {
             WizardStep::AgentType => match bare {
                 BareKey::Enter | BareKey::Tab => {
-                    // Re-resolve profiles for the newly selected agent type
-                    let at_key = wizard.selected_agent_type().to_string();
-                    wizard.available_profiles = self.config.profiles_for_agent_type(&at_key);
-                    wizard.profile_index = 0;
-                    // Update default name to reflect selected agent type
-                    let base = agent::agent_type_base_name(&at_key);
+                    let base = wizard.selected_base_agent().to_string();
+                    // Re-resolve sandbox backends for the selected base BEFORE advancing.
+                    wizard.available_sandbox_backends = self.config
+                        .available_backends_for_base(&base, self.detected_backends.as_ref());
+                    wizard.sandbox_backend_index = self.config
+                        .default_backend_index_for_base(&base, &wizard.available_sandbox_backends);
+                    // Re-resolve sandbox levels (backend-aware: includes custom levels
+                    // discovered for the freshly-resolved backend index).
+                    let backend_for_levels = wizard.available_sandbox_backends
+                        .get(wizard.sandbox_backend_index);
+                    wizard.available_sandbox_levels = self.config
+                        .supported_sandbox_levels(&base, backend_for_levels);
+                    wizard.sandbox_level_index = {
+                        let pinned = self.config.agent_types.get(&base)
+                            .and_then(|c| c.sandbox_level.as_deref());
+                        pinned
+                            .and_then(|p| wizard.available_sandbox_levels.iter().position(|l| l == p))
+                            .unwrap_or(0)
+                    };
+                    // Resolve profiles against the effective agent_type *now* — if the
+                    // SandboxBackend step is skipped (single backend), its resolution
+                    // hook never fires and the wizard would carry the previous agent's
+                    // profile list. The SandboxBackend Enter handler still re-resolves
+                    // when shown, which is fine and cheap.
+                    let effective = wizard.effective_agent_type();
+                    wizard.available_profiles = self.config.profiles_for_agent_type(&effective);
+                    wizard.profile_index = self.config.default_profile.as_ref()
+                        .and_then(|dp| wizard.available_profiles.iter().position(|p| p == dp))
+                        .unwrap_or(0);
+                    // Update default name to reflect the new base.
                     wizard.default_name = format!("{}-{}", base, self.next_agent_id + 1);
-                    wizard.step = WizardStep::Name;
+                    if let Some(next) = wizard.next_step() {
+                        wizard.step = next;
+                    }
                 }
                 BareKey::Up | BareKey::Char('k') => {
                     if wizard.agent_type_index > 0 {
@@ -759,17 +873,98 @@ impl State {
                 }
                 _ => {}
             },
-            WizardStep::Name => match bare {
+            WizardStep::SandboxBackend => match bare {
                 BareKey::Enter | BareKey::Tab => {
-                    if wizard.has_profiles() {
-                        wizard.step = WizardStep::Profile;
-                    } else {
-                        wizard.step = WizardStep::ProjectDir;
+                    // Resolve profiles against the *effective* agent_type now that the
+                    // user has committed to a backend (sandboxed canonical vs unsandboxed).
+                    let effective = wizard.effective_agent_type();
+                    wizard.available_profiles = self.config.profiles_for_agent_type(&effective);
+                    wizard.profile_index = self.config.default_profile.as_ref()
+                        .and_then(|dp| wizard.available_profiles.iter().position(|p| p == dp))
+                        .unwrap_or(0);
+                    // Re-resolve sandbox levels for the just-chosen backend (custom levels
+                    // are backend-specific: nono profile dirs differ from agent-sandbox).
+                    let base = wizard.selected_base_agent().to_string();
+                    let backend_for_levels = wizard.selected_sandbox_backend();
+                    let preserved = wizard.selected_sandbox_level().map(|s| s.to_string());
+                    wizard.available_sandbox_levels = self.config
+                        .supported_sandbox_levels(&base, backend_for_levels.as_ref());
+                    wizard.sandbox_level_index = preserved
+                        .as_deref()
+                        .and_then(|p| wizard.available_sandbox_levels.iter().position(|l| l == p))
+                        .or_else(|| {
+                            let pinned = self.config.agent_types.get(&base)
+                                .and_then(|c| c.sandbox_level.as_deref());
+                            pinned.and_then(|p| wizard.available_sandbox_levels.iter().position(|l| l == p))
+                        })
+                        .unwrap_or(0);
+                    if let Some(next) = wizard.next_step() {
+                        wizard.step = next;
                     }
                 }
                 BareKey::Backspace => {
-                    if wizard.name.is_empty() && wizard.has_agent_types() {
-                        wizard.step = WizardStep::AgentType;
+                    if let Some(prev) = wizard.prev_step() {
+                        wizard.step = prev;
+                    }
+                }
+                BareKey::Up | BareKey::Char('k') => {
+                    let len = wizard.available_sandbox_backends.len();
+                    if len > 0 {
+                        wizard.sandbox_backend_index = if wizard.sandbox_backend_index == 0 {
+                            len - 1
+                        } else {
+                            wizard.sandbox_backend_index - 1
+                        };
+                    }
+                }
+                BareKey::Down | BareKey::Char('j') => {
+                    let len = wizard.available_sandbox_backends.len();
+                    if len > 0 {
+                        wizard.sandbox_backend_index = (wizard.sandbox_backend_index + 1) % len;
+                    }
+                }
+                _ => {}
+            },
+            WizardStep::SandboxLevel => match bare {
+                BareKey::Enter | BareKey::Tab => {
+                    if let Some(next) = wizard.next_step() {
+                        wizard.step = next;
+                    }
+                }
+                BareKey::Backspace => {
+                    if let Some(prev) = wizard.prev_step() {
+                        wizard.step = prev;
+                    }
+                }
+                BareKey::Up | BareKey::Char('k') => {
+                    let len = wizard.available_sandbox_levels.len();
+                    if len > 0 {
+                        wizard.sandbox_level_index = if wizard.sandbox_level_index == 0 {
+                            len - 1
+                        } else {
+                            wizard.sandbox_level_index - 1
+                        };
+                    }
+                }
+                BareKey::Down | BareKey::Char('j') => {
+                    let len = wizard.available_sandbox_levels.len();
+                    if len > 0 {
+                        wizard.sandbox_level_index = (wizard.sandbox_level_index + 1) % len;
+                    }
+                }
+                _ => {}
+            },
+            WizardStep::Name => match bare {
+                BareKey::Enter | BareKey::Tab => {
+                    if let Some(next) = wizard.next_step() {
+                        wizard.step = next;
+                    }
+                }
+                BareKey::Backspace => {
+                    if wizard.name.is_empty() {
+                        if let Some(prev) = wizard.prev_step() {
+                            wizard.step = prev;
+                        }
                     } else {
                         wizard.name.pop();
                     }
@@ -781,10 +976,14 @@ impl State {
             },
             WizardStep::Profile => match bare {
                 BareKey::Enter | BareKey::Tab => {
-                    wizard.step = WizardStep::ProjectDir;
+                    if let Some(next) = wizard.next_step() {
+                        wizard.step = next;
+                    }
                 }
                 BareKey::Backspace => {
-                    wizard.step = WizardStep::Name;
+                    if let Some(prev) = wizard.prev_step() {
+                        wizard.step = prev;
+                    }
                 }
                 BareKey::Up | BareKey::Char('k') => {
                     if wizard.profile_index > 0 {
@@ -809,8 +1008,8 @@ impl State {
                             wizard.project_dir = selected;
                         }
                         wizard.clear_completions();
-                    } else {
-                        wizard.step = WizardStep::Confirm;
+                    } else if let Some(next) = wizard.next_step() {
+                        wizard.step = next;
                     }
                 }
                 BareKey::Tab => {
@@ -828,10 +1027,8 @@ impl State {
                 }
                 BareKey::Backspace => {
                     if wizard.project_dir.is_empty() {
-                        if wizard.has_profiles() {
-                            wizard.step = WizardStep::Profile;
-                        } else {
-                            wizard.step = WizardStep::Name;
+                        if let Some(prev) = wizard.prev_step() {
+                            wizard.step = prev;
                         }
                     } else {
                         wizard.project_dir.pop();
@@ -846,17 +1043,34 @@ impl State {
             },
             WizardStep::Confirm => match bare {
                 BareKey::Enter => {
-                    // Clone values out before dropping the borrow
+                    // Clone values out before dropping the borrow.
                     let name = wizard.name.clone();
-                    let agent_type = wizard.selected_agent_type().to_string();
+                    let agent_type = wizard.effective_agent_type();
                     let profile = wizard.selected_profile().map(|s| s.to_string());
                     let project_dir = wizard.project_dir.clone();
+                    let backend_choice = wizard.selected_sandbox_backend();
+                    // Skip level when the chosen backend is `None` (unsandboxed) — it's a no-op.
+                    let sandbox_level = if matches!(backend_choice, Some(sandbox_backend::SandboxBackend::None)) {
+                        None
+                    } else {
+                        wizard.selected_sandbox_level().map(|s| s.to_string())
+                    };
+                    let sandbox_backend = backend_choice;
                     self.wizard = None;
-                    self.spawn_wizard_agent(name, &agent_type, profile, project_dir);
+                    self.spawn_wizard_agent(
+                        name,
+                        &agent_type,
+                        profile,
+                        project_dir,
+                        sandbox_level,
+                        sandbox_backend,
+                    );
                     return true;
                 }
                 BareKey::Backspace => {
-                    wizard.step = WizardStep::ProjectDir;
+                    if let Some(prev) = wizard.prev_step() {
+                        wizard.step = prev;
+                    }
                 }
                 _ => {}
             },
@@ -871,6 +1085,8 @@ impl State {
         agent_type: &str,
         profile: Option<String>,
         project_dir: String,
+        sandbox_level_override: Option<String>,
+        sandbox_backend_override: Option<sandbox_backend::SandboxBackend>,
     ) {
         match agent::spawn_agent_custom(
             &self.config,
@@ -881,6 +1097,8 @@ impl State {
             profile,
             project_dir,
             self.launch_dir.as_deref(),
+            sandbox_level_override,
+            sandbox_backend_override,
         ) {
             Ok(info) => {
                 self.status_message = Some(format!("Spawned {}", info.name));
@@ -1106,6 +1324,8 @@ impl State {
                 saved.profile,
                 saved.project_dir,
                 self.launch_dir.as_deref(),
+                saved.sandbox_level,
+                saved.sandbox_backend,
             ) {
                 Ok(mut info) => {
                     info.group = saved.group;

--- a/lince-dashboard/plugin/src/types.rs
+++ b/lince-dashboard/plugin/src/types.rs
@@ -109,9 +109,11 @@ pub struct NamePromptState {
 }
 
 /// Which step the wizard is currently on.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WizardStep {
     AgentType,
+    SandboxBackend,
+    SandboxLevel,
     Name,
     Profile,
     ProjectDir,
@@ -122,10 +124,24 @@ pub enum WizardStep {
 #[derive(Debug, Clone)]
 pub struct WizardState {
     pub step: WizardStep,
-    /// Available agent type keys (from config.agent_types).
-    pub available_agent_types: Vec<(String, String)>,  // (key, display_name)
-    /// Currently selected agent type index.
+    /// Available *base* agent names (deduplicated by `agent_type_base_name`),
+    /// e.g. `[("claude", "Claude Code"), ("codex", "OpenAI Codex")]`. Sandbox
+    /// variant suffixes (`-unsandboxed`, `-paranoid`, ...) are folded out — the
+    /// wizard's SandboxBackend / SandboxLevel steps recover that information.
+    pub available_agent_types: Vec<(String, String)>,
+    /// Currently selected base agent index.
     pub agent_type_index: usize,
+    /// Available sandbox backends for the selected agent type. Includes
+    /// `SandboxBackend::None` when an `<base>-unsandboxed` entry exists.
+    pub available_sandbox_backends: Vec<crate::sandbox_backend::SandboxBackend>,
+    /// Currently selected sandbox backend index in `available_sandbox_backends`.
+    pub sandbox_backend_index: usize,
+    /// Available sandbox levels for the selected agent type (e.g. ["paranoid","normal","permissive"]).
+    /// May include custom levels discovered from the filesystem (e.g. "strict").
+    /// Empty for unsandboxed agents or legacy entries with no sandbox_level field.
+    pub available_sandbox_levels: Vec<String>,
+    /// Currently selected sandbox level index in `available_sandbox_levels`.
+    pub sandbox_level_index: usize,
     pub name: String,
     /// Auto-generated default name shown when the user leaves name empty (e.g. "claude-3").
     pub default_name: String,
@@ -141,17 +157,102 @@ pub struct WizardState {
 }
 
 impl WizardState {
-    /// Whether there are multiple agent types to choose from.
+    /// Whether there are multiple base agent types to choose from.
     pub fn has_agent_types(&self) -> bool {
         self.available_agent_types.len() > 1
     }
 
-    /// Return the selected agent type key, or the default as fallback.
-    pub fn selected_agent_type(&self) -> &str {
+    /// Return the selected *base* agent name (e.g. "claude"). Combine with
+    /// `selected_sandbox_backend()` to derive the effective agent_type.
+    pub fn selected_base_agent(&self) -> &str {
         self.available_agent_types
             .get(self.agent_type_index)
             .map(|(key, _)| key.as_str())
             .unwrap_or(crate::config::DEFAULT_AGENT_TYPE)
+    }
+
+    /// Resolve the effective `agent_type` config key for spawn:
+    /// - `<base>-unsandboxed` when backend is `None`
+    /// - `<base>` otherwise (canonical sandboxed entry)
+    pub fn effective_agent_type(&self) -> String {
+        let base = self.selected_base_agent();
+        if matches!(
+            self.selected_sandbox_backend(),
+            Some(crate::sandbox_backend::SandboxBackend::None)
+        ) {
+            format!("{}-unsandboxed", base)
+        } else {
+            base.to_string()
+        }
+    }
+
+    /// Whether there are multiple sandbox backends to choose from.
+    pub fn has_sandbox_backends(&self) -> bool {
+        self.available_sandbox_backends.len() > 1
+    }
+
+    /// Return the currently selected sandbox backend, or None if no backends available.
+    pub fn selected_sandbox_backend(&self) -> Option<crate::sandbox_backend::SandboxBackend> {
+        self.available_sandbox_backends.get(self.sandbox_backend_index).cloned()
+    }
+
+    /// Whether there are sandbox levels to choose from.
+    pub fn has_sandbox_levels(&self) -> bool {
+        !self.available_sandbox_levels.is_empty()
+    }
+
+    /// Return the currently selected sandbox level, or None if no levels available.
+    pub fn selected_sandbox_level(&self) -> Option<&str> {
+        self.available_sandbox_levels.get(self.sandbox_level_index).map(|s| s.as_str())
+    }
+
+    /// Build the ordered list of active wizard steps, applying skip rules.
+    /// Used by the renderer for the step counter and by key handlers for
+    /// computing prev/next steps without nested `if` arithmetic.
+    pub fn active_steps(&self) -> Vec<WizardStep> {
+        let mut steps = Vec::with_capacity(7);
+        if self.has_agent_types() {
+            steps.push(WizardStep::AgentType);
+        }
+        if self.has_sandbox_backends() {
+            steps.push(WizardStep::SandboxBackend);
+        }
+        if self.has_sandbox_levels() && !self.is_unsandboxed_choice() {
+            steps.push(WizardStep::SandboxLevel);
+        }
+        steps.push(WizardStep::Name);
+        if self.has_profiles() {
+            steps.push(WizardStep::Profile);
+        }
+        steps.push(WizardStep::ProjectDir);
+        steps.push(WizardStep::Confirm);
+        steps
+    }
+
+    /// Whether the user has currently selected the "no sandbox" backend.
+    pub fn is_unsandboxed_choice(&self) -> bool {
+        matches!(
+            self.selected_sandbox_backend(),
+            Some(crate::sandbox_backend::SandboxBackend::None)
+        )
+    }
+
+    /// Step that should follow the current one (or `None` if at end).
+    pub fn next_step(&self) -> Option<WizardStep> {
+        let steps = self.active_steps();
+        let idx = steps.iter().position(|s| s == &self.step)?;
+        steps.get(idx + 1).cloned()
+    }
+
+    /// Step that precedes the current one (or `None` if at start).
+    pub fn prev_step(&self) -> Option<WizardStep> {
+        let steps = self.active_steps();
+        let idx = steps.iter().position(|s| s == &self.step)?;
+        if idx == 0 {
+            None
+        } else {
+            steps.get(idx - 1).cloned()
+        }
     }
 
     /// Whether there are selectable profiles.
@@ -191,6 +292,12 @@ pub struct AgentInfo {
     pub model: Option<String>,
     /// Last event string read by poll_status_files(), used for change detection.
     pub last_polled_event: Option<String>,
+    /// Runtime-selected sandbox isolation level (wizard choice or saved state).
+    /// None for unsandboxed agents or legacy agents spawned without the wizard.
+    pub sandbox_level: Option<String>,
+    /// Runtime-selected sandbox backend (wizard choice or saved state).
+    /// None means use the agent type's TOML-pinned `sandbox_backend`.
+    pub sandbox_backend: Option<crate::sandbox_backend::SandboxBackend>,
 }
 
 impl AgentInfo {
@@ -235,6 +342,12 @@ pub struct SavedAgentInfo {
     pub group: Option<String>,
     pub tokens_in: u64,
     pub tokens_out: u64,
+    /// Runtime sandbox level selected at spawn time. None for older state files (backward compat).
+    #[serde(default)]
+    pub sandbox_level: Option<String>,
+    /// Runtime sandbox backend selected at spawn time. None for older state files (backward compat).
+    #[serde(default)]
+    pub sandbox_backend: Option<crate::sandbox_backend::SandboxBackend>,
 }
 
 fn default_agent_type() -> String {
@@ -251,6 +364,8 @@ impl From<&AgentInfo> for SavedAgentInfo {
             group: a.group.clone(),
             tokens_in: a.tokens_in,
             tokens_out: a.tokens_out,
+            sandbox_level: a.sandbox_level.clone(),
+            sandbox_backend: a.sandbox_backend.clone(),
         }
     }
 }

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -503,6 +503,18 @@ confirm_installation() {
 }
 
 # ── Generate filtered agents-defaults.toml ───────────────────────────
+#
+# Schema note: since the SandboxBackend wizard step shipped, agents-defaults.toml
+# has ONE canonical sandboxed entry per agent (e.g. `[agents.claude]`) plus an
+# optional `[agents.<agent>-unsandboxed]` sibling. The runtime backend (bwrap vs
+# nono) is picked by the user at spawn time in the N wizard, so install-time no
+# longer needs separate `<agent>-bwrap` / `<agent>-nono` entries — they don't
+# exist in the source file.
+#
+# The user's backend selection in quickstart therefore boils down to:
+#   - any sandboxed backend (bwrap or nono) → emit the canonical `[agents.<x>]`
+#   - "unsandboxed" → emit the `[agents.<x>-unsandboxed]` sibling
+# Picking both bwrap AND nono produces a single canonical entry (no dupe).
 generate_agent_defaults() {
     local src="$SCRIPT_DIR/lince-dashboard/agents-defaults.toml"
     local dst="$1"
@@ -516,32 +528,25 @@ generate_agent_defaults() {
     # Start with header
     head -13 "$src" > "$dst"
 
-    for agent in "${SELECTED_AGENTS[@]}"; do
-        for backend in "${SELECTED_BACKENDS[@]}"; do
-            echo "" >> "$dst"
+    # Decide once which entry types we need from the user's backend selection.
+    local need_sandboxed=false
+    local need_unsandboxed=false
+    for backend in "${SELECTED_BACKENDS[@]}"; do
+        case "$backend" in
+            bwrap|nono) need_sandboxed=true ;;
+            unsandboxed) need_unsandboxed=true ;;
+        esac
+    done
 
-            case "$backend" in
-                bwrap)
-                    # Claude uses base "claude" (already bwrap), others use "<agent>-bwrap"
-                    if [ "$agent" = "claude" ]; then
-                        extract_agent_block "$src" "agents.claude" >> "$dst"
-                    else
-                        extract_agent_block "$src" "agents.${agent}-bwrap" >> "$dst"
-                    fi
-                    ;;
-                nono)
-                    extract_agent_block "$src" "agents.${agent}-nono" >> "$dst"
-                    ;;
-                unsandboxed)
-                    # Claude has an explicit unsandboxed variant; others use the base name
-                    if [ "$agent" = "claude" ]; then
-                        extract_agent_block "$src" "agents.claude-unsandboxed" >> "$dst"
-                    else
-                        extract_agent_block "$src" "agents.${agent}" >> "$dst"
-                    fi
-                    ;;
-            esac
-        done
+    for agent in "${SELECTED_AGENTS[@]}"; do
+        if [ "$need_sandboxed" = true ]; then
+            echo "" >> "$dst"
+            extract_agent_block "$src" "agents.${agent}" >> "$dst"
+        fi
+        if [ "$need_unsandboxed" = true ]; then
+            echo "" >> "$dst"
+            extract_agent_block "$src" "agents.${agent}-unsandboxed" >> "$dst"
+        fi
     done
 }
 


### PR DESCRIPTION
## Summary

Replaces the install-time sandbox multi-select with a 3-step picker inside the `[N]` wizard. After picking an agent type, users now choose **Sandbox Backend** (bwrap / nono / none) and **Sandbox Level** (paranoid / normal / permissive + any custom levels) on every spawn — no more maintaining parallel `<agent>-paranoid` / `<agent>-permissive` entries.

Wizard flow: `Agent Type → Sandbox Backend (NEW) → Sandbox Level (NEW) → Name → Profile → ProjectDir → Confirm`

## Highlights

- **Step 1 dedup**: `[agents.*]` entries collapse by base name via `agent_type_base_name()`. Legacy `claude-paranoid` / `claude-permissive` from older installs fold harmlessly into the canonical "Claude Code" row.
- **Step 2 backend picker**: enumerates backends from `DetectedBackends` with TOML-pinned fallback during the boot detection race, plus a `None` choice when an `<agent>-unsandboxed` entry exists. Refreshes live when detection completes.
- **Step 3 level picker**: standard 3 levels + any custom level profiles auto-discovered from:
  - `~/.config/nono/profiles/lince-<base>-*.json` (per-agent)
  - `~/.agent-sandbox/profiles/<base>-<level>.toml` (per-agent)
  - `~/.agent-sandbox/profiles/<level>.toml` (agent-agnostic — matches agent-sandbox's own resolution order, expanded to every base)
- **Skip rules**: any single-option step is auto-skipped (e.g. `Sandbox Level` when backend is `None`). Skip rules live in one place via `WizardState::active_steps()` so prev/next navigation never drifts.
- **Persistence**: `AgentInfo.sandbox_level` and `.sandbox_backend` flow through `spawn_agent_custom` and round-trip via `SavedAgentInfo` (`#[serde(default)]` for backward compat).

## Side fixes shipped with this change

- `reconcile_panes` now matches sandboxed agents against `[pane_title_pattern, "nono", base_name]` instead of just the configured pattern, so nono-backend panes get reconciled and hidden after spawn instead of staying floating untracked. This also fixes the "last agent can't be focused" symptom (focus needs `pane_id`, which reconcile now assigns).
- `agents-defaults.toml`: add `[agents.pi-unsandboxed]` so the None backend choice appears for Pi.
- `quickstart.sh`: `generate_agent_defaults` was written for an older schema where `<agent>-bwrap` / `<agent>-nono` variants existed. Rewrite to emit the canonical sandboxed entry when any sandboxed backend is selected and the `-unsandboxed` sibling when unsandboxed is selected — fixes the regression where only `claude-unsandboxed` got installed.
- Wizard step 1 rows now share `sandbox_colors.normal` so per-agent palette quirks (e.g. cyan codex) don't drift from the dashboard table coloring.

## Out of scope (deferred)

- Auto-cleanup of redundant `*-paranoid` / `*-permissive` entries from existing user `config.toml` files.
- Removing `agents-template.toml` from the repo (kept one release for users who explicitly want frozen-level rows).

## Test plan

- [ ] `cd lince-dashboard && ./install.sh` (or `./update.sh` if previously installed)
- [ ] Press `N` → step 1 lists 5 deduplicated agents in matching blue
- [ ] On a host with both bwrap and nono installed → step 2 offers all three (`bwrap`/`nono`/`none`); on hosts with only one sandboxed backend installed → step 2 is auto-skipped
- [ ] Open wizard before backend detection completes (rapid fire) → only TOML-pinned backend offered; wait, reopen → list expands
- [ ] Step 3 shows `paranoid / normal / permissive` plus any custom level profiles dropped under `~/.config/nono/profiles/` or `~/.agent-sandbox/profiles/`
- [ ] Spawn `claude` + `nono` + `paranoid` → pane gets reconciled and hidden after spawn (multi-pattern match)
- [ ] Spawn `claude` + `none` → effective agent_type is `claude-unsandboxed`, level step skipped, row colored red
- [ ] Save+quit, restart → agents restored with same backend/level (color and badge match pre-restart)
- [ ] Run `./quickstart.sh`, pick all 5 agents + `unsandboxed` → resulting `~/.config/lince-dashboard/agents-defaults.toml` contains `<agent>-unsandboxed` for all 5
- [ ] Drop `~/.agent-sandbox/profiles/paranoid-with-ssh.toml`, reopen wizard → `paranoid-with-ssh` appears in step 3 for every agent

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)