### PR TITLE
sandbox: clear inherited 5s read timeout on paranoid AF_UNIX bridge

### DIFF
--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -927,6 +927,17 @@ class CredentialProxy:
             except OSError:
                 client.close()
                 return
+            # `create_connection` keeps the connect timeout pinned on the
+            # returned socket, so every subsequent recv() inherits a 5s
+            # read deadline. Slow-first-byte providers (e.g. Z.ai
+            # routinely > 10s ttfb on long streaming responses) trip it,
+            # the U2C thread raises TimeoutError, the bridge half-closes
+            # the client socket mid-request, and the agent's HTTP SDK
+            # retries — the paranoid-mode "Retrying in Xs" loop. Restore
+            # blocking-without-timeout semantics for the bridge's
+            # lifetime; the connect itself was already gated above.
+            upstream.settimeout(None)
+            client.settimeout(None)
 
             def _forward(src: socket.socket, dst: socket.socket) -> None:
                 try:


### PR DESCRIPTION
## Summary

- `socket.create_connection(..., timeout=5)` in `start_unix_bridge` left a 5s read deadline pinned on the bridge's upstream socket, killing any streaming response with ttfb > 5s.
- Symptom: paranoid-mode SDK retry loop ("Retrying in Xs · attempt N/10"), often failing all 10 attempts. Permissive/normal unaffected (no AF_UNIX bridge).
- Fix: `settimeout(None)` on both bridge sockets after connect; the gating was only meant for connection establishment.

Empirically confirmed against Z.ai (`api.z.ai/api/anthropic`), where ttfb routinely lands at 8–12s on long streaming completions. Before the fix the bridge half-closed at exactly 5.01s; after the fix the same requests stream to completion.

## Test plan

- [x] Repro retry loop in `--sandbox-level paranoid claude` against a slow upstream (Z.ai); see SDK retries.
- [x] Apply fix; same workload completes without retries.
- [x] `--sandbox-level permissive` / `normal` unchanged (bridge code path unused there).
- [ ] Smoke check on non-paranoid agents still working (no regression — change is scoped to the `unshare_net=true` codepath only).

Closes #79