### PR TITLE
fix: auto-inject GIT_SSH_COMMAND for bwrap UID remapping

### DIFF
--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -1963,6 +1963,13 @@ def build_bwrap_cmd(config: dict, project_dir: Path,
     cmd += ["--setenv", "UV_CACHE_DIR", f"{home}/.uv-cache"]
     cmd += ["--setenv", "UV_TOOL_DIR", f"{home}/.uv-tools"]
 
+    # bwrap's user namespace remaps root UID → 65534 (nobody), so SSH's
+    # safe.c rejects system config files owned by "nobody".  Instruct git
+    # to skip all SSH config files so connections work out of the box.
+    # Users can override via [env.extra] GIT_SSH_COMMAND = "..." if needed.
+    if "GIT_SSH_COMMAND" not in env_conf.get("extra", {}):
+        cmd += ["--setenv", "GIT_SSH_COMMAND", "ssh -F /dev/null"]
+
     # --- Wayland env vars (clipboard access for wl-paste) --------------------
     for wl_var in ("WAYLAND_DISPLAY", "XDG_RUNTIME_DIR"):
         val = os.environ.get(wl_var)


### PR DESCRIPTION
## Summary

- Auto-inject `GIT_SSH_COMMAND="ssh -F /dev/null"` in `build_bwrap_cmd()` so git SSH connections work inside bwrap sandboxes without manual configuration
- Fixes "Bad owner or permissions on /etc/ssh/ssh_config.d/*" error caused by bwrap user namespace UID remapping (root → nobody)

## Root Cause

bwrap creates a user namespace where real root-owned files appear as UID 65534 (nobody). SSH's `safe.c` rejects system config files not owned by root or the current user, breaking all SSH connections inside the sandbox.

## Fix

The sandbox now automatically sets `GIT_SSH_COMMAND="ssh -F /dev/null"`, which tells SSH to skip all config file includes. This is safe because git SSH connections only need defaults (key auth, known hosts). Users can override via `[env.extra]` in any profile.

## Test Plan

- [x] `agent-sandbox run -a zai --dry-run` shows `--setenv GIT_SSH_COMMAND 'ssh -F /dev/null'`
- [x] `agent-sandbox run -a zai --sandbox-level permissive --dry-run` shows the same
- [x] SSH to github.com succeeds inside bwrap: "Hi paoloantinori! You've successfully authenticated"
- [x] Existing `[env.extra] GIT_SSH_COMMAND` in user config takes precedence over auto-injection

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)