### PR TITLE
sandbox+dashboard: rename profiles -> providers (env-var bundles)

### DIFF
--- a/docs/documentation/dashboard/agent-examples.md
+++ b/docs/documentation/dashboard/agent-examples.md
@@ -42,7 +42,7 @@ Agents with `sandboxed = false` run without any LINCE-managed isolation. The das
 - A red `[NON-SANDBOXED]` tag in the Zellij pane title.
 - A red `[NON-SANDBOXED]` warning in the detail panel.
 
-Use unsandboxed mode only in trusted environments where sandbox restrictions are impractical. Unsandboxed agents still support profiles for provider selection -- the dashboard uses `env -u VAR1 VAR2=val ...` to set and unset environment variables cleanly.
+Use unsandboxed mode only in trusted environments where sandbox restrictions are impractical. Unsandboxed agents still support providers (env-var bundles) -- the dashboard uses `env -u VAR1 VAR2=val ...` to set and unset environment variables cleanly.
 
 ## Adding a Custom Agent
 
@@ -59,7 +59,7 @@ To add a custom agent manually:
 1. Choose a unique key (lowercase, hyphens allowed).
 2. Add an `[agents.<key>]` section to `~/.config/lince-dashboard/config.toml`.
 3. Set the required fields: `command`, `pane_title_pattern`, `status_pipe_name`, `display_name`, `short_label`, `color`, `sandboxed`.
-4. Optionally set `has_native_hooks`, `env_vars`, `home_ro_dirs`, `profiles`, etc.
+4. Optionally set `has_native_hooks`, `env_vars`, `home_ro_dirs`, `providers` (legacy `profiles`), etc.
 5. Restart the dashboard. The new type appears in the wizard.
 
 No code changes or recompilation required.
@@ -98,23 +98,23 @@ After spawning, the table shows:
 
 ## Example: Agent with Multiple Providers
 
-Claude Code can connect to different providers (Anthropic direct, Vertex AI, etc.) using profiles. This example shows how to configure provider switching for both sandboxed and unsandboxed modes.
+Claude Code can connect to different providers (Anthropic direct, Vertex AI, etc.) using **provider** entries (env-var bundles — gh#81 renamed these from "profiles" to disambiguate from sandbox isolation profiles). This example shows how to configure provider switching for both sandboxed and unsandboxed modes.
 
-**Sandbox profiles** (`~/.agent-sandbox/config.toml`):
+**Provider entries** in `~/.agent-sandbox/config.toml`:
 
 ```toml
-[profiles.anthropic]
+[claude.providers.anthropic]
 description = "Anthropic Direct API"
 env_unset = ["CLAUDE_CODE_USE_VERTEX", "CLOUD_ML_REGION"]
 
-[profiles.anthropic.env]
+[claude.providers.anthropic.env]
 ANTHROPIC_API_KEY = "sk-ant-..."
 
-[profiles.vertex]
+[claude.providers.vertex]
 description = "Vertex AI"
 env_unset = ["ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL"]
 
-[profiles.vertex.env]
+[claude.providers.vertex.env]
 CLAUDE_CODE_USE_VERTEX = "1"
 CLOUD_ML_REGION = "us-east5"
 ```
@@ -131,12 +131,16 @@ short_label = "CLU"
 color = "red"
 sandboxed = false
 has_native_hooks = true
-profiles = ["__discover__"]
+providers = ["__discover__"]   # legacy name `profiles` is also accepted
 ```
 
 The `env_unset` field is critical for unsandboxed agents. Because they inherit the full host environment, switching from Anthropic to Vertex requires **unsetting** `ANTHROPIC_API_KEY` before **setting** `CLAUDE_CODE_USE_VERTEX`. Without `env_unset`, both keys would be present and the agent could pick the wrong provider.
 
 For sandboxed agents, `env_unset` is a no-op because `agent-sandbox` uses `--clearenv` to start from a blank environment.
+
+> Pre-#81 configs spelled these `[profiles.*]` / `[<agent>.profiles.*]`. The
+> legacy form still works (with a one-shot deprecation note); run
+> `agent-sandbox migrate-providers` to rewrite the file in place.
 
 ## Handling bwrap Conflicts
 

--- a/docs/documentation/dashboard/config-reference.md
+++ b/docs/documentation/dashboard/config-reference.md
@@ -23,8 +23,8 @@ Created by `install.sh`. Holds dashboard-wide settings and optional agent type o
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `default_profile` | string | `""` | Default sandbox profile for new agents. Empty means no `-P` flag is passed. |
-| `sandbox_config_path` | string | `"~/.agent-sandbox/config.toml"` | Path to sandbox config for profile auto-discovery. |
+| `default_provider` | string | `""` | Default provider (env-var bundle) for new agents. Empty means no `-P` flag is passed. The legacy spelling `default_profile` is still accepted (gh#81). |
+| `sandbox_config_path` | string | `"~/.agent-sandbox/config.toml"` | Path to sandbox config for provider auto-discovery. |
 | `default_project_dir` | string | `""` | Default working directory for new agents. Empty means the current directory. |
 | `sandbox_command` | string | `"agent-sandbox"` | Path or name of the `agent-sandbox` binary. |
 | `agent_layout` | string | `"floating"` | How agent panes are created. `"floating"` for overlay panes, `"tiled"` for fixed layout grid. |
@@ -42,7 +42,7 @@ The plugin checks `config.toml` for changes every 5 seconds and applies them wit
 **Hot-reloadable** (applied immediately):
 
 - `focus_mode`, `status_method`, `max_agents`, `status_file_dir`
-- `agent_layout`, `default_profile`, `default_project_dir`
+- `agent_layout`, `default_provider`, `default_project_dir`
 
 **Not hot-reloadable** (requires restart, only affects new agents):
 
@@ -100,7 +100,7 @@ Each agent type is defined as a `[agents.<name>]` TOML table.
 
 | Key | Type | Required | Default | Description |
 |-----|------|----------|---------|-------------|
-| `command` | array of strings | Yes | -- | Command template. Supports `{agent_id}`, `{project_dir}`, `{profile}` placeholders. |
+| `command` | array of strings | Yes | -- | Command template. Supports `{agent_id}`, `{project_dir}`, `{provider}` (and `{profile}` as a legacy alias for `{provider}`) placeholders. |
 | `pane_title_pattern` | string | Yes | -- | Pattern to match Zellij pane titles for reconciliation. |
 | `status_pipe_name` | string | Yes | -- | Zellij pipe name for receiving status messages from this agent type. |
 | `display_name` | string | Yes | -- | Full name shown in the UI and wizard. |
@@ -111,7 +111,7 @@ Each agent type is defined as a `[agents.<name>]` TOML table.
 | `bwrap_conflict` | boolean | No | `false` | Set `true` when the agent uses bwrap internally. Triggers injection of `disable_inner_sandbox_args`. |
 | `disable_inner_sandbox_args` | array of strings | No | `[]` | Arguments appended to the agent command to disable its internal sandbox when `bwrap_conflict` is `true`. |
 | `ignore_wrapper_start` | boolean | No | `false` | If `true`, ignores the wrapper's initial `start` event. Useful for agents that launch into an interactive prompt. |
-| `profiles` | array of strings | No | `[]` | Sandbox profiles for this agent type. `["__discover__"]` means auto-discover from sandbox config. `[]` skips the profile wizard step. An explicit list restricts choices to those names. |
+| `providers` | array of strings | No | `[]` | Providers (env-var bundles) for this agent type. `["__discover__"]` means auto-discover from the sandbox config. `[]` skips the wizard's Provider step. An explicit list restricts choices to those names. The legacy key name `profiles` is still accepted (gh#81). |
 | `home_ro_dirs` | array of strings | No | `[]` | Home subdirectories to bind read-only in the sandbox (e.g. `["~/.claude/"]`). |
 | `home_rw_dirs` | array of strings | No | `[]` | Home subdirectories to bind read-write in the sandbox. |
 | `env_vars` | table | No | `{}` | Environment variables to set for the agent. Applied for both sandboxed and non-sandboxed agents. See [Environment Variable Resolution](#environment-variable-resolution). |
@@ -135,13 +135,14 @@ For **non-sandboxed** agents, `env_vars` are set via `env VAR=val ...` on the co
 
 ### Command Template Placeholders
 
-Command arrays support three placeholders that are resolved at spawn time:
+Command arrays support these placeholders, resolved at spawn time:
 
 | Placeholder | Resolved To | Example |
 |-------------|-------------|---------|
 | `{agent_id}` | Unique agent identifier | `agent-1`, `agent-2` |
 | `{project_dir}` | Project directory path | `/home/user/project/backend` |
-| `{profile}` | Selected sandbox profile name | `vertex`, `anthropic` |
+| `{provider}` | Selected provider name (env-var bundle) | `vertex`, `anthropic`, `zai` |
+| `{profile}` | Legacy alias for `{provider}` (gh#81) — same value | `vertex`, `anthropic` |
 
 Example command template:
 
@@ -155,32 +156,37 @@ Resolves to:
 agent-sandbox run -p /home/user/project/backend --id agent-1
 ```
 
-### Profile Discovery
+### Provider Discovery
 
-The `profiles` field controls how profiles are presented in the wizard:
+The `providers` field (legacy `profiles`) controls how providers are presented in the wizard's Provider step:
 
 | Value | Behavior |
 |-------|----------|
-| `["__discover__"]` | Auto-discover profiles from `[profiles.*]` sections in the sandbox config file (`sandbox_config_path`). |
-| `[]` (empty) | Skip the profile step in the wizard entirely. |
-| `["vertex", "anthropic"]` | Show only the listed profiles in the wizard, regardless of what exists in sandbox config. |
+| `["__discover__"]` | Auto-discover providers from `[providers.*]` / `[<agent>.providers.*]` sections in the sandbox config file (`sandbox_config_path`). Legacy `[profiles.*]` is also read. |
+| `[]` (empty) | Skip the Provider step in the wizard entirely. |
+| `["vertex", "anthropic"]` | Show only the listed providers in the wizard, regardless of what exists in sandbox config. |
 
-Auto-discovered profiles are loaded asynchronously at startup via `run_command()` (not direct filesystem access, due to WASI sandbox limitations).
+Auto-discovered providers are loaded asynchronously at startup via `run_command()` (not direct filesystem access, due to WASI sandbox limitations).
 
-Profiles may also declare an `env_unset` list in the sandbox config to remove conflicting environment variables before setting the profile's own vars:
+Providers may also declare an `env_unset` list in the sandbox config to remove conflicting environment variables before setting the provider's own vars:
 
 ```toml
 # In ~/.agent-sandbox/config.toml
-[profiles.vertex]
+[claude.providers.vertex]
 description = "Vertex AI"
 env_unset = ["ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL"]
 
-[profiles.vertex.env]
+[claude.providers.vertex.env]
 CLAUDE_CODE_USE_VERTEX = "1"
 CLOUD_ML_REGION = "us-east5"
 ```
 
-For sandboxed agents, `env_unset` is a no-op (the sandbox already starts with a blank environment). For non-sandboxed agents, it ensures the host's existing variables do not conflict with the profile's intended provider configuration.
+For sandboxed agents, `env_unset` is a no-op (the sandbox already starts with a blank environment). For non-sandboxed agents, it ensures the host's existing variables do not conflict with the provider's intended configuration.
+
+> **Two orthogonal axes** (gh#81): a *provider* (above) is an env-var bundle.
+> A *sandbox profile* (a.k.a. sandbox level — paranoid / normal / permissive)
+> is the isolation posture, set via `sandbox_level` and the wizard's separate
+> "Sandbox Level" step. They are independent — every combination is valid.
 
 ## Config Merge Order
 

--- a/docs/documentation/dashboard/sandbox-levels.md
+++ b/docs/documentation/dashboard/sandbox-levels.md
@@ -10,7 +10,7 @@ Until recently each combination of "agent type + isolation tightness" required i
 
 ### 1.1 Visual indicators
 
-The dashboard tags each agent pane and the wizard's profile-selection step with a per-level color cue, so the level you're running at is visible at a glance.
+The dashboard tags each agent pane and the wizard's *Sandbox Level (Profile)* step with a per-level color cue, so the level you're running at is visible at a glance.
 
 **Pane title.** Sandboxed agent panes carry a fixed glyph + bracketed level name in their pane title:
 
@@ -23,7 +23,7 @@ The dashboard tags each agent pane and the wizard's profile-selection step with 
 
 Non-sandboxed agents keep their existing `[NON-SANDBOXED] <name>` prefix. Agents on the legacy command-template path (no `sandbox_level` set) are not tagged.
 
-**Wizard.** The "N" wizard's *Profile* step colors each profile name using the same palette: `paranoid=green`, `normal=blue`, `permissive=yellow`, anything else falls back to the configurable default.
+**Wizard.** The "N" wizard's *Sandbox Level (Profile)* step colors each level name using the same palette: `paranoid=green`, `normal=blue`, `permissive=yellow`, anything else falls back to the configurable default. (Note: this is the **sandbox profile** axis — the *Provider* step that comes later picks the env-var bundle and is unrelated. See gh#81 for the disambiguation.)
 
 **Customising the colors.** The palette is configurable in `~/.config/lince-dashboard/config.toml`:
 
@@ -153,7 +153,7 @@ $ gh auth status                    # gh not present
 
 ### 2.3 Permissive
 
-**Network.** Anthropic API plus an explicit GitHub allowlist: `api.github.com`, `github.com`, `objects.githubusercontent.com`. Enough for `gh auth status`, `gh pr create`, `gh issue list`, and `git fetch`/`git clone` over HTTPS against those hosts.
+**Network.** Open. The credential proxy is **off** by default at this level so the agent reads API keys directly from the env and reaches the network without proxy interception. The `allow_domains` list (`api.github.com`, `github.com`, `objects.githubusercontent.com`) is preserved for documentation and only takes effect if the user explicitly turns the proxy back on (`[security] credential_proxy = true` in their config). Threat model: trusted agent that needs broad access — not adversarial.
 
 nono profile (`~/.config/nono/profiles/lince-claude-permissive.json`):
 
@@ -192,13 +192,13 @@ agent-sandbox (bwrap) fragment, `sandbox/profiles/claude-permissive.toml`:
 home_ro_dirs = [".config/gh", ".cache", ".ssh/known_hosts"]
 
 [security]
-credential_proxy = true
-block_git_push = true
+credential_proxy = false   # off by default at permissive
+block_git_push = true       # stays on — push via `gh` instead
 ```
 
 **Filesystem.** Read/write on `$WORKDIR`. Read-only on `~/.config/gh` (so `gh` finds its token), `~/.cache` (general tool cache reuse), and `~/.ssh/known_hosts` (so SSH-style git remotes don't trip on host-key prompts — the private SSH keys themselves are still hidden).
 
-**Tools.** Adds the `gh` CLI. Direct `git push` is still blocked; the intended push path is `gh pr create` / `gh repo sync`. Docker and Podman are not in scope and are not made reachable — that is a much wider trust boundary and is tracked separately.
+**Tools.** Adds the `gh` CLI. Direct `git push` is still blocked; the intended push path is `gh pr create` / `gh repo sync` using a scoped fine-grained PAT (see below) so a leaked/coerced token can't do destructive things. Docker and Podman are not in scope and are not made reachable — that is a much wider trust boundary and is tracked separately.
 
 **Recommended `gh` token: fine-grained PAT, scoped, non-destructive.** A prompt-injected agent at permissive level can read your `gh` token and act as you on GitHub. The default `gh auth login` token from a CLI device flow inherits broad `repo` scope and can do anything you can do — including delete branches, force-push, change repo settings, and read your other repos. Reduce the blast radius by giving the sandbox its own *fine-grained personal access token*, scoped to only the repository (or repositories) the agent is meant to work on, with permissions chosen so a leaked or coerced token cannot do destructive things.
 
@@ -374,7 +374,7 @@ For agent-sandbox (bwrap) users, the equivalent is a TOML fragment at `~/.agent-
 `allow_domains` is the user-visible knob that controls which hosts the credential proxy lets through. It appears in the shipped fragments and can be extended by the user without writing a custom level.
 
 - **In paranoid (`unshare_net = true`)**: `allow_domains` is the **strict allowlist**. Any HTTPS CONNECT or HTTP request to a host not in the union of `credential_rules.domains` and `allow_domains` is rejected. The shipped paranoid fragment sets `allow_domains = ["api.anthropic.com"]`.
-- **In permissive (`unshare_net = false`)**: `allow_domains` lists the extra hosts the proxy passes through without credential injection. The shipped permissive fragment sets `allow_domains = ["api.github.com", "github.com", "objects.githubusercontent.com"]`.
+- **In permissive (`unshare_net = false`, proxy off by default)**: `allow_domains` is documentation-only by default — the proxy isn't running, so nothing is enforced. The shipped permissive fragment lists `["api.github.com", "github.com", "objects.githubusercontent.com"]` so that if a user opts into `[security] credential_proxy = true` on top of permissive, the gh CLI's typical hosts pass through without credential injection without any further config.
 - **Append-merged, not replaced**: when the user adds `[security] allow_domains = [...]` in `~/.agent-sandbox/config.toml`, the entries are concatenated onto whatever the active fragment ships. Switching from paranoid to permissive (or vice versa) does not silently drop the user's additions, but it does change which fragment's defaults they extend.
 
 ### Worked example: paranoid + pypi.org

--- a/docs/documentation/dashboard/usage-guide.md
+++ b/docs/documentation/dashboard/usage-guide.md
@@ -48,7 +48,7 @@ Name: my-agent          (default: agent-3)  [Enter] OK  [Esc] Cancel
 
 - Type a custom name or press `Enter` to accept the default (`agent-N`).
 - `Esc` cancels without spawning.
-- Profile and project directory use config defaults. Use `N` (wizard) for full control.
+- Provider and project directory use config defaults. Use `N` (wizard) for full control.
 
 ### Wizard Mode
 
@@ -67,17 +67,24 @@ Keys `1` through `9` focus the corresponding agent by its row number in the tabl
 
 ## Agent Creation Wizard
 
-The wizard (`N`) walks through five steps to create a new agent.
+The wizard (`N`) walks through up to seven steps to create a new agent
+(steps that are not applicable are auto-skipped — e.g. `Sandbox Backend`
+when only one is installed, `Sandbox Level` for unsandboxed agents,
+`Provider` for agent types with no providers configured).
 
-**Step 1: Agent Type** -- Select from available agent types using `j`/`k`. Sandboxed agents are shown in green; unsandboxed agents are shown in red. This step is skipped if only one agent type is configured.
+**Step 1: Agent Type** -- Select from available agent types using `j`/`k`. Sandboxed agents are shown in green; unsandboxed agents are shown in red. Skipped when only one agent type is configured.
 
-**Step 2: Agent Name** -- Text input for a custom name. Leave empty and press `Enter` to accept the auto-generated default (e.g. `agent-3`).
+**Step 2: Sandbox Backend** -- Pick `bwrap` (agent-sandbox) or `nono`. Skipped when only one backend is detected on this host. Selecting "no sandbox" routes to the agent type's `<base>-unsandboxed` entry.
 
-**Step 3: Profile** -- Conditional step, shown only when the selected agent type has profiles configured. Select a sandbox profile from the list (e.g. `vertex`, `anthropic`). Profiles control provider selection and environment variables.
+**Step 3: Sandbox Level (Profile)** -- Pick the isolation posture: `paranoid`, `normal`, `permissive`, or any custom level discovered on disk. This is the **sandbox profile** axis (gh#81) — the wizard label is "Sandbox Level" but the value also appears as `Profile:` in the detail pane. Skipped for unsandboxed runs.
 
-**Step 4: Project Directory** -- Text input for the working directory path. Tab-completion is available. Defaults to the directory where `zd` was launched.
+**Step 4: Agent Name** -- Text input for a custom name. Leave empty and press `Enter` to accept the auto-generated default (e.g. `agent-3`).
 
-**Step 5: Confirm** -- Review all settings. Press `Enter` to create the agent, or `Backspace` to go back and change a setting.
+**Step 5: Provider** -- Conditional step, shown only when the selected agent type has providers configured (`providers = ["__discover__"]` or an explicit list in `agents-defaults.toml`). Pick a provider name (env-var bundle: `vertex`, `anthropic`, `zai`, …) discovered from `~/.agent-sandbox/config.toml`. The Provider axis is **independent** of Sandbox Level — combine freely. Was named "Profile" pre-#81.
+
+**Step 6: Project Directory** -- Text input for the working directory path. Tab-completion is available. Defaults to the directory where `zd` was launched.
+
+**Step 7: Confirm** -- Review all settings (Type / Backend / Profile / Name / Provider / Dir). Press `Enter` to create the agent, or `Backspace` to go back and change a setting.
 
 ## Agent Lifecycle
 
@@ -105,11 +112,12 @@ The wizard (`N`) walks through five steps to create a new agent.
 
 ## Agent Detail Panel
 
-Press `Enter` on any agent to toggle a detail panel below the table. It displays:
+Press `i` to toggle a detail panel below the table. It displays:
 
 - **Agent type** -- display name with color. Red `[UNSANDBOXED]` warning if applicable.
 - **Status** -- current status with color coding.
-- **Profile** -- the sandbox profile in use (if any).
+- **Profile** -- the sandbox isolation level in use (paranoid / normal / permissive / custom). `(default)` for unsandboxed agents.
+- **Provider** -- the provider env-var bundle in use (e.g. `anthropic`, `vertex`, `zai`). `(default)` if none was selected. **Distinct from Profile (gh#81).**
 - **Project directory** -- the working directory path.
 - **Token usage** -- input and output token counts with `k`/`M` suffixes.
 - **Active tool** -- the tool name currently in use (reported during `PreToolUse` events).
@@ -143,7 +151,7 @@ When agents span multiple project directories, the dashboard automatically group
 
 ## Session Save and Restore
 
-Press `Q` to save the current agent configuration and quit Zellij. On next launch from the same directory, agents are automatically re-spawned with their saved names, profiles, project directories, and token counts.
+Press `Q` to save the current agent configuration and quit Zellij. On next launch from the same directory, agents are automatically re-spawned with their saved names, providers, project directories, and token counts. (Pre-#81 saved-state files use `profile` as the field name; they continue to load thanks to a serde alias on `provider`.)
 
 - State is saved to `.lince-dashboard` in the directory where `zd` was launched.
 - Different directories maintain independent state. Launch from `~/project-a` and `~/project-b` for separate sessions.

--- a/docs/documentation/sandbox/cli-reference.md
+++ b/docs/documentation/sandbox/cli-reference.md
@@ -42,13 +42,13 @@ Launch an AI coding agent inside the sandbox. Defaults to Claude Code in the cur
 
 Options not recognized by `agent-sandbox run` are passed directly to the agent. This means agent flags like `--continue`, `--model`, `--resume`, and `--print` (long form) work without the `--` separator. Use `--` for edge cases where a flag conflicts (e.g., `-p` is used by both agent-sandbox and some agents).
 
-On launch, a banner displays active protections (profile, project path, filesystem mode, network, PID isolation, git push status, env var policy, and credential proxy state).
+On launch, a banner displays active protections (provider, project path, filesystem mode, network, PID isolation, git push status, env var policy, and credential proxy state).
 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `-p`, `--project` | `.` (cwd) | Project directory to mount writable |
 | `-a`, `--agent` | `claude` | Agent to run (looks up `[agents.<name>]` in config) |
-| `-P`, `--profile` | config default | Provider profile name (defined in `config.toml`) |
+| `-P`, `--provider`, `--profile` | config default | Provider name — env-var bundle defined under `[providers.*]` / `[<agent>.providers.*]` in `config.toml` (e.g. `anthropic`, `vertex`, `zai`). `--profile` is the legacy spelling and still works (gh#81). |
 | `--sandbox-level NAME` | per-agent default | Sandbox isolation level: `paranoid`, `normal`, `permissive`, or any custom name. Loads `sandbox/profiles/<NAME>.toml` (built-in) or `~/.agent-sandbox/profiles/<NAME>.toml` (user-supplied) and deep-merges it into the config. See [Configuration Reference](sandbox/config-reference.md#sandbox-levels) |
 | `--log` | config value | Enable session transcript logging |
 | `--no-log` | config value | Disable session transcript logging |
@@ -200,7 +200,7 @@ Remove old snapshots beyond the configured maximum count (`max_project_snapshots
 ### learn
 
 ```
-agent-sandbox learn [-a AGENT] [-P PROFILE] [--duration SECONDS]
+agent-sandbox learn [-a AGENT] [-P PROVIDER] [--duration SECONDS]
                     [--compare] [--apply] [--output FILE]
 ```
 
@@ -211,7 +211,7 @@ Requires `strace` (standard on all Linux distributions).
 | Flag | Default | Description |
 |------|---------|-------------|
 | `-a`, `--agent` | `claude` | Agent to learn |
-| `-P`, `--profile` | none | Provider profile name |
+| `-P`, `--provider`, `--profile` | none | Provider name (env-var bundle) |
 | `--duration` | unlimited | Kill the agent after N seconds |
 | `--compare` | off | Compare observed needs vs current config |
 | `--apply` | off | Auto-merge suggestions into `config.toml` |
@@ -219,10 +219,25 @@ Requires `strace` (standard on all Linux distributions).
 
 ---
 
+### migrate-providers
+
+```
+agent-sandbox migrate-providers [--dry-run]
+```
+
+Rewrite the resolved `config.toml` in place, translating the legacy
+`[profiles.*]` / `[<agent>.profiles.*]` keys (and `default_profile`) to
+the canonical `[providers.*]` / `[<agent>.providers.*]` / `default_provider`
+spelling introduced in gh#81. A `.bak` backup is written next to the
+original. Use `--dry-run` to preview a unified diff. Idempotent — re-running
+on an already-migrated file is a no-op.
+
+---
+
 ### nono-sync
 
 ```
-agent-sandbox nono-sync [--dry-run] [--agent NAME] [-P PROFILE]
+agent-sandbox nono-sync [--dry-run] [--agent NAME] [-P PROVIDER]
 ```
 
 Generate nono JSON profiles from lince agent configuration. Used when the `nono` backend is selected or on macOS.
@@ -231,7 +246,7 @@ Generate nono JSON profiles from lince agent configuration. Used when the `nono`
 |------|---------|-------------|
 | `--dry-run` | off | Print generated JSON without writing files |
 | `--agent` | all agents | Sync a specific agent only |
-| `-P`, `--profile` | none | Provider profile name for env var mapping |
+| `-P`, `--provider`, `--profile` | none | Provider name (env-var bundle) for env var mapping |
 
 ---
 
@@ -250,7 +265,7 @@ If neither exists, the sandbox refuses to start with a clear error. There is no 
 2. `[agents.<name>]` in user `config.toml`
 3. Hardcoded fallback for `claude`
 
-**Environment handling** -- all host environment variables are cleared via `--clearenv`. Only variables listed in `[env].passthrough` and those defined in the active profile are injected. API keys belong in `[*.profiles.*.env]` sections, not in your shell.
+**Environment handling** -- all host environment variables are cleared via `--clearenv`. Only variables listed in `[env].passthrough` and those defined in the active provider are injected. API keys belong in `[*.providers.*.env]` sections (legacy `[*.profiles.*.env]` still works), not in your shell.
 
 ---
 
@@ -267,10 +282,11 @@ agent-sandbox run -a codex
 agent-sandbox run -a gemini
 ```
 
-Switch provider profiles:
+Switch providers (env-var bundles):
 ```bash
-agent-sandbox run -P zai          # Vertex AI
-agent-sandbox run -P mm           # Direct Anthropic API
+agent-sandbox run --provider zai          # Z.AI / GLM
+agent-sandbox run -P vertex               # Vertex AI (-P is a shorter form)
+agent-sandbox run -P anthropic            # Direct Anthropic API
 ```
 
 Review and merge config changes after a session:

--- a/docs/documentation/sandbox/config-reference.md
+++ b/docs/documentation/sandbox/config-reference.md
@@ -44,7 +44,7 @@ General sandbox behavior and filesystem exposure.
 | `persist_toolchains` | bool | `true` | Persist build-tool caches (cargo registry, npm cache, go modules) between sessions |
 | `auto_expose_path` | bool | `true` | Auto-detect `$PATH` entries under `$HOME` and expose them read-only. Top-level dirs are mounted, and deeper subdirectories explicitly in the host PATH are also added to the sandbox PATH (e.g. `~/Applications/apache-maven-3.9.14/bin`) |
 | `home_ro_dirs` | list of strings | `[".config/gcloud"]` | Additional home subdirectories to expose read-only (relative to `$HOME`). Note: this only mounts the filesystem — it does not add entries to PATH. Add the tool's `bin` directory to your host shell PATH for automatic sandbox PATH inclusion |
-| `default_profile` | string | `""` | Default provider profile when `-P` is not specified. Set to a profile name defined in `[*.profiles.*]`. Leave empty to run without a profile |
+| `default_provider` | string | `""` | Default provider (env-var bundle) when `-P` / `--provider` is not specified. Set to a provider name defined in `[providers.*]` / `[<agent>.providers.*]`. Leave empty to run without a provider. The legacy spelling `default_profile` is still accepted (gh#81). |
 | `backend` | string | `"auto"` | Sandbox backend: `"agent-sandbox"` (bubblewrap), `"nono"` (Landlock/Seatbelt), or `"auto"` (prefers agent-sandbox on Linux, nono on macOS) |
 
 ```toml
@@ -54,7 +54,7 @@ ro_dirs = ["~/project"]
 persist_toolchains = true
 auto_expose_path = true
 home_ro_dirs = [".config/gcloud"]
-default_profile = "zai"
+default_provider = "zai"
 backend = "auto"
 ```
 
@@ -138,11 +138,11 @@ Environment variable isolation. All host env vars are cleared; only those listed
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `passthrough` | list of strings | `["TERM", "COLORTERM", "TERM_PROGRAM", "LANG", "LC_ALL", "EDITOR", "VISUAL", "ZELLIJ", "ZELLIJ_SESSION_NAME", "LINCE_AGENT_ID"]` | Host environment variables passed into the sandbox. API keys should go in profiles, not here |
+| `passthrough` | list of strings | `["TERM", "COLORTERM", "TERM_PROGRAM", "LANG", "LC_ALL", "EDITOR", "VISUAL", "ZELLIJ", "ZELLIJ_SESSION_NAME", "LINCE_AGENT_ID"]` | Host environment variables passed into the sandbox. API keys should go in providers (`[<agent>.providers.<name>.env]`), not here |
 
 ### [env.extra]
 
-Static environment variables set inside every sandbox run, regardless of profile.
+Static environment variables set inside every sandbox run, regardless of provider.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
@@ -274,48 +274,67 @@ For the full level matrix, per-backend behavior, and custom-level recipes, see [
 
 ---
 
-## Profiles
+## Providers
 
-Profiles store provider credentials and agent-specific overrides so API keys live in the TOML file instead of your shell environment. Two naming formats are supported:
+A *provider* is a named env-var bundle that switches the model
+provider/account (Anthropic vs Vertex vs Z.ai vs Minimax …). API keys live
+in the TOML file instead of your shell environment.
+
+> **Naming note (gh#81):** what was called "profile" pre-#81 is now
+> "provider". The legacy `[profiles.*]` / `[<agent>.profiles.*]` spelling is
+> still accepted (with a one-shot deprecation note on stderr); run
+> `agent-sandbox migrate-providers` to rewrite the file in place. The word
+> "profile" now refers exclusively to the **sandbox isolation level**
+> (paranoid / normal / permissive — see [Sandbox Levels](#sandbox-levels)
+> above), which is a separate axis you can combine freely with any provider.
+
+Two naming formats are accepted (both for canonical and legacy):
 
 **Namespaced (recommended)**:
 ```toml
-[claude.profiles.vertex]
+[claude.providers.vertex]
 description = "Vertex AI"
-[claude.profiles.vertex.env]
+[claude.providers.vertex.env]
 CLAUDE_CODE_USE_VERTEX = "1"
 ANTHROPIC_VERTEX_PROJECT_ID = "my-gcp-project"
 ANTHROPIC_VERTEX_REGION = "us-east5"
 
-[codex.profiles.default]
+[codex.providers.default]
 description = "Default OpenAI key"
-[codex.profiles.default.env]
+[codex.providers.default.env]
 OPENAI_API_KEY = "sk-..."
 ```
 
-**Legacy (still works, mapped to `claude`)**:
+**Top-level (mapped to `claude`)**:
 ```toml
-[profiles.vertex]
+[providers.vertex]
 description = "Vertex AI"
-[profiles.vertex.env]
+[providers.vertex.env]
 CLAUDE_CODE_USE_VERTEX = "1"
 ```
 
-### Profile keys
+**Legacy (still works)**: replace `providers` with `profiles` in any of the
+above. `agent-sandbox migrate-providers` rewrites it for you.
+
+### Provider keys
 
 | Key | Type | Description |
 |-----|------|-------------|
 | `description` | string | Human-readable label (shown in the run banner) |
 | `env` | table | Environment variables injected via `--setenv` |
 | `env_unset` | list of strings | Environment variables to explicitly unset inside the sandbox |
-| `default_args` | list of strings | Override the agent's `default_args` when this profile is active |
+| `default_args` | list of strings | Override the agent's `default_args` when this provider is active |
 
-### Interaction with the -P flag
+### Interaction with the -P / --provider flag
 
-- `default_profile` in `[sandbox]` sets the profile used when `-P` is omitted.
-- `-P <name>` overrides the default for that invocation.
-- Profile env vars are injected via bwrap `--setenv` and do not need to exist in the host shell.
-- If a profile defines `default_args`, those replace the base agent `default_args`.
+- `default_provider` in `[sandbox]` sets the provider used when `-P` /
+  `--provider` is omitted (legacy `default_profile` still accepted).
+- `-P <name>` (= `--provider <name>` = `--profile <name>`) overrides for
+  that invocation.
+- Provider env vars are injected via bwrap `--setenv` and do not need to
+  exist in the host shell.
+- If a provider defines `default_args`, those replace the base agent
+  `default_args`.
 
 ### Security note
 

--- a/docs/documentation/sandbox/security-model.md
+++ b/docs/documentation/sandbox/security-model.md
@@ -73,7 +73,7 @@ For the full level matrix, per-backend behavior, and how to ship a custom level,
 |------------|-----|-----|
 | Read/write project directory | Agent needs to edit your code | `--bind $PWD $PWD` (writable) |
 | Read other projects | Agent may reference sibling repos | `--ro-bind ~/project ~/project` (configurable) |
-| Network access | Open in `normal` and `permissive` for API calls, pip, npm, git clone. In `paranoid` only the credential proxy is reachable | No `--unshare-net` in `normal`/`permissive`; `bwrap --unshare-net` set in `paranoid` |
+| Network access | Open in `normal` and `permissive` for API calls, pip, npm, git clone — credential proxy is **off** by default at both, the agent reaches APIs directly. In `paranoid` only the credential proxy is reachable. | No `--unshare-net` in `normal`/`permissive`; `bwrap --unshare-net` set in `paranoid` |
 | Build tools | python, node, cargo, make, gcc, etc. | System dirs read-only + `$HOME` PATH dirs auto-detected (including deep subdirectories) |
 | Agent config | Settings, MCP servers, skills | Isolated copy in `~/.agent-sandbox/claude-config` |
 | Package caches | cargo, npm, go can download dependencies | Persistent writable dirs for registry/cache subdirectories |
@@ -124,7 +124,7 @@ The `push.default` git option is forced to `nothing`, so even a bare `git push` 
 
 The credential proxy keeps API keys outside the sandbox entirely. Instead of passing `ANTHROPIC_API_KEY` into the sandbox environment, a proxy runs on the host, intercepts API calls, and injects the correct authentication header. A prompt-injected agent cannot exfiltrate the key because it never exists in the sandbox's memory.
 
-In `normal` and `permissive` levels the proxy is reached via TCP loopback (`http://localhost:PORT`) and the agent's `*_BASE_URL` is rewritten to point at it. In `paranoid` the proxy is reached via a unix socket bind-mounted into the sandbox; an in-sandbox `socat` bridge presents that socket as plain TCP localhost so any SDK that uses `*_BASE_URL` works unchanged.
+By default the proxy is **off** at `normal` and `permissive` and only kicks in when the user opts into `[security] credential_proxy = true` in their config. When opted in (or at `paranoid`, where it's mandatory), the agent's `*_BASE_URL` is rewritten to point at the proxy. At `normal`/`permissive` the proxy is reached via TCP loopback (`http://localhost:PORT`); at `paranoid` it's reached via a unix socket bind-mounted into the sandbox, with an in-sandbox `socat` bridge presenting the socket as plain TCP localhost so any SDK that uses `*_BASE_URL` works unchanged.
 
 Enable it in `config.toml`:
 
@@ -170,9 +170,9 @@ Additional hosts can be blocked via `[credential_proxy].blocked_hosts`.
 All host environment variables are stripped with `--clearenv`. Only two sources of variables enter the sandbox:
 
 1. **`[env].passthrough`** -- an explicit whitelist of host vars (terminal settings, locale). API keys should never be listed here.
-2. **Profile `env` sections** -- provider credentials and settings injected via `--setenv`. These do not need to exist in the host shell.
+2. **Provider `env` sections** -- credentials and settings injected via `--setenv` from `[<agent>.providers.<name>.env]` (legacy `[<agent>.profiles.<name>.env]` still works — see gh#81). These do not need to exist in the host shell.
 
-Static variables can also be set via `[env.extra]` for every run regardless of profile.
+Static variables can also be set via `[env.extra]` for every run regardless of provider.
 
 ---
 
@@ -184,7 +184,7 @@ Static variables can also be set via `[env.extra]` for every run regardless of p
 | **Git push bypass** | The agent could call `/usr/bin/git push` directly, bypassing the wrapper. However, without SSH keys or credential helpers, authentication fails. The wrapper is defense-in-depth |
 | **Not a VM** | bubblewrap uses Linux namespaces, a kernel feature. A kernel vulnerability in namespace handling could theoretically allow escape. For higher assurance, run the sandbox inside a VM |
 | **Linux only** | agent-sandbox requires bubblewrap, which depends on Linux kernel namespaces. macOS users can use the [nono](https://github.com/always-further/nono) backend (Landlock/Seatbelt) |
-| **MCP server secrets** | If `~/.claude/settings.json` contains API keys in MCP server env vars, those are copied to the sandbox. Review `~/.agent-sandbox/claude-config/settings.json` after init. With `credential_proxy = true`, profile API keys stay outside the sandbox |
+| **MCP server secrets** | If `~/.claude/settings.json` contains API keys in MCP server env vars, those are copied to the sandbox. Review `~/.agent-sandbox/claude-config/settings.json` after init. With `credential_proxy = true`, API keys configured in providers stay outside the sandbox |
 | **Tmpfs home is writable** | The `$HOME` tmpfs overlay is writable (that is how tmpfs works). The agent can create temporary files like `~/temp.txt`, but they are ephemeral and vanish when the sandbox exits. They never touch your real home directory |
 | **Credential proxy and HTTPS** | The proxy rewrites `*_BASE_URL` to `http://localhost:PORT`. All major AI SDKs support base URL overrides, so this is transparent. Custom HTTP clients that ignore `*_BASE_URL` env vars will not benefit from the proxy |
 | **Learn mode accuracy** | `strace` captures actual I/O but may miss paths checked with `access()` or `stat()` without opening. The learn sandbox is permissive, so the agent may access paths blocked in the real sandbox. Use the report as guidance, not as an exhaustive spec |

--- a/lince-dashboard/agents-defaults.toml
+++ b/lince-dashboard/agents-defaults.toml
@@ -10,7 +10,16 @@
 # Command templates support placeholders:
 #   {agent_id}    - unique agent identifier (e.g. "agent-1")
 #   {project_dir} - project directory path
-#   {profile}     - sandbox profile name
+#   {provider}    - provider name (env-var bundle: anthropic / vertex / zai / ...)
+#   {profile}     - legacy alias for {provider}, kept for back-compat (gh#81)
+#
+# Note: there are TWO orthogonal axes that historically shared the word
+# "profile":
+#   * sandbox profile = isolation level (paranoid / normal / permissive),
+#     selected via the `sandbox_level` field below.
+#   * provider = env-var bundle (Anthropic vs Vertex vs Z.ai vs ...),
+#     selected via the `providers` field below and the wizard's "Provider" step.
+# These are independent — you can run e.g. `paranoid + zai`. See gh#81.
 #
 # Sandbox model (claude, codex, gemini, opencode, pi):
 #   - sandbox_backend = "bwrap" | "nono"  (default per OS)
@@ -52,14 +61,15 @@ short_label = "CLA"
 # Color follows the sandbox-level gradient (basic ANSI palette):
 #   paranoid=green, normal=blue, permissive=yellow, unsandboxed=red
 # The same palette drives the per-pane title indicator and the "N" wizard's
-# profile-selection step (gh#63). Override via [dashboard.sandbox_colors] in
+# Provider step when the provider name happens to match a level keyword
+# (gh#63). Override via [dashboard.sandbox_colors] in
 # ~/.config/lince-dashboard/config.toml — see docs/documentation/dashboard/
 # sandbox-levels.md §1.1.
 color = "blue"
 sandboxed = true
 has_native_hooks = true
 home_ro_dirs = ["~/.claude/"]
-profiles = ["__discover__"]
+providers = ["__discover__"]
 sandbox_level = "normal"          # paranoid | normal | permissive (or custom; see docs)
 # sandbox_backend defaults to "agent-sandbox" (bwrap) on Linux, "nono" on macOS.
 # Uncomment to force a specific backend (overrides the OS default):
@@ -74,7 +84,7 @@ short_label = "CLU"
 color = "red"
 sandboxed = false
 has_native_hooks = true
-profiles = ["__discover__"]
+providers = ["__discover__"]
 
 [agents.codex]
 # Legacy fallback command — ignored when sandbox_level is set.
@@ -91,7 +101,7 @@ ignore_wrapper_start = true
 bwrap_conflict = true
 disable_inner_sandbox_args = ["--sandbox", "danger-full-access"]
 home_ro_dirs = ["~/.codex/"]
-profiles = ["__discover__"]
+providers = ["__discover__"]
 sandbox_level = "normal"          # paranoid | normal | permissive (or custom; see docs)
 # sandbox_backend defaults to bwrap on Linux, nono on macOS. Uncomment to override:
 # sandbox_backend = "nono"
@@ -110,7 +120,7 @@ sandboxed = false
 has_native_hooks = false
 ignore_wrapper_start = true
 bwrap_conflict = false
-profiles = ["__discover__"]
+providers = ["__discover__"]
 
 [agents.codex-unsandboxed.env_vars]
 OPENAI_API_KEY = "$OPENAI_API_KEY"
@@ -128,7 +138,7 @@ has_native_hooks = false
 bwrap_conflict = false
 disable_inner_sandbox_args = []
 home_ro_dirs = ["~/.gemini/"]
-profiles = ["__discover__"]
+providers = ["__discover__"]
 sandbox_level = "normal"          # paranoid | normal | permissive (or custom; see docs)
 # sandbox_backend defaults to bwrap on Linux, nono on macOS. Uncomment to override:
 # sandbox_backend = "nono"
@@ -146,7 +156,7 @@ color = "red"
 sandboxed = false
 has_native_hooks = false
 disable_inner_sandbox_args = []
-profiles = ["__discover__"]
+providers = ["__discover__"]
 
 [agents.gemini-unsandboxed.env_vars]
 GEMINI_API_KEY = "$GEMINI_API_KEY"
@@ -164,7 +174,7 @@ has_native_hooks = false
 bwrap_conflict = false
 disable_inner_sandbox_args = []
 home_ro_dirs = ["~/.config/opencode/"]
-profiles = ["__discover__"]
+providers = ["__discover__"]
 sandbox_level = "normal"          # paranoid | normal | permissive (or custom; see docs)
 # sandbox_backend defaults to bwrap on Linux, nono on macOS. Uncomment to override:
 # sandbox_backend = "nono"
@@ -179,7 +189,7 @@ color = "red"
 sandboxed = false
 has_native_hooks = false
 home_ro_dirs = ["~/.config/opencode/"]
-profiles = ["__discover__"]
+providers = ["__discover__"]
 
 [agents.pi]
 # Legacy fallback command — ignored when sandbox_level is set.
@@ -194,7 +204,7 @@ has_native_hooks = true
 bwrap_conflict = false
 disable_inner_sandbox_args = []
 home_ro_dirs = ["~/.pi/"]
-profiles = ["__discover__"]
+providers = ["__discover__"]
 sandbox_level = "normal"          # paranoid | normal | permissive (or custom; see docs)
 # sandbox_backend defaults to bwrap on Linux, nono on macOS. Uncomment to override:
 # sandbox_backend = "nono"
@@ -248,7 +258,7 @@ short_label = "PIU"
 color = "red"
 sandboxed = false
 has_native_hooks = true
-profiles = ["__discover__"]
+providers = ["__discover__"]
 
 [agents.pi-unsandboxed.env_vars]
 ANTHROPIC_API_KEY = "$ANTHROPIC_API_KEY"

--- a/lince-dashboard/plugin/src/agent.rs
+++ b/lince-dashboard/plugin/src/agent.rs
@@ -84,19 +84,24 @@ pub fn default_agent_pane_coords() -> FloatingPaneCoordinates {
 use crate::config::now_secs;
 
 /// Apply placeholder substitution to a command template.
-/// Replaces `{agent_id}`, `{project_dir}`, `{profile}` in each arg.
+///
+/// Replaces `{agent_id}`, `{project_dir}`, `{provider}` (canonical) and
+/// `{profile}` (legacy alias — kept for back-compat with existing
+/// `agents-defaults.toml` files; both expand to the provider name).
 fn expand_command_template(
     template: &[String],
     agent_id: &str,
     project_dir: &str,
-    profile: Option<&str>,
+    provider: Option<&str>,
 ) -> Vec<String> {
+    let prov = provider.unwrap_or("");
     template
         .iter()
         .map(|arg| {
             arg.replace("{agent_id}", agent_id)
                 .replace("{project_dir}", project_dir)
-                .replace("{profile}", profile.unwrap_or(""))
+                .replace("{provider}", prov)
+                .replace("{profile}", prov)
         })
         .collect()
 }
@@ -266,7 +271,7 @@ fn spawn_inner(
     agents: &[AgentInfo],
     name: String,
     agent_type: &str,
-    profile: Option<String>,
+    provider: Option<String>,
     project_dir: String,
     group: Option<String>,
     sandbox_level_override: Option<String>,
@@ -284,24 +289,24 @@ fn spawn_inner(
     let id = format!("{}-{}", base, next_id);
     let name = if name.is_empty() { id.clone() } else { name };
 
-    // Validate profile: drop it if it doesn't exist for this agent type.
-    // Prevents failures when e.g. default_profile is "anthropic" but a codex
-    // agent has no such profile, or when restoring a saved agent whose profile
-    // was removed from config.
-    let profile = profile.and_then(|p| {
-        let available = config.profiles_for_agent_type(agent_type);
+    // Validate provider: drop it if it doesn't exist for this agent type.
+    // Prevents failures when e.g. default_provider is "anthropic" but a codex
+    // agent has no such provider, or when restoring a saved agent whose
+    // provider was removed from config.
+    let provider = provider.and_then(|p| {
+        let available = config.providers_for_agent_type(agent_type);
         if available.iter().any(|a| a == &p) { Some(p) } else { None }
     });
 
     let args: Vec<String> = if let Some(type_config) = config.agent_types.get(agent_type) {
         let mut expanded: Vec<String> = Vec::new();
 
-        // For non-sandboxed agents, apply profile env vars via `env` command.
+        // For non-sandboxed agents, apply provider env vars via `env` command.
         // Sandboxed agents go through agent-sandbox which handles env internally.
         if !type_config.sandboxed {
-            // Unset conflicting env vars from profile
-            if let Some(ref prof_name) = profile {
-                if let Some(details) = config.profile_details_for(agent_type, prof_name) {
+            // Unset conflicting env vars from provider
+            if let Some(ref prov_name) = provider {
+                if let Some(details) = config.provider_details_for(agent_type, prov_name) {
                     for var in &details.env_unset {
                         expanded.push("-u".to_string());
                         expanded.push(var.clone());
@@ -364,14 +369,15 @@ fn spawn_inner(
                 &type_config.command,
                 &id,
                 &project_dir,
-                profile.as_deref(),
+                provider.as_deref(),
             ));
         }
-        // For agent-sandbox (bwrap) agents, pass the profile via -P flag so
-        // agent-sandbox can resolve the profile's env vars internally.
-        // Nono agents already have --profile baked into their command template.
+        // For agent-sandbox (bwrap) agents, pass the provider via -P flag so
+        // agent-sandbox can resolve the provider's env vars internally. Nono
+        // agents already have `--profile` (nono's own concept, unrelated to
+        // provider) baked into their command template.
         if type_config.sandboxed && *effective_backend == SandboxBackend::AgentSandbox {
-            if let Some(ref p) = profile {
+            if let Some(ref p) = provider {
                 if !p.is_empty() {
                     expanded.push("-P".to_string());
                     expanded.push(p.clone());
@@ -386,7 +392,7 @@ fn spawn_inner(
             config.sandbox_command.clone(),
             "run".to_string(),
         ];
-        if let Some(ref p) = profile {
+        if let Some(ref p) = provider {
             if !p.is_empty() {
                 args.push("-P".to_string());
                 args.push(p.clone());
@@ -425,7 +431,7 @@ fn spawn_inner(
         id,
         name,
         agent_type: agent_type.to_string(),
-        profile,
+        provider,
         project_dir,
         status: AgentStatus::Starting,
         pane_id: None,
@@ -444,7 +450,7 @@ fn spawn_inner(
     })
 }
 
-/// Spawn a new agent with custom name, profile, project directory, and optional sandbox overrides.
+/// Spawn a new agent with custom name, provider, project directory, and optional sandbox overrides.
 ///
 /// `sandbox_level_override` / `sandbox_backend_override` are the runtime values selected in the
 /// wizard (or restored from saved state). When `None`, `spawn_inner` falls back to the
@@ -455,13 +461,13 @@ pub fn spawn_agent_custom(
     agents: &[AgentInfo],
     custom_name: String,
     agent_type: &str,
-    custom_profile: Option<String>,
+    custom_provider: Option<String>,
     custom_project_dir: String,
     launch_dir: Option<&str>,
     sandbox_level_override: Option<String>,
     sandbox_backend_override: Option<SandboxBackend>,
 ) -> Result<AgentInfo, String> {
-    let profile = match custom_profile {
+    let provider = match custom_provider {
         Some(ref p) if p.is_empty() => None,
         other => other,
     };
@@ -478,7 +484,7 @@ pub fn spawn_agent_custom(
         agents,
         custom_name,
         agent_type,
-        profile,
+        provider,
         project_dir,
         None,
         sandbox_level_override,

--- a/lince-dashboard/plugin/src/config.rs
+++ b/lince-dashboard/plugin/src/config.rs
@@ -17,7 +17,9 @@ pub const DEFAULT_SANDBOX_COMMAND: &str = "agent-sandbox";
 /// String keys only — no enum, fully data-driven.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentTypeConfig {
-    /// Command template. Supports `{agent_id}`, `{project_dir}`, `{profile}` placeholders.
+    /// Command template. Supports `{agent_id}`, `{project_dir}`, and the
+    /// equivalent provider placeholders `{provider}` (canonical) /
+    /// `{profile}` (legacy alias) — both expand to the selected provider name.
     pub command: Vec<String>,
     /// Pattern to match pane titles for reconciliation (e.g. "agent-sandbox").
     pub pane_title_pattern: String,
@@ -57,12 +59,16 @@ pub struct AgentTypeConfig {
     /// Custom mapping from agent event names to lince status strings.
     #[serde(default)]
     pub event_map: HashMap<String, String>,
-    /// Sandbox profiles applicable to this agent type.
-    /// - `["__discover__"]` means use all auto-discovered profiles (default for sandboxed agents via agent-sandbox).
-    /// - Empty or omitted means no profiles (skip profile wizard step).
-    /// - Explicit list restricts the wizard to those profile names.
-    #[serde(default)]
-    pub profiles: Vec<String>,
+    /// Providers (env-var bundles) applicable to this agent type.
+    /// - `["__discover__"]` means use all auto-discovered providers (default
+    ///   for sandboxed agents via agent-sandbox).
+    /// - Empty or omitted means no providers (skip the wizard's Provider step).
+    /// - An explicit list restricts the wizard to those provider names.
+    ///
+    /// Was `profiles` pre-#81 — the legacy spelling is still accepted via
+    /// `serde(alias)` so existing user `agents-defaults.toml` files keep working.
+    #[serde(default, alias = "profiles")]
+    pub providers: Vec<String>,
     /// Sandbox backend used by this agent type.
     /// Overrides the global `[dashboard].sandbox_backend` setting.
     /// Defaults to `AgentSandbox` for backward compatibility.
@@ -200,29 +206,37 @@ fn default_max_agents() -> usize {
     8
 }
 
-/// Parsed profile details from sandbox config (env vars to set/unset).
+/// Parsed provider details from sandbox config (env vars to set/unset).
+///
+/// Each provider corresponds to a `[providers.<name>]` (canonical) or
+/// legacy `[profiles.<name>]` table in `~/.agent-sandbox/config.toml`. See
+/// gh#81 for the rename rationale.
 #[derive(Debug, Clone, Default)]
-pub struct ProfileDetails {
-    /// Environment variables to set (from `[profiles.<name>.env]`).
+pub struct ProviderDetails {
+    /// Environment variables to set (from `[<...>.<name>.env]`).
     pub env: HashMap<String, String>,
-    /// Environment variables to unset (from `[profiles.<name>.env_unset]`).
+    /// Environment variables to unset (from `[<...>.<name>.env_unset]`).
     pub env_unset: Vec<String>,
 }
 
 /// Main dashboard configuration, deserialized from the `[dashboard]` TOML table.
 #[derive(Debug, Clone, Deserialize)]
 pub struct DashboardConfig {
-    #[serde(default)]
-    pub default_profile: Option<String>,
-    /// Per-agent-type profile names, keyed by agent base name (e.g. "claude", "codex").
-    /// Populated from `[profiles.*]` (legacy → "claude") and `[<agent>.profiles.*]`
+    /// Default provider (env-var bundle) name. Was `default_profile` pre-#81;
+    /// the legacy spelling is still accepted as a serde alias.
+    #[serde(default, alias = "default_profile")]
+    pub default_provider: Option<String>,
+    /// Per-agent-type provider names, keyed by agent base name (e.g. "claude",
+    /// "codex"). Populated from `[providers.*]` / `[<agent>.providers.*]`
+    /// (canonical) and the legacy `[profiles.*]` / `[<agent>.profiles.*]`
     /// sections in the sandbox config.
     #[serde(skip)]
-    pub profiles_by_agent: HashMap<String, Vec<String>>,
-    /// Per-agent-type profile details (env vars), keyed by agent base name then profile name.
+    pub providers_by_agent: HashMap<String, Vec<String>>,
+    /// Per-agent-type provider details (env vars), keyed by agent base name
+    /// then provider name.
     #[serde(skip)]
-    pub profile_details_by_agent: HashMap<String, HashMap<String, ProfileDetails>>,
-    /// Path to sandbox config for profile auto-discovery.
+    pub provider_details_by_agent: HashMap<String, HashMap<String, ProviderDetails>>,
+    /// Path to sandbox config for provider auto-discovery.
     /// Defaults to `~/.agent-sandbox/config.toml`.
     #[serde(default)]
     pub sandbox_config_path: Option<String>,
@@ -267,9 +281,9 @@ pub struct DashboardConfig {
 impl Default for DashboardConfig {
     fn default() -> Self {
         DashboardConfig {
-            default_profile: None,
-            profiles_by_agent: HashMap::new(),
-            profile_details_by_agent: HashMap::new(),
+            default_provider: None,
+            providers_by_agent: HashMap::new(),
+            provider_details_by_agent: HashMap::new(),
             sandbox_config_path: None,
             default_project_dir: None,
             sandbox_command: default_sandbox_command(),
@@ -359,8 +373,9 @@ pub fn common_prefix(items: &[String]) -> String {
 
 /// Context key for identifying RunCommandResult callbacks (shared with state_file).
 pub const CMD_TYPE_KEY: &str = "type";
-/// Command type for async profile discovery via `run_command`.
-pub const CMD_DISCOVER_PROFILES: &str = "discover_profiles";
+/// Command type for async provider discovery via `run_command` (was
+/// `CMD_DISCOVER_PROFILES` pre-#81).
+pub const CMD_DISCOVER_PROVIDERS: &str = "discover_providers";
 /// Command type for async loading of agent type defaults via `run_command`.
 pub const CMD_LOAD_AGENT_DEFAULTS: &str = "load_agent_defaults";
 
@@ -391,11 +406,12 @@ pub const CMD_PATH_COMPLETE: &str = "path_complete";
 /// suffix-less "normal" profile). See `discover_sandbox_levels_async()`.
 pub const CMD_DISCOVER_SANDBOX_LEVELS: &str = "discover_sandbox_levels";
 
-/// Extract profile details from a TOML table (the value side of a `[*.profiles.<name>]` entry).
-fn parse_profile_details(profile_table: &toml::Table) -> ProfileDetails {
-    let mut pd = ProfileDetails::default();
+/// Extract provider details from a TOML table (the value side of a
+/// `[*.providers.<name>]` / `[*.profiles.<name>]` entry).
+fn parse_provider_details(table: &toml::Table) -> ProviderDetails {
+    let mut pd = ProviderDetails::default();
     // Parse env vars to set
-    if let Some(env_table) = profile_table.get("env").and_then(|v| v.as_table()) {
+    if let Some(env_table) = table.get("env").and_then(|v| v.as_table()) {
         for (k, v) in env_table {
             if let Some(s) = v.as_str() {
                 pd.env.insert(k.clone(), s.to_string());
@@ -403,7 +419,7 @@ fn parse_profile_details(profile_table: &toml::Table) -> ProfileDetails {
         }
     }
     // Parse env vars to unset
-    if let Some(unset_arr) = profile_table.get("env_unset").and_then(|v| v.as_array()) {
+    if let Some(unset_arr) = table.get("env_unset").and_then(|v| v.as_array()) {
         for v in unset_arr {
             if let Some(s) = v.as_str() {
                 pd.env_unset.push(s.to_string());
@@ -413,64 +429,82 @@ fn parse_profile_details(profile_table: &toml::Table) -> ProfileDetails {
     pd
 }
 
-/// Parse sandbox profiles from TOML content, returning per-agent-type maps.
+/// Parse providers (env-var bundles) from sandbox config TOML content,
+/// returning per-agent-type maps.
 ///
-/// Recognises two formats:
-///   - Legacy `[profiles.<name>]`          → attributed to agent base "claude"
-///   - Namespaced `[<agent>.profiles.<name>]` → attributed to `<agent>`
+/// Recognises four formats — canonical first, legacy second:
+///   - `[providers.<name>]`              → attributed to agent base "claude"
+///   - `[<agent>.providers.<name>]`      → attributed to `<agent>`
+///   - Legacy `[profiles.<name>]`        → attributed to "claude"
+///   - Legacy `[<agent>.profiles.<name>]` → attributed to `<agent>`
 ///
-/// Returns `(profiles_by_agent, details_by_agent)`.
-pub fn parse_profiles_from_toml(
+/// When both forms exist for the same agent + name, the canonical entry wins.
+/// Returns `(providers_by_agent, details_by_agent)`.
+pub fn parse_providers_from_toml(
     content: &str,
-) -> (HashMap<String, Vec<String>>, HashMap<String, HashMap<String, ProfileDetails>>) {
+) -> (HashMap<String, Vec<String>>, HashMap<String, HashMap<String, ProviderDetails>>) {
     let table: toml::Table = match toml::from_str(content) {
         Ok(t) => t,
         Err(_) => return (HashMap::new(), HashMap::new()),
     };
 
     let mut by_agent: HashMap<String, Vec<String>> = HashMap::new();
-    let mut details_by_agent: HashMap<String, HashMap<String, ProfileDetails>> = HashMap::new();
+    let mut details_by_agent: HashMap<String, HashMap<String, ProviderDetails>> = HashMap::new();
 
-    // 1) Legacy `[profiles.*]` → attributed to "claude"
-    if let Some(profiles) = table.get("profiles").and_then(|v| v.as_table()) {
-        let agent = "claude".to_string();
-        let names = by_agent.entry(agent.clone()).or_default();
-        let details = details_by_agent.entry(agent).or_default();
-        for (name, value) in profiles {
-            if !names.contains(name) {
-                names.push(name.clone());
-            }
-            if let Some(profile_table) = value.as_table() {
-                details.entry(name.clone()).or_insert_with(|| parse_profile_details(profile_table));
-            }
+    fn push_one(
+        agent: &str,
+        name: &str,
+        detail_table: Option<&toml::Table>,
+        by_agent: &mut HashMap<String, Vec<String>>,
+        details_by_agent: &mut HashMap<String, HashMap<String, ProviderDetails>>,
+    ) {
+        let names = by_agent.entry(agent.to_string()).or_default();
+        if !names.iter().any(|n| n == name) {
+            names.push(name.to_string());
+        }
+        // Last-wins semantics: a later (higher-precedence) call OVERWRITES the
+        // previous detail for the same agent + name. Match the Python reader's
+        // dict.update() behaviour so the same config produces the same env-var
+        // bundle on both sides — see the precedence comment below.
+        if let Some(t) = detail_table {
+            details_by_agent
+                .entry(agent.to_string())
+                .or_default()
+                .insert(name.to_string(), parse_provider_details(t));
         }
     }
 
-    // 2) Namespaced `[<agent>.profiles.*]`
-    // Scan all top-level keys: any that contain a `profiles` subtable are treated
-    // as agent-type profile namespaces. This supports custom agent types too.
-    for (key, value) in &table {
-        if key == "profiles" {
-            continue; // Already handled above as legacy
+    // Process from LOWEST to HIGHEST precedence so the last write wins
+    // (matches `resolve_providers` in sandbox/agent-sandbox: legacy top →
+    // legacy ns → canonical top → canonical ns, with later layers replacing
+    // earlier ones for any colliding agent + name pair).
+    //
+    // 1) Legacy top-level [profiles.*]      → "claude"
+    // 2) Canonical top-level [providers.*]  → "claude"
+    for top_key in ["profiles", "providers"] {
+        if let Some(top) = table.get(top_key).and_then(|v| v.as_table()) {
+            for (name, value) in top {
+                push_one("claude", name, value.as_table(), &mut by_agent, &mut details_by_agent);
+            }
         }
-        if let Some(agent_section) = value.as_table() {
-            if let Some(profiles) = agent_section.get("profiles").and_then(|v| v.as_table()) {
-                let agent = key.clone();
-                let names = by_agent.entry(agent.clone()).or_default();
-                let details = details_by_agent.entry(agent).or_default();
-                for (name, val) in profiles {
-                    if !names.contains(name) {
-                        names.push(name.clone());
-                    }
-                    if let Some(profile_table) = val.as_table() {
-                        details.entry(name.clone()).or_insert_with(|| parse_profile_details(profile_table));
-                    }
+    }
+    // 3) Legacy namespaced [<agent>.profiles.*]
+    // 4) Canonical namespaced [<agent>.providers.*] — highest precedence
+    for (agent_key, agent_value) in &table {
+        if agent_key == "providers" || agent_key == "profiles" {
+            continue;
+        }
+        let Some(agent_section) = agent_value.as_table() else { continue };
+        for sub_key in ["profiles", "providers"] {
+            if let Some(provs) = agent_section.get(sub_key).and_then(|v| v.as_table()) {
+                for (name, val) in provs {
+                    push_one(agent_key, name, val.as_table(), &mut by_agent, &mut details_by_agent);
                 }
             }
         }
     }
 
-    // Sort each agent's profile names
+    // Sort each agent's provider names
     for names in by_agent.values_mut() {
         names.sort();
     }
@@ -483,15 +517,16 @@ pub fn shell_escape(s: &str) -> String {
     s.replace('\'', "'\\''")
 }
 
-/// Kick off async discovery of sandbox profiles by reading config files
-/// via `run_command`. Results arrive in `Event::RunCommandResult` with
-/// context `type=discover_profiles`.
+/// Kick off async discovery of providers (env-var bundles) by reading sandbox
+/// config files via `run_command`. Results arrive in `Event::RunCommandResult`
+/// with context `type=discover_providers`. Was `discover_profiles_async`
+/// pre-#81 — see issue for naming rationale.
 ///
 /// Reads the global config and optionally a project-local config. Each file
 /// is cat'd separately and their outputs are joined by a NUL byte so the
 /// handler can parse them independently (avoiding invalid TOML from
-/// concatenating files with duplicate `[profiles]` headers).
-pub fn discover_profiles_async(sandbox_config_path: Option<&str>, launch_dir: Option<&str>) {
+/// concatenating files with duplicate `[providers]` headers).
+pub fn discover_providers_async(sandbox_config_path: Option<&str>, launch_dir: Option<&str>) {
     // Build the global config path for the shell script.
     // IMPORTANT: We must NOT quote paths that start with `~` because the shell
     // only performs tilde expansion on unquoted tildes.  `expand_tilde()` uses
@@ -516,7 +551,7 @@ pub fn discover_profiles_async(sandbox_config_path: Option<&str>, launch_dir: Op
         );
     }
 
-    run_typed_command(&["sh", "-c", &script], CMD_DISCOVER_PROFILES);
+    run_typed_command(&["sh", "-c", &script], CMD_DISCOVER_PROVIDERS);
 }
 
 /// Kick off async discovery of custom sandbox-level profile files.
@@ -694,7 +729,7 @@ impl DashboardConfig {
     /// Returns `(config, error)` where `error` is `Some(msg)` if reading or
     /// parsing failed (in which case `config` holds all defaults).
     ///
-    /// Profile auto-discovery happens asynchronously via `discover_profiles_async()`
+    /// Provider auto-discovery happens asynchronously via `discover_providers_async()`
     /// after the plugin has permissions and knows the launch directory.
     ///
     /// # Manual testing
@@ -718,14 +753,14 @@ impl DashboardConfig {
     }
 
 
-    /// Merge discovered per-agent-type profiles, deduplicating.
-    pub fn merge_profiles(
+    /// Merge discovered per-agent-type providers, deduplicating.
+    pub fn merge_providers(
         &mut self,
         by_agent: &HashMap<String, Vec<String>>,
-        details_by_agent: &HashMap<String, HashMap<String, ProfileDetails>>,
+        details_by_agent: &HashMap<String, HashMap<String, ProviderDetails>>,
     ) {
         for (agent, names) in by_agent {
-            let existing = self.profiles_by_agent.entry(agent.clone()).or_default();
+            let existing = self.providers_by_agent.entry(agent.clone()).or_default();
             for name in names {
                 if !existing.contains(name) {
                     existing.push(name.clone());
@@ -734,35 +769,36 @@ impl DashboardConfig {
             existing.sort();
         }
         for (agent, details) in details_by_agent {
-            let existing = self.profile_details_by_agent.entry(agent.clone()).or_default();
+            let existing = self.provider_details_by_agent.entry(agent.clone()).or_default();
             for (name, detail) in details {
                 existing.entry(name.clone()).or_insert_with(|| detail.clone());
             }
         }
     }
 
-    /// Resolve the effective profile list for a given agent type.
+    /// Resolve the effective provider list for a given agent type.
     ///
-    /// - If the agent type has `profiles = ["__discover__"]`, returns discovered profiles
-    ///   for the agent's base name (e.g. "claude", "codex").
-    /// - If the agent type has an explicit list, returns the intersection with discovered.
-    /// - If the agent type has no profiles (empty), returns an empty list.
-    pub fn profiles_for_agent_type(&self, agent_type: &str) -> Vec<String> {
+    /// - If the agent type has `providers = ["__discover__"]`, returns
+    ///   discovered providers for the agent's base name (e.g. "claude", "codex").
+    /// - If the agent type has an explicit list, returns the intersection with
+    ///   discovered providers (so unknown names are silently filtered).
+    /// - If the agent type has no providers (empty), returns an empty list.
+    pub fn providers_for_agent_type(&self, agent_type: &str) -> Vec<String> {
         let cfg = match self.agent_types.get(agent_type) {
             Some(c) => c,
             None => return Vec::new(),
         };
-        if cfg.profiles.is_empty() {
+        if cfg.providers.is_empty() {
             return Vec::new();
         }
         let base = crate::agent::agent_type_base_name(agent_type);
-        let discovered = self.profiles_by_agent.get(base);
-        if cfg.profiles.len() == 1 && cfg.profiles[0] == "__discover__" {
+        let discovered = self.providers_by_agent.get(base);
+        if cfg.providers.len() == 1 && cfg.providers[0] == "__discover__" {
             return discovered.cloned().unwrap_or_default();
         }
-        // Explicit list: intersect with discovered profiles for validation
+        // Explicit list: intersect with discovered providers for validation
         let disc = discovered.cloned().unwrap_or_default();
-        cfg.profiles
+        cfg.providers
             .iter()
             .filter(|p| disc.contains(p))
             .cloned()
@@ -912,12 +948,12 @@ impl DashboardConfig {
         0
     }
 
-    /// Look up profile details for a given agent type and profile name.
-    pub fn profile_details_for(&self, agent_type: &str, profile_name: &str) -> Option<&ProfileDetails> {
+    /// Look up provider details for a given agent type and provider name.
+    pub fn provider_details_for(&self, agent_type: &str, provider_name: &str) -> Option<&ProviderDetails> {
         let base = crate::agent::agent_type_base_name(agent_type);
-        self.profile_details_by_agent
+        self.provider_details_by_agent
             .get(base)
-            .and_then(|m| m.get(profile_name))
+            .and_then(|m| m.get(provider_name))
     }
 
     /// Return the event_map for a given agent type, or None if empty/missing.
@@ -926,5 +962,78 @@ impl DashboardConfig {
             .get(agent_type)
             .map(|c| &c.event_map)
             .filter(|m| !m.is_empty())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pre-#81 `agents-defaults.toml` files used `profiles = [...]`. The
+    /// rename added `#[serde(alias = "profiles")]` on `AgentTypeConfig.providers`
+    /// so legacy files keep working without the user editing them.
+    #[test]
+    fn legacy_profiles_field_in_agent_defaults_loads() {
+        let toml_text = r#"
+            [agents.claude]
+            command = ["claude"]
+            pane_title_pattern = "claude"
+            status_pipe_name = "claude-status"
+            display_name = "Claude"
+            short_label = "CLA"
+            color = "blue"
+            sandboxed = true
+            profiles = ["__discover__"]
+        "#;
+        let parsed = parse_agent_defaults(toml_text.as_bytes());
+        let claude = parsed.get("claude").expect("claude should parse");
+        assert_eq!(claude.providers, vec!["__discover__"]);
+    }
+
+    /// Sandbox config dual-read: namespaced canonical `[<agent>.providers.X]`
+    /// must beat top-level legacy `[profiles.X]` for the same name. Matches
+    /// the precedence implemented by `resolve_providers` in
+    /// `sandbox/agent-sandbox` (legacy → canonical, last wins).
+    #[test]
+    fn namespaced_canonical_overrides_top_level_legacy() {
+        let toml_text = r#"
+            [profiles.zai]
+            description = "from-legacy-top"
+            [profiles.zai.env]
+            ANTHROPIC_BASE_URL = "https://legacy.example.com"
+
+            [claude.providers.zai]
+            description = "from-canonical-ns"
+            [claude.providers.zai.env]
+            ANTHROPIC_BASE_URL = "https://canonical.example.com"
+        "#;
+        let (_names, details) = parse_providers_from_toml(toml_text);
+        let claude = details.get("claude").expect("claude bucket");
+        let zai = claude.get("zai").expect("zai entry");
+        assert_eq!(
+            zai.env.get("ANTHROPIC_BASE_URL").map(String::as_str),
+            Some("https://canonical.example.com"),
+            "namespaced canonical must replace top-level legacy",
+        );
+    }
+
+    /// Both forms in the same file must each contribute their distinct
+    /// providers without dropping anything. Uses an explicit name list assert
+    /// so a regression in iteration order would still surface a missing entry.
+    #[test]
+    fn legacy_and_canonical_coexist() {
+        let toml_text = r#"
+            [profiles.legacyOnly]
+            [profiles.legacyOnly.env]
+            X = "1"
+
+            [claude.providers.canonicalOnly]
+            [claude.providers.canonicalOnly.env]
+            Y = "2"
+        "#;
+        let (names, _details) = parse_providers_from_toml(toml_text);
+        let mut claude = names.get("claude").cloned().unwrap_or_default();
+        claude.sort();
+        assert_eq!(claude, vec!["canonicalOnly", "legacyOnly"]);
     }
 }

--- a/lince-dashboard/plugin/src/dashboard.rs
+++ b/lince-dashboard/plugin/src/dashboard.rs
@@ -291,22 +291,22 @@ fn render_agent_table(
     let col_type: usize = 5;  // 3 chars label + "!" marker + space
     let col_sandbox: usize = 6; // "bwrap" / "nono" / "NOSB" + padding
     let col_name: usize = 20;
-    let col_profile: usize = 12;
+    let col_provider: usize = 12;
     let col_status: usize = 12;
 
     // Show optional columns only when terminal is wide enough
     let base_width: usize = 1 + col_idx + 1 + col_type + 1 + col_name + 1 + col_status;
     let show_sandbox = cols >= base_width + 1 + col_sandbox;
-    let show_profile = cols >= base_width + 1 + col_sandbox + 1 + col_profile;
+    let show_provider = cols >= base_width + 1 + col_sandbox + 1 + col_provider;
 
     let hdr_sandbox = if show_sandbox { format!("{} ", pad_left("Sbox", col_sandbox)) } else { String::new() };
-    let hdr_profile = if show_profile { format!("{} ", pad_left("Profile", col_profile)) } else { String::new() };
+    let hdr_provider = if show_provider { format!("{} ", pad_left("Provider", col_provider)) } else { String::new() };
     let hdr = format!(
         " {} {} {} {} {}{}",
         pad_left("#", col_idx), pad_left("Agent", col_type),
         pad_left("Name", col_name),
         pad_left("Status", col_status),
-        hdr_sandbox, hdr_profile,
+        hdr_sandbox, hdr_provider,
     );
     println!("{}{}{}", BOLD, truncate(&hdr, cols), RESET);
 
@@ -421,10 +421,12 @@ fn render_agent_table(
                     String::new()
                 };
 
-                // Build optional profile column string
-                let profile_col = if show_profile {
-                    let p = agent.profile.as_deref().unwrap_or("-");
-                    format!("{} ", pad_left(p, col_profile))
+                // Build optional provider column string (the env-var bundle —
+                // gh#81 renamed this from "Profile"). The sandbox isolation
+                // level is shown via the row color, not as a separate column.
+                let provider_col = if show_provider {
+                    let p = agent.provider.as_deref().unwrap_or("-");
+                    format!("{} ", pad_left(p, col_provider))
                 } else {
                     String::new()
                 };
@@ -436,7 +438,7 @@ fn render_agent_table(
                         pad_left(&agent.name, col_name),
                     );
                     let status_str = pad_left(&status_label, col_status);
-                    let trailing = format!(" {}{}", sandbox_col, profile_col);
+                    let trailing = format!(" {}{}", sandbox_col, provider_col);
                     let main_visible = strip_ansi_len(&main_part);
                     let suffix_visible_len = strip_ansi_len(&subagent_suffix);
                     let trailing_visible = strip_ansi_len(&trailing);
@@ -471,7 +473,7 @@ fn render_agent_table(
                         prefix, pad_left(&idx_str, col_idx), type_col, name_field,
                         status_color, if needs_attention { BOLD } else { "" },
                         pad_left(&status_label, col_status), subagent_suffix, RESET,
-                        sandbox_col, profile_col,
+                        sandbox_col, provider_col,
                     );
                     println!("{}", truncate(&line, cols));
                 }
@@ -520,9 +522,18 @@ fn render_detail_panel(agent: &AgentInfo, cols: usize, max_rows: usize, agent_ty
         );
         row += 1;
     }
+    // Show "Profile" (sandbox isolation level — paranoid/normal/permissive)
+    // and "Provider" (env-var bundle — anthropic/vertex/zai/...) on
+    // SEPARATE lines. They're orthogonal axes; conflating them confused users
+    // (gh#81). Either may be `(default)` independently.
     if row < max_rows {
-        let profile = agent.profile.as_deref().unwrap_or("(default)");
+        let profile = agent.sandbox_level.as_deref().unwrap_or("(default)");
         println!(" {}Profile:{} {}", CYAN, RESET, profile);
+        row += 1;
+    }
+    if row < max_rows {
+        let provider = agent.provider.as_deref().unwrap_or("(default)");
+        println!(" {}Provider:{} {}", CYAN, RESET, provider);
         row += 1;
     }
     if row < max_rows {
@@ -687,9 +698,10 @@ pub fn render_wizard(
     let step_label = match wizard.step {
         WizardStep::AgentType => "Agent Type",
         WizardStep::SandboxBackend => "Sandbox Backend",
-        WizardStep::SandboxLevel => "Sandbox Level",
+        WizardStep::SandboxLevel => "Sandbox Level (Profile)",
         WizardStep::Name => "Agent Name",
-        WizardStep::Profile => "Profile",
+        // gh#81: this step picks an env-var bundle, not a sandbox profile.
+        WizardStep::Provider => "Provider",
         WizardStep::ProjectDir => "Project Directory",
         WizardStep::Confirm => "Confirm",
     };
@@ -761,34 +773,37 @@ pub fn render_wizard(
         }
         WizardStep::Confirm => {
             let base_display = wizard.selected_base_agent();
-            let profile_display = wizard.selected_profile().unwrap_or("(none)");
+            let provider_display = wizard.selected_provider().unwrap_or("(none)");
             let dir_display = if wizard.project_dir.is_empty() { "(current dir)" } else { &wizard.project_dir };
             // Show base agent + backend separately rather than the resolved
             // `<base>-unsandboxed` key — matches the user's mental model.
-            push_box_line(&mut lines, &format!("  Type:    {}", base_display), box_width);
+            push_box_line(&mut lines, &format!("  Type:     {}", base_display), box_width);
             if let Some(backend) = wizard.selected_sandbox_backend() {
-                push_box_line(&mut lines, &format!("  Backend: {}", backend.display_name()), box_width);
+                push_box_line(&mut lines, &format!("  Backend:  {}", backend.display_name()), box_width);
             }
-            // Level is meaningful only when a sandboxed backend is selected.
+            // Profile (sandbox isolation level) is meaningful only when a sandboxed backend is selected.
             if !wizard.is_unsandboxed_choice() {
                 if let Some(level) = wizard.selected_sandbox_level() {
-                    push_box_line(&mut lines, &format!("  Level:   {}", level), box_width);
+                    push_box_line(&mut lines, &format!("  Profile:  {}", level), box_width);
                 }
             }
             let effective_name = if wizard.name.is_empty() { &wizard.default_name } else { &wizard.name };
-            push_box_line(&mut lines, &format!("  Name:    {}", effective_name), box_width);
-            push_box_line(&mut lines, &format!("  Profile: {}", profile_display), box_width);
-            push_box_line(&mut lines, &format!("  Dir:     {}", dir_display), box_width);
+            push_box_line(&mut lines, &format!("  Name:     {}", effective_name), box_width);
+            // Provider is the env-var bundle (gh#81 — distinct from Profile/sandbox-level above).
+            push_box_line(&mut lines, &format!("  Provider: {}", provider_display), box_width);
+            push_box_line(&mut lines, &format!("  Dir:      {}", dir_display), box_width);
             push_box_line(&mut lines, "", box_width);
             push_box_line(&mut lines, "  [Enter] Create  [Bksp] Back  [Esc] Cancel", box_width);
         }
-        WizardStep::Profile => {
-            // Render profile list with selection marker.
-            // Profiles named after sandbox levels (paranoid/normal/permissive)
-            // pick up the configured palette; custom profile names get the
-            // default color. Matches the per-pane title indicator (gh#63).
-            for (i, name) in wizard.available_profiles.iter().enumerate() {
-                let marker = if i == wizard.profile_index { ">" } else { " " };
+        WizardStep::Provider => {
+            // Render provider list with selection marker. Providers named
+            // after sandbox levels (paranoid/normal/permissive) historically
+            // picked up the level palette; we keep that color hint for
+            // visual continuity even though the two concepts are distinct
+            // (gh#63 / gh#81). Most provider names are env-bundle names
+            // (anthropic / vertex / zai) which fall through to the default color.
+            for (i, name) in wizard.available_providers.iter().enumerate() {
+                let marker = if i == wizard.provider_index { ">" } else { " " };
                 let color = color_name_to_ansi(sandbox_colors.for_level(name));
                 push_box_line(
                     &mut lines,
@@ -797,6 +812,11 @@ pub fn render_wizard(
                 );
             }
             push_box_line(&mut lines, "", box_width);
+            push_box_line(
+                &mut lines,
+                "  Provider = env-var bundle (e.g. anthropic, vertex, zai).",
+                box_width,
+            );
             push_box_line(&mut lines, "  [j/k] Select  [Enter] Next  [Esc] Cancel", box_width);
         }
         WizardStep::ProjectDir => {

--- a/lince-dashboard/plugin/src/main.rs
+++ b/lince-dashboard/plugin/src/main.rs
@@ -232,18 +232,18 @@ impl ZellijPlugin for State {
                             let (cfg, err) = DashboardConfig::parse_toml(&content);
                             // Preserve async-loaded fields that config.toml doesn't contain.
                             let prev_agent_types = std::mem::take(&mut self.config.agent_types);
-                            let prev_profiles = std::mem::take(&mut self.config.profiles_by_agent);
-                            let prev_details = std::mem::take(&mut self.config.profile_details_by_agent);
+                            let prev_providers = std::mem::take(&mut self.config.providers_by_agent);
+                            let prev_details = std::mem::take(&mut self.config.provider_details_by_agent);
                             self.config = cfg;
                             self.config_error = err;
                             if self.config.agent_types.is_empty() {
                                 self.config.agent_types = prev_agent_types;
                             }
-                            if self.config.profiles_by_agent.is_empty() {
-                                self.config.profiles_by_agent = prev_profiles;
+                            if self.config.providers_by_agent.is_empty() {
+                                self.config.providers_by_agent = prev_providers;
                             }
-                            if self.config.profile_details_by_agent.is_empty() {
-                                self.config.profile_details_by_agent = prev_details;
+                            if self.config.provider_details_by_agent.is_empty() {
+                                self.config.provider_details_by_agent = prev_details;
                             }
                         }
                         // Mark as loaded so timer doesn't retry
@@ -253,8 +253,8 @@ impl ZellijPlugin for State {
                     Some(CMD_GET_CWD) if exit_code == Some(0) => {
                         let dir = String::from_utf8_lossy(&stdout).trim().to_string();
                         if !dir.is_empty() {
-                            // Kick off async profile discovery (reads sandbox config via shell).
-                            config::discover_profiles_async(
+                            // Kick off async provider discovery (reads sandbox config via shell).
+                            config::discover_providers_async(
                                 self.config.sandbox_config_path.as_deref(),
                                 Some(&dir),
                             );
@@ -304,14 +304,14 @@ impl ZellijPlugin for State {
                         // Nothing to do, just acknowledge.
                         false
                     }
-                    Some(config::CMD_DISCOVER_PROFILES) => {
+                    Some(config::CMD_DISCOVER_PROVIDERS) => {
                         // Each config file's output is separated by NUL.
                         // Parse each independently to avoid duplicate-section TOML errors.
                         for chunk in stdout.split(|&b| b == 0) {
                             if chunk.is_empty() { continue; }
                             let content = String::from_utf8_lossy(chunk);
-                            let (by_agent, details_by_agent) = config::parse_profiles_from_toml(&content);
-                            self.config.merge_profiles(&by_agent, &details_by_agent);
+                            let (by_agent, details_by_agent) = config::parse_providers_from_toml(&content);
+                            self.config.merge_providers(&by_agent, &details_by_agent);
                         }
                         true
                     }
@@ -580,9 +580,9 @@ impl State {
                 } else {
                     default_base.to_string()
                 };
-                let available_profiles = self.config.profiles_for_agent_type(&effective_type);
-                let default_profile_index = self.config.default_profile.as_ref()
-                    .and_then(|dp| available_profiles.iter().position(|p| p == dp))
+                let available_providers = self.config.providers_for_agent_type(&effective_type);
+                let default_provider_index = self.config.default_provider.as_ref()
+                    .and_then(|dp| available_providers.iter().position(|p| p == dp))
                     .unwrap_or(0);
                 // Sandbox levels follow the canonical sandboxed entry (skipped when backend = None).
                 // Levels are backend-aware: discovered custom levels from
@@ -615,8 +615,8 @@ impl State {
                     sandbox_level_index,
                     name: String::new(),
                     default_name,
-                    available_profiles,
-                    profile_index: default_profile_index,
+                    available_providers,
+                    provider_index: default_provider_index,
                     project_dir: default_dir,
                     completions: Vec::new(),
                     completion_index: None,
@@ -758,7 +758,7 @@ impl State {
                         &self.agents,
                         name,
                         &effective_type,
-                        self.config.default_profile.clone(),
+                        self.config.default_provider.clone(),
                         self.config
                             .default_project_dir
                             .clone()
@@ -848,9 +848,9 @@ impl State {
                     // profile list. The SandboxBackend Enter handler still re-resolves
                     // when shown, which is fine and cheap.
                     let effective = wizard.effective_agent_type();
-                    wizard.available_profiles = self.config.profiles_for_agent_type(&effective);
-                    wizard.profile_index = self.config.default_profile.as_ref()
-                        .and_then(|dp| wizard.available_profiles.iter().position(|p| p == dp))
+                    wizard.available_providers = self.config.providers_for_agent_type(&effective);
+                    wizard.provider_index = self.config.default_provider.as_ref()
+                        .and_then(|dp| wizard.available_providers.iter().position(|p| p == dp))
                         .unwrap_or(0);
                     // Update default name to reflect the new base.
                     wizard.default_name = format!("{}-{}", base, self.next_agent_id + 1);
@@ -878,9 +878,9 @@ impl State {
                     // Resolve profiles against the *effective* agent_type now that the
                     // user has committed to a backend (sandboxed canonical vs unsandboxed).
                     let effective = wizard.effective_agent_type();
-                    wizard.available_profiles = self.config.profiles_for_agent_type(&effective);
-                    wizard.profile_index = self.config.default_profile.as_ref()
-                        .and_then(|dp| wizard.available_profiles.iter().position(|p| p == dp))
+                    wizard.available_providers = self.config.providers_for_agent_type(&effective);
+                    wizard.provider_index = self.config.default_provider.as_ref()
+                        .and_then(|dp| wizard.available_providers.iter().position(|p| p == dp))
                         .unwrap_or(0);
                     // Re-resolve sandbox levels for the just-chosen backend (custom levels
                     // are backend-specific: nono profile dirs differ from agent-sandbox).
@@ -974,7 +974,7 @@ impl State {
                 }
                 _ => {}
             },
-            WizardStep::Profile => match bare {
+            WizardStep::Provider => match bare {
                 BareKey::Enter | BareKey::Tab => {
                     if let Some(next) = wizard.next_step() {
                         wizard.step = next;
@@ -986,16 +986,16 @@ impl State {
                     }
                 }
                 BareKey::Up | BareKey::Char('k') => {
-                    if wizard.profile_index > 0 {
-                        wizard.profile_index -= 1;
+                    if wizard.provider_index > 0 {
+                        wizard.provider_index -= 1;
                     } else {
-                        wizard.profile_index = wizard.available_profiles.len().saturating_sub(1);
+                        wizard.provider_index = wizard.available_providers.len().saturating_sub(1);
                     }
                 }
                 BareKey::Down | BareKey::Char('j') => {
-                    let len = wizard.available_profiles.len();
+                    let len = wizard.available_providers.len();
                     if len > 0 {
-                        wizard.profile_index = (wizard.profile_index + 1) % len;
+                        wizard.provider_index = (wizard.provider_index + 1) % len;
                     }
                 }
                 _ => {}
@@ -1046,7 +1046,7 @@ impl State {
                     // Clone values out before dropping the borrow.
                     let name = wizard.name.clone();
                     let agent_type = wizard.effective_agent_type();
-                    let profile = wizard.selected_profile().map(|s| s.to_string());
+                    let provider = wizard.selected_provider().map(|s| s.to_string());
                     let project_dir = wizard.project_dir.clone();
                     let backend_choice = wizard.selected_sandbox_backend();
                     // Skip level when the chosen backend is `None` (unsandboxed) — it's a no-op.
@@ -1060,7 +1060,7 @@ impl State {
                     self.spawn_wizard_agent(
                         name,
                         &agent_type,
-                        profile,
+                        provider,
                         project_dir,
                         sandbox_level,
                         sandbox_backend,
@@ -1083,7 +1083,7 @@ impl State {
         &mut self,
         name: String,
         agent_type: &str,
-        profile: Option<String>,
+        provider: Option<String>,
         project_dir: String,
         sandbox_level_override: Option<String>,
         sandbox_backend_override: Option<sandbox_backend::SandboxBackend>,
@@ -1094,7 +1094,7 @@ impl State {
             &self.agents,
             name,
             agent_type,
-            profile,
+            provider,
             project_dir,
             self.launch_dir.as_deref(),
             sandbox_level_override,
@@ -1321,7 +1321,7 @@ impl State {
                 &self.agents,
                 saved.name,
                 &saved.agent_type,
-                saved.profile,
+                saved.provider,
                 saved.project_dir,
                 self.launch_dir.as_deref(),
                 saved.sandbox_level,

--- a/lince-dashboard/plugin/src/state_file.rs
+++ b/lince-dashboard/plugin/src/state_file.rs
@@ -71,3 +71,54 @@ pub fn parse_loaded_state(stdout: &[u8]) -> Result<SavedState, String> {
     state.version = STATE_VERSION;
     Ok(state)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pre-#81 state files spelled the env-bundle field as `profile`. The
+    /// rename added `#[serde(alias = "profile")]` on `SavedAgentInfo.provider`
+    /// so old `.lince-dashboard` files keep loading transparently.
+    #[test]
+    fn loads_pre_issue81_state_file_with_profile_field() {
+        let json = br#"{
+            "version": 2,
+            "agents": [
+                {
+                    "name": "agent-1",
+                    "agent_type": "claude",
+                    "profile": "vertex",
+                    "project_dir": "/tmp/proj",
+                    "tokens_in": 0,
+                    "tokens_out": 0
+                }
+            ],
+            "next_agent_id": 1
+        }"#;
+        let state = parse_loaded_state(json).expect("legacy state must load");
+        assert_eq!(state.agents.len(), 1);
+        assert_eq!(state.agents[0].provider.as_deref(), Some("vertex"));
+    }
+
+    /// New state files use `provider`. Round-trip serialization writes
+    /// `provider` and reads it back without falling through the alias.
+    #[test]
+    fn round_trips_provider_field() {
+        let json = br#"{
+            "version": 2,
+            "agents": [
+                {
+                    "name": "agent-1",
+                    "agent_type": "claude",
+                    "provider": "zai",
+                    "project_dir": "/tmp/proj",
+                    "tokens_in": 0,
+                    "tokens_out": 0
+                }
+            ],
+            "next_agent_id": 1
+        }"#;
+        let state = parse_loaded_state(json).expect("canonical state must load");
+        assert_eq!(state.agents[0].provider.as_deref(), Some("zai"));
+    }
+}

--- a/lince-dashboard/plugin/src/types.rs
+++ b/lince-dashboard/plugin/src/types.rs
@@ -109,13 +109,19 @@ pub struct NamePromptState {
 }
 
 /// Which step the wizard is currently on.
+///
+/// Note: `Provider` selects an env-var bundle (Anthropic vs Vertex vs Z.ai
+/// vs ...) — distinct from `SandboxLevel`, which selects the isolation
+/// posture (paranoid/normal/permissive). The two axes are independent;
+/// users can run e.g. `paranoid + zai`. See gh#81.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WizardStep {
     AgentType,
     SandboxBackend,
     SandboxLevel,
     Name,
-    Profile,
+    /// Pick the provider env-var bundle (was `Profile` pre-#81).
+    Provider,
     ProjectDir,
     Confirm,
 }
@@ -145,10 +151,12 @@ pub struct WizardState {
     pub name: String,
     /// Auto-generated default name shown when the user leaves name empty (e.g. "claude-3").
     pub default_name: String,
-    /// Available sandbox profiles (from config).
-    pub available_profiles: Vec<String>,
-    /// Currently selected profile index in `available_profiles`.
-    pub profile_index: usize,
+    /// Available providers (env-var bundles) discovered from sandbox config.
+    /// Was `available_profiles` pre-#81.
+    pub available_providers: Vec<String>,
+    /// Currently selected provider index in `available_providers`.
+    /// Was `profile_index` pre-#81.
+    pub provider_index: usize,
     pub project_dir: String,
     /// Tab-completion suggestions for the project directory.
     pub completions: Vec<String>,
@@ -221,8 +229,8 @@ impl WizardState {
             steps.push(WizardStep::SandboxLevel);
         }
         steps.push(WizardStep::Name);
-        if self.has_profiles() {
-            steps.push(WizardStep::Profile);
+        if self.has_providers() {
+            steps.push(WizardStep::Provider);
         }
         steps.push(WizardStep::ProjectDir);
         steps.push(WizardStep::Confirm);
@@ -255,9 +263,9 @@ impl WizardState {
         }
     }
 
-    /// Whether there are selectable profiles.
-    pub fn has_profiles(&self) -> bool {
-        !self.available_profiles.is_empty()
+    /// Whether there are selectable providers (env-var bundles).
+    pub fn has_providers(&self) -> bool {
+        !self.available_providers.is_empty()
     }
 
     /// Clear any pending tab-completion state.
@@ -266,9 +274,10 @@ impl WizardState {
         self.completion_index = None;
     }
 
-    /// Return the selected profile name, or None if no profiles are available.
-    pub fn selected_profile(&self) -> Option<&str> {
-        self.available_profiles.get(self.profile_index).map(|s| s.as_str())
+    /// Return the selected provider name, or None if no providers are available.
+    /// Was `selected_profile()` pre-#81.
+    pub fn selected_provider(&self) -> Option<&str> {
+        self.available_providers.get(self.provider_index).map(|s| s.as_str())
     }
 }
 
@@ -277,7 +286,9 @@ pub struct AgentInfo {
     pub id: String,
     pub name: String,
     pub agent_type: String,
-    pub profile: Option<String>,
+    /// Provider env-var bundle name selected at spawn time (was `profile`
+    /// pre-#81). Distinct from `sandbox_level`, which is the isolation posture.
+    pub provider: Option<String>,
     pub project_dir: String,
     pub status: AgentStatus,
     pub pane_id: Option<u32>,
@@ -337,7 +348,10 @@ pub struct SavedAgentInfo {
     /// Agent type key referencing AgentTypeConfig in config. Defaults to DEFAULT_AGENT_TYPE for v1 compat.
     #[serde(default = "default_agent_type")]
     pub agent_type: String,
-    pub profile: Option<String>,
+    /// Provider env-var bundle name. `serde(alias = "profile")` keeps
+    /// pre-#81 `.lince-dashboard` files loadable.
+    #[serde(default, alias = "profile")]
+    pub provider: Option<String>,
     pub project_dir: String,
     pub group: Option<String>,
     pub tokens_in: u64,
@@ -359,7 +373,7 @@ impl From<&AgentInfo> for SavedAgentInfo {
         Self {
             name: a.name.clone(),
             agent_type: a.agent_type.clone(),
-            profile: a.profile.clone(),
+            provider: a.provider.clone(),
             project_dir: a.project_dir.clone(),
             group: a.group.clone(),
             tokens_in: a.tokens_in,

--- a/sandbox/CHEATSHEET.md
+++ b/sandbox/CHEATSHEET.md
@@ -66,7 +66,7 @@ Quick reference for what the sandbox blocks and what it lets through.
 |----------|--------|-------|
 | `TERM`, `LANG`, `EDITOR` | **Passed through** | Basic shell env |
 | `PATH` | **Set by sandbox** | Includes sandbox bin, system, detected home tools, and deep subdirectories explicitly in host PATH |
-| `ANTHROPIC_API_KEY` | **From profile only** | Not inherited from shell |
+| `ANTHROPIC_API_KEY` | **From provider only** | Not inherited from shell — set in `[<agent>.providers.<name>.env]` |
 | `AWS_SECRET_ACCESS_KEY` | **Blocked** | Never passed |
 | `GITHUB_TOKEN`, `GH_TOKEN` | **Blocked** | Never passed |
 | Other secrets | **Blocked** | `--clearenv` strips everything not whitelisted |

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -93,40 +93,62 @@ agent-sandbox run
 
 That's it. Claude starts with `--dangerously-skip-permissions` by default (configurable) and has full autonomy within your project directory, but cannot escape.
 
-## Using profiles
+## Using providers
 
-Profiles allow you to switch between different API providers (Anthropic, Vertex AI, custom endpoints) without modifying your config. First, define profiles in `~/.agent-sandbox/config.toml`:
+A **provider** is a named env-var bundle that lets you switch between API
+providers (Anthropic direct, Vertex AI, Z.AI, custom endpoints …) without
+editing the rest of your config. Define one or more in
+`~/.agent-sandbox/config.toml`:
 
 ```toml
-[claude.profiles.vertex]
+[claude.providers.vertex]
 description = "Vertex AI"
-[claude.profiles.vertex.env]
+[claude.providers.vertex.env]
 CLAUDE_CODE_USE_VERTEX = "1"
 ANTHROPIC_VERTEX_PROJECT_ID = "my-gcp-project"
 ANTHROPIC_VERTEX_REGION = "us-east5"
 
-[claude.profiles.anthropic]
+[claude.providers.anthropic]
 description = "Direct Anthropic API"
-[claude.profiles.anthropic.env]
+[claude.providers.anthropic.env]
 ANTHROPIC_API_KEY = "sk-ant-..."
 ```
 
-Then use the `-P` / `--profile` flag to select one at runtime:
+Then use `-P` / `--provider` (legacy spelling `--profile` still works) to
+pick one at runtime:
 
 ```bash
-# Use the default profile (or none if not configured)
+# Use the default provider (or none, if not configured)
 agent-sandbox run
 
-# Use a specific profile
-agent-sandbox run --profile vertex
+# Use a specific provider
+agent-sandbox run --provider vertex
 agent-sandbox run -P anthropic
 
-# Set a default profile in config.toml to avoid specifying it each time
+# Set a default in [sandbox] to avoid specifying it each time
 [sandbox]
-default_profile = "vertex"
+default_provider = "vertex"
 ```
 
-You can also set `default_profile` in your `config.toml` to avoid specifying `-P` every time (see `config.toml.example` for the full syntax).
+> **Naming note (gh#81):** what used to be called `[profiles.*]` /
+> `default_profile` is now `[providers.*]` / `default_provider`. The legacy
+> spelling is still accepted (the sandbox prints a one-shot stderr
+> deprecation note when only the legacy form is present); run
+> `agent-sandbox migrate-providers` to rewrite your config in place. See
+> `config.toml.example` for the full syntax.
+
+## Two orthogonal axes: sandbox profile vs provider
+
+agent-sandbox has two configuration knobs that historically shared the word
+"profile" (gh#81). They are independent and can be combined freely:
+
+| Axis | What it controls | Where it lives | How to select |
+|------|------------------|----------------|---------------|
+| **Sandbox profile** (a.k.a. sandbox level) | Isolation posture: file/network policy, credential proxy, namespace flags | TOML fragments under `sandbox/profiles/<agent>-<level>.toml` (`paranoid` / `normal` / `permissive` ship by default) | `--sandbox-level <name>` |
+| **Provider** | Env-var bundle that switches the model provider/account (Anthropic vs Vertex vs Z.ai vs Minimax …) | `[providers.<name>]` / `[<agent>.providers.<name>]` in `~/.agent-sandbox/config.toml` | `-P <name>` / `--provider <name>`, or `[sandbox].default_provider` |
+
+So `agent-sandbox run --sandbox-level paranoid -P zai` picks the paranoid
+isolation level *and* the Z.AI env-var bundle — the two don't interact.
 
 ## Project-local config overrides
 
@@ -163,7 +185,7 @@ Lists (e.g. `extra_rw`, `allow_domains`) are **appended**, not replaced, so proj
 
 5. **Read-only build tools**: Tools installed under `$HOME` (like `~/.cargo/bin/cargo`) are available read-only. `cargo install new-tool` inside the sandbox will fail. Use system package managers to install new tools, or add specific writable directories via `extra_rw` in config.
 
-6. **MCP server secrets**: If your `~/.claude/settings.json` contains API keys in MCP server environment variables, those are copied to the sandbox. Review `~/.agent-sandbox/claude-config/settings.json` after init and remove any credentials you don't want exposed. With `credential_proxy = true`, API keys configured in profiles are kept outside the sandbox.
+6. **MCP server secrets**: If your `~/.claude/settings.json` contains API keys in MCP server environment variables, those are copied to the sandbox. Review `~/.agent-sandbox/claude-config/settings.json` after init and remove any credentials you don't want exposed. With `credential_proxy = true`, API keys configured in providers (`[<agent>.providers.<name>.env]`) are kept outside the sandbox.
 
 7. **Tmpfs home is writable**: The `$HOME` tmpfs overlay is writable (that's how tmpfs works). Claude can create files like `~/temp.txt`, but they are ephemeral and vanish when the sandbox exits. They never touch your real home directory.
 
@@ -215,14 +237,18 @@ cat /etc/resolv.conf
 
 ### Using Claude with Vertex AI (Google Cloud)
 
-If you use Claude via Vertex AI, create a profile with the Vertex env vars (see [Using profiles](#using-profiles) above). Also add the Google Cloud ADC credentials directory:
+If you use Claude via Vertex AI, define a `vertex` provider with the Vertex
+env vars (see [Using providers](#using-providers) above for the full
+example). Also expose the Google Cloud ADC credentials directory:
 
 ```toml
 [sandbox]
 home_ro_dirs = [".config/gcloud"]  # Google Cloud ADC credentials
 ```
 
-Do NOT add `CLAUDECODE` or `CLAUDE_CODE_ENTRYPOINT` to env passthrough or profiles: these are session markers that would trigger "nested session" detection and prevent Claude from starting.
+Do NOT add `CLAUDECODE` or `CLAUDE_CODE_ENTRYPOINT` to env passthrough or
+provider env tables: these are session markers that would trigger "nested
+session" detection and prevent Claude from starting.
 
 ### Claude says "permission denied" writing to a file
 

--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -1298,26 +1298,102 @@ def find_agents_defaults() -> dict[str, dict]:
     return _agents_defaults_cache
 
 
-def resolve_profiles(config: dict, agent_name: str = "claude") -> dict:
-    """Resolve profiles for a given agent, merging legacy and namespaced formats.
+_legacy_profiles_warned = False
 
-    Merge order (later wins):
+
+def _warn_legacy_profiles_once() -> None:
+    """Print a one-shot stderr deprecation note about [profiles.*] keys.
+
+    The codebase used to overload "profile" for two unrelated concepts:
+    the env-var bundle (now "provider") and the sandbox isolation level
+    (still "profile" — see sandbox/profiles/<agent>-<level>.toml). The
+    canonical key in config.toml is ``[providers.*]`` / ``[<agent>.providers.*]``;
+    legacy ``[profiles.*]`` is still read for back-compat. This warning fires
+    once per process, only when no canonical [providers.*] table is present.
+    """
+    global _legacy_profiles_warned
+    if _legacy_profiles_warned:
+        return
+    _legacy_profiles_warned = True
+    print(
+        "agent-sandbox: note: [profiles.*] / [<agent>.profiles.*] is the legacy "
+        "spelling — the canonical key is now [providers.*] / [<agent>.providers.*]. "
+        "Run 'agent-sandbox migrate-providers' to rewrite your config.toml in place.",
+        file=sys.stderr,
+    )
+
+
+def resolve_providers(config: dict, agent_name: str = "claude") -> dict:
+    """Resolve provider env-var bundles for a given agent.
+
+    A *provider* is an env-var bundle that switches model provider/account
+    (Anthropic vs Vertex vs Z.ai vs Minimax, etc.). Selected at runtime via
+    ``-P / --provider`` or via ``[sandbox].default_provider``. This is a
+    different axis from the *sandbox profile* (paranoid/normal/permissive)
+    fragments under ``sandbox/profiles/`` — see ``load_sandbox_level_fragment``.
+
+    Merge order (later wins, i.e. canonical overrides legacy):
       1. Legacy ``[profiles.*]`` — only included when agent_name is "claude"
-      2. Namespaced ``[<agent_name>.profiles.*]``
+      2. Legacy namespaced ``[<agent_name>.profiles.*]``
+      3. Canonical ``[providers.*]`` — only included when agent_name is "claude"
+      4. Canonical namespaced ``[<agent_name>.providers.*]``
 
-    Returns a flat dict of profile_name → profile_config.
+    A one-shot deprecation warning fires when only the legacy form is present
+    (no ``[providers.*]`` key anywhere in the file).
+
+    Returns a flat dict of name → config.
     """
     merged: dict = {}
-    # Legacy [profiles.*] → attributed to "claude"
+    saw_legacy = False
+    saw_canonical = False
+
+    # 1. Legacy top-level [profiles.*] (only attributed to claude).
     if agent_name == "claude":
-        merged.update(config.get("profiles", {}))
-    # Namespaced [<agent>.profiles.*]
+        legacy_top = config.get("profiles")
+        if isinstance(legacy_top, dict) and legacy_top:
+            saw_legacy = True
+            merged.update(legacy_top)
+    # 2. Legacy namespaced [<agent>.profiles.*].
     agent_section = config.get(agent_name, {})
     if isinstance(agent_section, dict):
-        namespaced = agent_section.get("profiles", {})
-        if isinstance(namespaced, dict):
-            merged.update(namespaced)
+        legacy_ns = agent_section.get("profiles")
+        if isinstance(legacy_ns, dict) and legacy_ns:
+            saw_legacy = True
+            merged.update(legacy_ns)
+    # 3. Canonical top-level [providers.*] (only attributed to claude).
+    if agent_name == "claude":
+        canonical_top = config.get("providers")
+        if isinstance(canonical_top, dict) and canonical_top:
+            saw_canonical = True
+            merged.update(canonical_top)
+    # 4. Canonical namespaced [<agent>.providers.*].
+    if isinstance(agent_section, dict):
+        canonical_ns = agent_section.get("providers")
+        if isinstance(canonical_ns, dict) and canonical_ns:
+            saw_canonical = True
+            merged.update(canonical_ns)
+
+    if saw_legacy and not saw_canonical:
+        _warn_legacy_profiles_once()
     return merged
+
+
+# Back-compat alias: old name kept so external scripts/imports keep working.
+# Internal callers use ``resolve_providers``.
+resolve_profiles = resolve_providers
+
+
+def resolve_default_provider(config: dict) -> str | None:
+    """Return the default provider name from [sandbox], honoring legacy alias.
+
+    Prefers ``default_provider`` (canonical); falls back to ``default_profile``
+    (legacy). Returns None when neither is set or the value is empty.
+    """
+    sandbox = config.get("sandbox", {}) or {}
+    val = sandbox.get("default_provider")
+    if val is None or val == "":
+        val = sandbox.get("default_profile")
+    return val if val else None
 
 
 def resolve_agent_config(config: dict, agent_name: str) -> dict:
@@ -1610,10 +1686,11 @@ def generate_nono_profile(
     for var, val in env_conf.get("extra", {}).items():
         all_env[var] = _expand_env_value(val)
 
-    # Profile env (if a profile is selected)
+    # Provider env (if a provider is selected). Parameter is still spelled
+    # ``profile_name`` for back-compat with the public function signature.
     if profile_name:
-        profiles = resolve_profiles(config, agent_name)
-        prof_data = profiles.get(profile_name, {})
+        providers = resolve_providers(config, agent_name)
+        prof_data = providers.get(profile_name, {})
         if isinstance(prof_data, dict):
             for var, val in prof_data.get("env", {}).items():
                 all_env[var] = _expand_env_value(val)
@@ -1691,17 +1768,20 @@ def cmd_nono_sync(args) -> None:
     else:
         print(f"  output: {NONO_PROFILE_DIR}/\n")
 
-    # Resolve the profile name if any
-    profile_name = getattr(args, "profile", None)
-    if profile_name is None:
-        profile_name = config.get("sandbox", {}).get("default_profile", "") or None
+    # Resolve the provider name (env-var bundle) if any. ``args.provider`` is
+    # the canonical destination shared with --profile / -P; ``provider_name``
+    # is the parameter we pass to generate_nono_profile (still spelled
+    # ``profile_name`` in that signature for back-compat).
+    provider_name = getattr(args, "provider", None)
+    if provider_name is None:
+        provider_name = resolve_default_provider(config)
 
     all_warnings: list[str] = []
 
     for agent_name in agent_names:
         agent_cfg = resolve_agent_config(config, agent_name)
         profile, warnings = generate_nono_profile(
-            agent_name, agent_cfg, config, profile_name=profile_name,
+            agent_name, agent_cfg, config, profile_name=provider_name,
         )
         all_warnings.extend(warnings)
 
@@ -1729,6 +1809,83 @@ def cmd_nono_sync(args) -> None:
     if not dry_run:
         print(f"\nDone. {len(agent_names)} profile(s) written to {NONO_PROFILE_DIR}/")
         print("Run agents with nono:  nono run --profile lince-<agent> -- <command>")
+
+
+def _migrate_providers_text(text: str) -> tuple[str, int]:
+    """Translate legacy [profiles.*] / default_profile keys to canonical names.
+
+    Returns (new_text, num_substitutions). Operates on raw config text so user
+    comments and formatting are preserved — a TOML round-trip would strip them.
+
+    Substitutions, all anchored at start-of-line:
+      - ``[<agent>.profiles.<rest>]`` → ``[<agent>.providers.<rest>]``
+      - ``[profiles.<rest>]``         → ``[providers.<rest>]``
+      - ``default_profile = ...``     → ``default_provider = ...``
+
+    Order matters: the namespaced pattern is tried first so it doesn't get
+    swallowed by the bare ``[profiles.*]`` rule.
+    """
+    new = text
+    total = 0
+    new, n1 = re.subn(
+        r"^(\s*)\[(\w+)\.profiles\.(.+?)\]\s*$",
+        r"\1[\2.providers.\3]",
+        new,
+        flags=re.MULTILINE,
+    )
+    total += n1
+    new, n2 = re.subn(
+        r"^(\s*)\[profiles\.(.+?)\]\s*$",
+        r"\1[providers.\2]",
+        new,
+        flags=re.MULTILINE,
+    )
+    total += n2
+    new, n3 = re.subn(
+        r"^(\s*)default_profile(\s*=)",
+        r"\1default_provider\2",
+        new,
+        flags=re.MULTILINE,
+    )
+    total += n3
+    return new, total
+
+
+def cmd_migrate_providers(args) -> None:
+    """Rewrite the user's config.toml in place: [profiles.*] → [providers.*].
+
+    Resolves the active config via the same lookup as ``load_config()`` (project
+    override wins over user config). Writes a ``.bak`` backup next to the
+    original file. With ``--dry-run`` prints a unified diff and does not
+    write. Idempotent — running twice is a no-op.
+    """
+    cfg_path = find_config()
+    text = cfg_path.read_text()
+    new_text, n = _migrate_providers_text(text)
+    if n == 0 or text == new_text:
+        print(f"{cfg_path}: already uses [providers.*] — nothing to migrate.")
+        return
+
+    if getattr(args, "dry_run", False):
+        import difflib
+        diff = difflib.unified_diff(
+            text.splitlines(keepends=True),
+            new_text.splitlines(keepends=True),
+            fromfile=str(cfg_path),
+            tofile=f"{cfg_path} (migrated)",
+        )
+        sys.stdout.writelines(diff)
+        print(
+            f"\n# {n} substitution(s) would be made. "
+            f"Re-run without --dry-run to apply.",
+            file=sys.stderr,
+        )
+        return
+
+    bak = cfg_path.with_name(cfg_path.name + ".bak")
+    bak.write_text(text)
+    cfg_path.write_text(new_text)
+    print(f"Migrated {cfg_path} ({n} substitutions). Backup: {bak}")
 
 
 def human_size(n: int) -> str:
@@ -1896,16 +2053,17 @@ def build_bwrap_cmd(config: dict, project_dir: Path,
     sec = config.get("security", {})
     agent_cfg = agent_config or resolve_agent_config(config, agent_name)
 
-    # Resolve profile
+    # Resolve provider env-var bundle (CLI param is still called ``profile``
+    # for back-compat with the shared bwrap builder signature).
     prof: dict = {}
     if profile:
-        profiles = resolve_profiles(config, agent_name)
-        if profile not in profiles:
-            avail = ", ".join(sorted(profiles)) if profiles else "(none defined)"
-            print(f"Error: unknown profile '{profile}'.", file=sys.stderr)
-            print(f"Available profiles: {avail}", file=sys.stderr)
+        providers = resolve_providers(config, agent_name)
+        if profile not in providers:
+            avail = ", ".join(sorted(providers)) if providers else "(none defined)"
+            print(f"Error: unknown provider '{profile}'.", file=sys.stderr)
+            print(f"Available providers: {avail}", file=sys.stderr)
             sys.exit(1)
-        prof = profiles[profile]
+        prof = providers[profile]
 
     cmd: list[str] = ["bwrap"]
 
@@ -2376,7 +2534,7 @@ def cmd_init(args) -> None:
         config_created = True
 
     if config_created:
-        print(f"\nEdit {SANDBOX_DIR / 'config.toml'} to configure profiles and API keys.\n")
+        print(f"\nEdit {SANDBOX_DIR / 'config.toml'} to configure providers and API keys.\n")
 
     print("Run Claude in sandbox:\n  agent-sandbox run\n")
 
@@ -2430,26 +2588,31 @@ def cmd_run(args, agent_extra: list[str]) -> None:
         ts = datetime.now().strftime("%Y-%m-%d_%H%M%S")
         log_file = log_dir / f"{ts}_{project_dir.name}.log"
 
-    # Resolve profile: explicit -P flag > default_profile from config
-    profile = args.profile
+    # Resolve provider: explicit -P / --provider flag > default_provider from config.
+    # ``args.provider`` is the canonical destination; ``-P`` and ``--profile`` are
+    # legacy spellings that share the same dest (see argparse setup in main()).
+    provider = getattr(args, "provider", None)
     from_default = False
-    if profile is None:
-        profile = config.get("sandbox", {}).get("default_profile", "") or None
+    if provider is None:
+        provider = resolve_default_provider(config)
         from_default = True
     prof_desc = None
-    if profile:
-        profiles = resolve_profiles(config, agent_name)
-        if profile not in profiles:
+    if provider:
+        providers = resolve_providers(config, agent_name)
+        if provider not in providers:
             if from_default:
-                # default_profile doesn't exist for this agent type — silently skip
-                profile = None
+                # default_provider doesn't exist for this agent type — silently skip
+                provider = None
             else:
-                # Explicit -P flag: hard error
-                avail = ", ".join(sorted(profiles)) if profiles else "(none defined)"
-                print(f"Error: unknown profile '{profile}'.", file=sys.stderr)
-                print(f"Available profiles: {avail}", file=sys.stderr)
+                # Explicit -P / --provider flag: hard error
+                avail = ", ".join(sorted(providers)) if providers else "(none defined)"
+                print(f"Error: unknown provider '{provider}'.", file=sys.stderr)
+                print(f"Available providers: {avail}", file=sys.stderr)
                 sys.exit(1)
-        prof_desc = profiles[profile].get("description", "")
+        prof_desc = providers[provider].get("description", "")
+    # Local alias — older code paths below (and the bwrap builder API) still
+    # pass the value as ``profile``.
+    profile = provider
 
     sec = config.get("security", {})
 
@@ -2477,9 +2640,9 @@ def cmd_run(args, agent_extra: list[str]) -> None:
             print("# nono command that would be executed:\n")
             print(f"# config: {config_path}")
             print(f"# agent: {agent_name} ({agent_cfg['command']})")
-            print(f"# profile: lince-{agent_name}")
-            if profile:
-                print(f"# provider: {profile}")
+            print(f"# nono profile: lince-{agent_name}")
+            if provider:
+                print(f"# provider: {provider}")
             _pretty_print_cmd(cmd)
             return
 
@@ -2489,9 +2652,9 @@ def cmd_run(args, agent_extra: list[str]) -> None:
         print(f"  backend     nono ({shutil.which('nono')})")
         print(f"  agent       {agent_name} ({agent_cfg['command']})")
         print(f"  nono prof   lince-{agent_name}")
-        if profile:
+        if provider:
             desc = f" ({prof_desc})" if prof_desc else ""
-            print(f"  profile     {profile}{desc}")
+            print(f"  provider    {provider}{desc}")
         print(f"  project     {project_dir}")
         print(f"  isolation   Landlock LSM / Seatbelt")
         print(f"  network     enabled")
@@ -2598,8 +2761,8 @@ def cmd_run(args, agent_extra: list[str]) -> None:
         for var, val in env_conf.get("extra", {}).items():
             collected_env[var] = _expand_env_value(val)
         if profile:
-            all_profiles = resolve_profiles(config, agent_name)
-            prof_data = all_profiles.get(profile, {})
+            all_providers = resolve_providers(config, agent_name)
+            prof_data = all_providers.get(profile, {})
             for var, val in prof_data.get("env", {}).items():
                 collected_env[var] = _expand_env_value(val)
         for var, val in agent_cfg.get("env", {}).items():
@@ -2693,12 +2856,12 @@ def cmd_run(args, agent_extra: list[str]) -> None:
                 print(
                     "Error: [security] unshare_net = true requires at "
                     f"least one credential rule (e.g. {keys_for_msg} in "
-                    "[env.extra] or in the active provider profile), "
-                    "otherwise the proxy doesn't start and the sandbox "
+                    "[env.extra] or in the active provider's [providers.<name>.env] "
+                    "block), otherwise the proxy doesn't start and the sandbox "
                     "has no path to any LLM API.\n"
                     f"{quick}\n"
                     f"You can also add a key to [env.extra] in "
-                    f"{config_path} or pick a profile with `-P`."
+                    f"{config_path} or pick a provider with `-P` / `--provider`."
                     f"{oauth_note}",
                     file=sys.stderr,
                 )
@@ -2832,7 +2995,7 @@ def cmd_run(args, agent_extra: list[str]) -> None:
         print(f"# config: {config_path}")
         print(f"# agent: {agent_name} ({agent_cfg['command']})")
         if profile:
-            print(f"# profile: {profile}")
+            print(f"# provider: {profile}")
         if proxy:
             print(f"# credential proxy: 127.0.0.1:{proxy.get_port()}")
         _pretty_print_cmd(cmd)
@@ -2851,7 +3014,7 @@ def cmd_run(args, agent_extra: list[str]) -> None:
     print(f"  agent       {agent_name} ({agent_cfg['command']})")
     if profile:
         desc = f" ({prof_desc})" if prof_desc else ""
-        print(f"  profile     {profile}{desc}")
+        print(f"  provider    {profile}{desc}")
     if agent_name == "claude":
         if claude_scratched:
             print(f"  agent-cfg   ephemeral scratch (per-run, discarded on exit)")
@@ -3076,30 +3239,34 @@ def cmd_status(args) -> None:
     extra = f" (+{deep_count} deep)" if deep_count > 0 else ""
     print(f"  home PATH dirs  {len(home_dirs)} detected{extra}")
 
-    # Profiles — collect from all agent types (legacy + namespaced)
-    default_prof = config_data.get("sandbox", {}).get("default_profile", "") or None
-    # Discover which agent names have namespaced profiles
-    agent_names_with_profiles: set[str] = set()
+    # Providers (env-var bundles) — collect from all agent types, scanning
+    # both canonical [providers.*] / [<agent>.providers.*] and legacy
+    # [profiles.*] / [<agent>.profiles.*].
+    default_prov = resolve_default_provider(config_data)
+    agent_names_with_providers: set[str] = set()
     for key, val in config_data.items():
-        if key == "profiles":
-            agent_names_with_profiles.add("claude")  # legacy → claude
-        elif isinstance(val, dict) and isinstance(val.get("profiles"), dict):
-            agent_names_with_profiles.add(key)
-    if not agent_names_with_profiles:
-        agent_names_with_profiles.add("claude")
-    for aname in sorted(agent_names_with_profiles):
-        profiles = resolve_profiles(config_data, aname)
-        if profiles:
+        if key in ("profiles", "providers"):
+            agent_names_with_providers.add("claude")  # top-level → claude
+        elif isinstance(val, dict) and (
+            isinstance(val.get("providers"), dict)
+            or isinstance(val.get("profiles"), dict)
+        ):
+            agent_names_with_providers.add(key)
+    if not agent_names_with_providers:
+        agent_names_with_providers.add("claude")
+    for aname in sorted(agent_names_with_providers):
+        providers = resolve_providers(config_data, aname)
+        if providers:
             parts = []
-            for name, pconf in sorted(profiles.items()):
+            for name, pconf in sorted(providers.items()):
                 desc = pconf.get("description", "") if isinstance(pconf, dict) else ""
-                marker = " *" if name == default_prof else ""
+                marker = " *" if name == default_prov else ""
                 label = f"{name}{marker} ({desc})" if desc else f"{name}{marker}"
                 parts.append(label)
-            prefix = f"  profiles [{aname}]"
+            prefix = f"  providers [{aname}]"
             print(f"{prefix:<22}{', '.join(parts)}")
-    if default_prof:
-        print(f"  default profile {default_prof}")
+    if default_prov:
+        print(f"  default provider {default_prov}")
 
     # Config diff summary (only meaningful in isolated-copy mode)
     if not use_real:
@@ -4679,12 +4846,13 @@ def build_learn_bwrap_cmd(
     sec = config.get("security", {})
     agent_cfg = agent_config
 
-    # Resolve profile
+    # Resolve provider env-var bundle (legacy "profile" param name kept for
+    # API compat — see comment in build_bwrap_cmd).
     prof: dict = {}
     if profile:
-        profiles = resolve_profiles(config, agent_name)
-        if profile in profiles:
-            prof = profiles[profile]
+        providers = resolve_providers(config, agent_name)
+        if profile in providers:
+            prof = providers[profile]
 
     cmd: list[str] = ["bwrap"]
 
@@ -4990,11 +5158,12 @@ def cmd_learn(args) -> None:
     if config.get("security", {}).get("block_git_push", True):
         ensure_git_wrapper()
 
-    # 5. Resolve profile
-    profile = args.profile
+    # 5. Resolve provider (env-var bundle). The flag is ``--provider`` /
+    # ``--profile`` / ``-P`` — all share dest=provider. Local var ``profile``
+    # is kept because the bwrap-builder API still spells it that way.
+    profile = getattr(args, "provider", None)
     if profile is None:
-        dp = config.get("sandbox", {}).get("default_profile", "")
-        profile = dp or None
+        profile = resolve_default_provider(config)
 
     # 6. Build the permissive bwrap command
     bwrap_cmd = build_learn_bwrap_cmd(
@@ -5022,7 +5191,7 @@ def cmd_learn(args) -> None:
     print(f"  config      {config_path}")
     print(f"  agent       {agent_name} ({agent_cfg['command']})")
     if profile:
-        print(f"  profile     {profile}")
+        print(f"  provider    {profile}")
     print(f"  project     {project_dir}")
     print(f"  trace file  {trace_file}")
     print(
@@ -5151,8 +5320,13 @@ def main() -> None:
     p_run.add_argument("-a", "--agent", default="claude",
                        help="Agent to run (default: claude). "
                             "Looks up [agents.<name>] in config.")
-    p_run.add_argument("-P", "--profile", default=None,
-                       help="Provider profile name (defined in config.toml)")
+    p_run.add_argument(
+        "-P", "--provider", "--profile",
+        dest="provider", default=None,
+        help="Provider name — env-var bundle defined under [providers.*] / "
+             "[<agent>.providers.*] in config.toml (e.g. anthropic, vertex, "
+             "zai). --profile is the legacy spelling and still works.",
+    )
     p_run.add_argument("--log", action="store_true", default=None,
                        help="Enable session transcript logging")
     p_run.add_argument("--no-log", action="store_false", dest="log",
@@ -5331,8 +5505,10 @@ def main() -> None:
         help="Agent to learn (default: claude)",
     )
     p_learn.add_argument(
-        "-P", "--profile", default=None,
-        help="Provider profile name (defined in config.toml)",
+        "-P", "--provider", "--profile",
+        dest="provider", default=None,
+        help="Provider name (env-var bundle defined under [providers.*] in "
+             "config.toml). --profile is the legacy spelling.",
     )
     p_learn.add_argument(
         "--duration", type=int, default=None, metavar="SECONDS",
@@ -5351,6 +5527,17 @@ def main() -> None:
         help="Save TOML suggestions to FILE (default: temp file)",
     )
 
+    # migrate-providers
+    p_mig = sub.add_parser(
+        "migrate-providers",
+        help="Rewrite config.toml: [profiles.*] → [providers.*] "
+             "(see gh#81 for context)",
+    )
+    p_mig.add_argument(
+        "--dry-run", action="store_true",
+        help="Print a unified diff of the changes without writing the file.",
+    )
+
     # nono-sync
     p_nono = sub.add_parser(
         "nono-sync",
@@ -5365,8 +5552,11 @@ def main() -> None:
         help="Sync a specific agent only (default: all agents)",
     )
     p_nono.add_argument(
-        "-P", "--profile", default=None,
-        help="Provider profile name for env var mapping",
+        "-P", "--provider", "--profile",
+        dest="provider", default=None,
+        help="Provider name (env-var bundle defined in config.toml) — "
+             "selects which env vars to bake into the generated nono profile. "
+             "--profile is the legacy spelling.",
     )
 
     # ---- Split argv on '--' so extra args go to the agent -------------------
@@ -5405,6 +5595,7 @@ def main() -> None:
         "snapshot-prune": lambda: cmd_snapshot_prune(args),
         "learn": lambda: cmd_learn(args),
         "nono-sync": lambda: cmd_nono_sync(args),
+        "migrate-providers": lambda: cmd_migrate_providers(args),
     }
     dispatch[args.command]()
 

--- a/sandbox/config.toml.example
+++ b/sandbox/config.toml.example
@@ -21,10 +21,16 @@ auto_expose_path = true
 # .config/gcloud is needed for Vertex AI / Google Cloud authentication
 home_ro_dirs = [".config/gcloud"]
 
-# Default provider profile (used when -P is not specified).
-# Set to a profile name defined in [profiles.*] below.
-# Leave empty to run without a profile.
-default_profile = ""
+# Default provider — env-var bundle used when -P / --provider is not given.
+# Set to a name defined in [providers.*] / [<agent>.providers.*] below.
+# Leave empty to run without a provider.
+#
+# Note: a "provider" (env-var bundle) is a separate concept from a "sandbox
+# profile" (the isolation level — paranoid/normal/permissive — selected with
+# `--sandbox-level`). The two axes are independent: you can run e.g.
+# `paranoid + zai`. The legacy key `default_profile` is still accepted and
+# `agent-sandbox migrate-providers` rewrites your config to the new spelling.
+default_provider = ""
 
 [claude]
 # Legacy section — still works for backward compatibility.
@@ -75,7 +81,7 @@ strip_sections = ['credential', 'url ".*"']
 
 [env]
 # Environment variables passed through FROM THE HOST SHELL.
-# API keys and provider settings go in [profiles.*] sections below.
+# API keys and provider settings go in [providers.*] sections below.
 passthrough = [
     "TERM",
     "COLORTERM",
@@ -94,7 +100,7 @@ passthrough = [
 # Values support $VAR / ${VAR} expansion against the host environment
 # (shell semantics — unset vars resolve to empty strings, never to the
 # literal $VAR text). Same expansion applies to [agents.*.env] and
-# [<agent>.profiles.*.env] values.
+# [<agent>.providers.*.env] values.
 [env.extra]
 # CUSTOM_VAR = "value"
 # FROM_HOST = "$SOME_HOST_VAR"
@@ -134,62 +140,71 @@ block_git_push = true
 # Credential proxy: intercept API calls and inject credentials so that
 # API keys never enter the sandbox environment.  The proxy runs on the
 # host and forwards requests to the real API with the correct headers.
-# Requires API keys to be configured in a [*.profiles.*.env] section.
+# Requires API keys to be configured in a [*.providers.*.env] section.
 credential_proxy = false
 
 # [credential_proxy]
 # # Extra hosts to block (cloud metadata endpoints are always blocked).
 # blocked_hosts = ["169.254.169.254", "metadata.google.internal", "metadata.azure.internal"]
 
-# --- Provider profiles ---
-# Profiles are namespaced by agent type: [<agent>.profiles.<name>]
-# Legacy [profiles.<name>] is still supported and maps to "claude".
-# The wizard only shows profiles matching the selected agent type.
-# API keys live here, NOT in your shell environment.
+# --- Providers (env-var bundles) ---
+# A *provider* is a named env-var bundle that switches model provider/account
+# (Anthropic vs Vertex vs Z.ai vs Minimax, etc.). Pick one at runtime with
+# `-P <name>` / `--provider <name>`, or set [sandbox].default_provider above.
+#
+# Providers are namespaced by agent type: [<agent>.providers.<name>].
+# Top-level [providers.<name>] (and the legacy [profiles.<name>] form) maps
+# to "claude" for back-compat. The wizard only shows providers matching the
+# selected agent type. API keys live here, NOT in your shell environment.
+#
+# Sandbox isolation level (paranoid / normal / permissive) is a SEPARATE axis
+# — see `--sandbox-level` and sandbox/profiles/<agent>-<level>.toml.
 
-# --- Claude profiles ---
+# --- Claude providers ---
 
-# [claude.profiles.vertex]
+# [claude.providers.vertex]
 # description = "Vertex AI"
-# [claude.profiles.vertex.env]
+# [claude.providers.vertex.env]
 # CLAUDE_CODE_USE_VERTEX = "1"
 # CLOUD_ML_REGION = "us-east5"
 # ANTHROPIC_VERTEX_PROJECT_ID = "my-gcp-project"
 # env_unset = ["ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN"]
 
-# [claude.profiles.anthropic]
+# [claude.providers.anthropic]
 # description = "Direct Anthropic API"
-# [claude.profiles.anthropic.env]
+# [claude.providers.anthropic.env]
 # ANTHROPIC_API_KEY = "sk-ant-..."
 # env_unset = ["CLAUDE_CODE_USE_VERTEX", "CLOUD_ML_REGION", "ANTHROPIC_VERTEX_PROJECT_ID"]
 
-# [claude.profiles.zai]
+# [claude.providers.zai]
 # description = "Zai GLM"
-# [claude.profiles.zai.env]
+# [claude.providers.zai.env]
 # ANTHROPIC_BASE_URL = "https://api.z.ai/api/anthropic"
 # ANTHROPIC_AUTH_TOKEN = "XXXX"
 
-# [claude.profiles.mm]
+# [claude.providers.mm]
 # description = "Minimax Anthropic API"
-# [claude.profiles.mm.env]
+# [claude.providers.mm.env]
 # ANTHROPIC_BASE_URL = "https://api.minimax.io/anthropic"
 # ANTHROPIC_AUTH_TOKEN = "XXXX"
 
-# --- Codex profiles ---
+# --- Codex providers ---
 
-# [codex.profiles.default]
+# [codex.providers.default]
 # description = "Default OpenAI key"
-# [codex.profiles.default.env]
+# [codex.providers.default.env]
 # OPENAI_API_KEY = "sk-..."
 
-# --- Gemini profiles ---
+# --- Gemini providers ---
 
-# [gemini.profiles.default]
+# [gemini.providers.default]
 # description = "Default Gemini key"
-# [gemini.profiles.default.env]
+# [gemini.providers.default.env]
 # GEMINI_API_KEY = "..."
 
 # --- Legacy format (still works, mapped to claude) ---
+# Pre-#81 spelling. New configs should use [providers.*] / [<agent>.providers.*].
+# Run `agent-sandbox migrate-providers` to rewrite an existing config in place.
 # [profiles.vertex]
 # description = "Vertex AI"
 # [profiles.vertex.env]

--- a/sandbox/profiles/claude-permissive.toml
+++ b/sandbox/profiles/claude-permissive.toml
@@ -4,17 +4,22 @@
 # on top of the user's resolved config. Lists like home_ro_dirs and
 # allow_domains are appended (not replaced).
 #
-# Permissive opens up github + the gh CLI's filesystem footprint while
-# keeping the credential proxy on. Network is NOT kernel-isolated here
-# (unshare_net is left at its default, off) — the threat model is "trusted
-# agent that needs broader access, not adversarial".
+# Permissive opens up github + the gh CLI's filesystem footprint and lets
+# the agent talk to the network directly. The threat model is "trusted
+# agent that needs broader access, not adversarial":
+#   - credential_proxy = false: the agent reads API keys directly from the
+#     env. No proxy interception, no allowlist enforcement on the host.
+#   - unshare_net is left at its default (off): no kernel-level network
+#     isolation either. allow_domains is therefore moot here and is kept
+#     only as documentation of which hosts the gh CLI typically reaches.
+#   - block_git_push stays on: we expect the user to use `gh` (with a
+#     fine-grained token) for any push-style operations, not raw git.
 #
-# To narrow what the proxy is allowed to forward (without going to the
-# stricter paranoid level), keep this fragment but tighten allow_domains
-# in your own config:
+# To get credential-injection without keys in the sandbox env, opt back in
+# explicitly in your own config (deep-merged on top of this fragment):
 #
 #   [security]
-#   allow_domains = []   # block everything except credential-rule hosts
+#   credential_proxy = true
 
 [sandbox]
 home_ro_dirs = [".config/gh", ".cache", ".ssh/known_hosts"]
@@ -29,8 +34,14 @@ home_ro_dirs = [".config/gh", ".cache", ".ssh/known_hosts"]
 passthrough = ["GH_TOKEN", "GITHUB_TOKEN"]
 
 [security]
-credential_proxy = true
+credential_proxy = false
+# block_git_push stays on by design: users push via `gh` (with a
+# fine-grained token), so the bare-`git push` block is defense-in-depth
+# without blocking real workflows.
 block_git_push = true
+# Documents the hosts gh CLI typically reaches. Only enforced when the
+# user opts into credential_proxy = true on top of permissive — otherwise
+# the proxy is off and there is no allowlist to enforce.
 allow_domains = [
     "api.github.com",
     "github.com",

--- a/sandbox/profiles/codex-permissive.toml
+++ b/sandbox/profiles/codex-permissive.toml
@@ -10,8 +10,17 @@ home_ro_dirs = [".config/gh", ".cache", ".ssh/known_hosts"]
 passthrough = ["GH_TOKEN", "GITHUB_TOKEN"]
 
 [security]
-credential_proxy = true
+# credential_proxy off in permissive: the agent reads API keys directly
+# from the env (no proxy interception, no allowlist enforcement). For a
+# proxy-on permissive variant, set `credential_proxy = true` in your own
+# config — it deep-merges over this fragment.
+credential_proxy = false
+# block_git_push stays on by design: users push via `gh` (with a
+# fine-grained token), so the bare-`git push` block is defense-in-depth
+# without blocking real workflows.
 block_git_push = true
+# Documents the hosts gh CLI typically reaches. Only enforced when the
+# user opts into credential_proxy = true on top of permissive.
 allow_domains = [
     "api.github.com",
     "github.com",

--- a/sandbox/profiles/gemini-permissive.toml
+++ b/sandbox/profiles/gemini-permissive.toml
@@ -10,8 +10,17 @@ home_ro_dirs = [".config/gh", ".cache", ".ssh/known_hosts"]
 passthrough = ["GH_TOKEN", "GITHUB_TOKEN"]
 
 [security]
-credential_proxy = true
+# credential_proxy off in permissive: the agent reads API keys directly
+# from the env (no proxy interception, no allowlist enforcement). For a
+# proxy-on permissive variant, set `credential_proxy = true` in your own
+# config — it deep-merges over this fragment.
+credential_proxy = false
+# block_git_push stays on by design: users push via `gh` (with a
+# fine-grained token), so the bare-`git push` block is defense-in-depth
+# without blocking real workflows.
 block_git_push = true
+# Documents the hosts gh CLI typically reaches. Only enforced when the
+# user opts into credential_proxy = true on top of permissive.
 allow_domains = [
     "api.github.com",
     "github.com",

--- a/sandbox/profiles/opencode-permissive.toml
+++ b/sandbox/profiles/opencode-permissive.toml
@@ -10,8 +10,17 @@ home_ro_dirs = [".config/gh", ".cache", ".ssh/known_hosts"]
 passthrough = ["GH_TOKEN", "GITHUB_TOKEN"]
 
 [security]
-credential_proxy = true
+# credential_proxy off in permissive: the agent reads API keys directly
+# from the env (no proxy interception, no allowlist enforcement). For a
+# proxy-on permissive variant, set `credential_proxy = true` in your own
+# config — it deep-merges over this fragment.
+credential_proxy = false
+# block_git_push stays on by design: users push via `gh` (with a
+# fine-grained token), so the bare-`git push` block is defense-in-depth
+# without blocking real workflows.
 block_git_push = true
+# Documents the hosts gh CLI typically reaches. Only enforced when the
+# user opts into credential_proxy = true on top of permissive.
 allow_domains = [
     "api.github.com",
     "github.com",

--- a/sandbox/profiles/pi-permissive.toml
+++ b/sandbox/profiles/pi-permissive.toml
@@ -10,8 +10,17 @@ home_ro_dirs = [".config/gh", ".cache", ".ssh/known_hosts"]
 passthrough = ["GH_TOKEN", "GITHUB_TOKEN"]
 
 [security]
-credential_proxy = true
+# credential_proxy off in permissive: the agent reads API keys directly
+# from the env (no proxy interception, no allowlist enforcement). For a
+# proxy-on permissive variant, set `credential_proxy = true` in your own
+# config — it deep-merges over this fragment.
+credential_proxy = false
+# block_git_push stays on by design: users push via `gh` (with a
+# fine-grained token), so the bare-`git push` block is defense-in-depth
+# without blocking real workflows.
 block_git_push = true
+# Documents the hosts gh CLI typically reaches. Only enforced when the
+# user opts into credential_proxy = true on top of permissive.
 allow_domains = [
     "api.github.com",
     "github.com",


### PR DESCRIPTION
## Summary

Disambiguate "profile". Pre-#81 the codebase overloaded the term for two unrelated, orthogonal concepts:

- **provider** — env-var bundle (Anthropic vs Vertex vs Z.ai vs Minimax …) — now lives under `[providers.*]` / `[<agent>.providers.*]`, selectable with `-P` / `--provider` (legacy `--profile` still works).
- **profile** — sandbox isolation level (paranoid / normal / permissive) — fragments under `sandbox/profiles/` selected with `--sandbox-level` (unchanged).

You can combine them freely: `agent-sandbox run --sandbox-level paranoid -P zai`.

## Sandbox (`sandbox/agent-sandbox`)

- `resolve_providers` reads canonical `[providers.*]` + legacy `[profiles.*]` (last-wins; namespaced canonical beats top-level legacy). One-shot stderr deprecation note when only legacy is present.
- `default_provider` with `default_profile` fallback.
- `--provider` canonical alias for `-P` / `--profile` (all share `dest=provider`).
- New `agent-sandbox migrate-providers [--dry-run]` rewrites `config.toml` in place via regex (preserves comments). Idempotent, writes `.bak`.
- **Permissive level**: `credential_proxy` now defaults to `false` (was `true` since #57). Proxy interception is more associated with paranoid; forcing localhost-loop API calls in a level advertised as "trusted, broad access" was inconsistent. `block_git_push` stays on (push via `gh` with a fine-grained PAT). Users who want proxy-on permissive can deep-merge `[security] credential_proxy = true` on top.

## Dashboard (`lince-dashboard/plugin/src/*`)

- `WizardStep::Profile` → `Provider`; types/fields renamed accordingly (`available_providers`, `provider_index`, `selected_provider`, `ProviderDetails`, `providers_by_agent`, …).
- `SavedAgentInfo.provider` with `#[serde(alias = "profile")]` so pre-#81 `.lince-dashboard` files keep loading.
- `AgentTypeConfig.providers` with `serde(alias = "profiles")`; `DashboardConfig.default_provider` with `serde(alias = "default_profile")`.
- `{provider}` placeholder added to command templates; `{profile}` kept as alias.
- **Detail pane** shows BOTH `Profile: <sandbox-level>` and `Provider: <env-bundle>` on separate lines.
- Tests added in `state_file.rs` and `config.rs` covering back-compat aliases and the dual-read precedence rule.

## Docs

Vocabulary updated across `sandbox/{README,CHEATSHEET}.md`, `sandbox/config.toml.example`, `lince-dashboard/agents-defaults.toml`, and the seven `docs/documentation/{sandbox,dashboard}/*.md` files. New "Two orthogonal axes" section in `sandbox/README.md` alongside the "Using providers" section (carried over and renamed from the upstream "Using profiles" section in #82).

## Test plan

- [ ] `cargo build --target wasm32-wasip1` clean (verified locally — debug + release)
- [ ] `agent-sandbox --help` and `run --help` show `-P, --provider, --profile` with new wording
- [ ] `agent-sandbox migrate-providers --dry-run` on a legacy-only `config.toml` shows the expected substitutions
- [ ] After migration, a re-run reports "already uses [providers.*] — nothing to migrate"
- [ ] Pre-#81 `[profiles.*]` config still loads and prints the one-shot deprecation note
- [ ] `--provider zai` injects the bundle's env vars in `--dry-run`
- [ ] Wizard's Provider step renders correctly (label "Provider", help text mentions env-var bundle)
- [ ] Detail pane shows separate `Profile:` and `Provider:` lines
- [ ] Save + restart loads a pre-#81 `.lince-dashboard` file (serde alias path)
- [ ] `agent-sandbox run --sandbox-level permissive -P zai` no longer starts the credential proxy (proxy comment line absent in `--dry-run`)
- [ ] `agent-sandbox run --sandbox-level paranoid` still starts the credential proxy

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)