### PR TITLE
dashboard: hide info panel by default

### DIFF
--- a/lince-dashboard/plugin/src/main.rs
+++ b/lince-dashboard/plugin/src/main.rs
@@ -66,7 +66,7 @@ impl Default for State {
             agents: Vec::new(),
             selected_index: 0,
             focused_agent: None,
-            show_detail: true,
+            show_detail: false,
             show_help: false,
             status_message: None,
             next_agent_id: 0,


### PR DESCRIPTION
## Summary
- Flip `State::default().show_detail` from `true` to `false` so the agent table fills the full available height on dashboard launch.
- The `i` key already toggles the detail panel and status-bar hints already adapt — no other changes required.

## Test plan
- [x] `bash lince-dashboard/plugin/build.sh` — clean release build
- [ ] Launch dashboard: confirm no detail panel reserved at the bottom; agent table uses full height.
- [ ] Press `i`: detail panel appears for the selected agent.
- [ ] Press `i` again: detail panel hidden, table reclaims the rows.
- [ ] Status-bar hints reflect the current state (`i:Info` when hidden, `i:Hide info` when visible).

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)