### PR TITLE
feat: add lince-config CLI and lince-configure skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 uv.lock
 .claude/
 .agent-sandbox/
+.pi/
 .serena
 
 # Rust build artifacts

--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ The multi-agent TUI dashboard — a Zellij WASM plugin (Rust, ~900 KB) that mana
 
 Documentation: [Usage Guide](https://lince.sh/documentation/#/dashboard/usage-guide) | [Configuration](https://lince.sh/documentation/#/dashboard/config-reference) | [Agent Examples](https://lince.sh/documentation/#/dashboard/agent-examples)
 
+### [lince-config/](lince-config/)
+
+Structured CLI for reading and editing LINCE configuration files (`~/.agent-sandbox/config.toml` and `~/.config/lince-dashboard/config.toml`). Preserves comments and formatting via `tomlkit`. Installed to `~/.local/bin/lince-config`.
+
+Also powers the **`/lince-configure` skill** — a natural-language interface that lets any AI coding agent read and modify its own configuration interactively (conversational or guided-menu mode). Installed automatically by `quickstart.sh` or `lince-dashboard/install.sh`.
+
 ### [sandbox/](sandbox/)
 
 Bubblewrap-based sandbox for running AI coding agents safely. Restricts filesystem access, blocks git push, isolates environment variables, and hides host processes — with near-zero overhead. Supports any agent via `--agent` flag (`agent-sandbox run -a codex`, `-a gemini`, etc.). Used by the dashboard to spawn every agent.
@@ -133,6 +139,10 @@ Documentation: [CLI Reference](https://lince.sh/documentation/#/sandbox/cli-refe
 ### `/lince-setup` skill (bundled with lince-dashboard)
 
 An [agentskills.io](https://agentskills.io)-compliant skill that lets any AI coding agent register itself with the lince ecosystem. Generates correct TOML configuration for both agent-sandbox and lince-dashboard. Installed automatically by `lince-dashboard/install.sh`.
+
+### `/lince-configure` skill (bundled with lince-dashboard)
+
+An [agentskills.io](https://agentskills.io)-compliant skill for natural-language configuration of LINCE. Ask any AI agent to configure providers, change sandbox levels, set API keys, adjust dashboard settings, or diagnose issues — it drives `lince-config` under the hood. Supports conversational and guided-menu interaction. Installed automatically by `lince-dashboard/install.sh` (requires the `lince-config` CLI).
 
 ## Related Projects
 

--- a/docs/documentation/README.md
+++ b/docs/documentation/README.md
@@ -19,10 +19,17 @@ Multi-agent TUI dashboard for Zellij. Spawn, monitor, and switch between multipl
 - [Agent Examples](dashboard/agent-examples.md) -- defaults, custom agents, advanced setups
 - [Sandbox Levels](dashboard/sandbox-levels.md) -- paranoid / normal / permissive: what each level does and how to ship a custom one
 
+## Configuration CLI (lince-config)
+
+Structured CLI for reading and editing LINCE TOML configuration files. Also powers the `/lince-configure` skill for natural-language configuration.
+
+- [README & Commands](https://github.com/RisorseArtificiali/lince/blob/main/lince-config/README.md) -- install, commands, and examples
+
 ## Quick Links
 
 - [Getting Started](https://github.com/RisorseArtificiali/lince/blob/main/QUICKSTART.md)
 - [GitHub Repository](https://github.com/RisorseArtificiali/lince)
 - [Cheat Sheet](https://github.com/RisorseArtificiali/lince/blob/main/sandbox/CHEATSHEET.md)
 - [Multi-Agent Guide](https://github.com/RisorseArtificiali/lince/blob/main/lince-dashboard/MULTI-AGENT-GUIDE.md)
+- [lince-config README](https://github.com/RisorseArtificiali/lince/blob/main/lince-config/README.md)
 - [nono Integration](https://github.com/RisorseArtificiali/lince/blob/main/sandbox/docs/nono-integration.md)

--- a/docs/documentation/_sidebar.md
+++ b/docs/documentation/_sidebar.md
@@ -11,3 +11,6 @@
   - [Configuration Reference](dashboard/config-reference.md)
   - [Agent Examples](dashboard/agent-examples.md)
   - [Sandbox Levels](dashboard/sandbox-levels.md)
+
+- **Configuration CLI (lince-config)**
+  - [README & Commands](https://github.com/RisorseArtificiali/lince/blob/main/lince-config/README.md)

--- a/docs/documentation/dashboard/agent-examples.md
+++ b/docs/documentation/dashboard/agent-examples.md
@@ -50,6 +50,8 @@ Use unsandboxed mode only in trusted environments where sandbox restrictions are
 
 The easiest way to add a new agent is the `/lince-setup` skill. Run the target agent outside the dashboard, invoke `/lince-setup`, and the agent describes its own requirements. The skill generates correct TOML for both sandbox and dashboard configs.
 
+For ongoing configuration changes (providers, sandbox levels, API keys, diagnostics), use the **`/lince-configure` skill** — a natural-language interface backed by the `lince-config` CLI that supports both conversational and guided-menu interaction.
+
 See the [Multi-Agent Guide](https://github.com/RisorseArtificiali/lince/blob/main/lince-dashboard/MULTI-AGENT-GUIDE.md) for the full flow and examples.
 
 ### Manual Configuration
@@ -223,4 +225,5 @@ If an incoming event matches the `event_map`, the mapped status is used. Otherwi
 - [Usage Guide](dashboard/usage-guide.md) -- how to operate the dashboard
 - [Configuration Reference](dashboard/config-reference.md) -- all config keys and their defaults
 - [Sandbox CLI Reference](sandbox/cli-reference.md) -- the `agent-sandbox` command
+- [lince-config CLI](https://github.com/RisorseArtificiali/lince/blob/main/lince-config/README.md) -- structured CLI for reading and editing LINCE configuration
 - [Multi-Agent Guide](https://github.com/RisorseArtificiali/lince/blob/main/lince-dashboard/MULTI-AGENT-GUIDE.md) -- migration guide for multi-agent support

--- a/docs/documentation/dashboard/config-reference.md
+++ b/docs/documentation/dashboard/config-reference.md
@@ -212,4 +212,5 @@ This means you can safely update `agents-defaults.toml` (via `update.sh`) withou
 - [Usage Guide](dashboard/usage-guide.md) -- how to operate the dashboard
 - [Agent Examples](dashboard/agent-examples.md) -- preset agents and custom configuration examples
 - [Sandbox CLI Reference](sandbox/cli-reference.md) -- the `agent-sandbox` command
+- [lince-config CLI](https://github.com/RisorseArtificiali/lince/blob/main/lince-config/README.md) -- structured CLI for reading and editing LINCE configuration
 - [Multi-Agent Guide](https://github.com/RisorseArtificiali/lince/blob/main/lince-dashboard/MULTI-AGENT-GUIDE.md) -- migration guide for multi-agent support

--- a/docs/documentation/dashboard/usage-guide.md
+++ b/docs/documentation/dashboard/usage-guide.md
@@ -269,4 +269,5 @@ Option 2 — Via GUI: **Terminator → Preferences → Keybindings → copy_clip
 - [Configuration Reference](dashboard/config-reference.md) -- all config keys and their defaults
 - [Agent Examples](dashboard/agent-examples.md) -- preset agents and custom configuration examples
 - [Sandbox CLI Reference](sandbox/cli-reference.md) -- the `agent-sandbox` command
+- [lince-config CLI](https://github.com/RisorseArtificiali/lince/blob/main/lince-config/README.md) -- structured CLI for reading and editing LINCE configuration
 - [Multi-Agent Guide](https://github.com/RisorseArtificiali/lince/blob/main/lince-dashboard/MULTI-AGENT-GUIDE.md) -- migration guide for multi-agent support

--- a/docs/documentation/sandbox/cli-reference.md
+++ b/docs/documentation/sandbox/cli-reference.md
@@ -340,3 +340,4 @@ ls ~/.agent-sandbox/logs/
 - [Configuration Reference](sandbox/config-reference.md) -- every TOML key documented
 - [Security Model](sandbox/security-model.md) -- threat model, defense layers, credential proxy details
 - [Cheatsheet](https://github.com/RisorseArtificiali/lince/blob/main/sandbox/CHEATSHEET.md) -- quick-reference card
+- [lince-config CLI](https://github.com/RisorseArtificiali/lince/blob/main/lince-config/README.md) -- structured CLI for reading and editing LINCE configuration

--- a/docs/documentation/sandbox/config-reference.md
+++ b/docs/documentation/sandbox/config-reference.md
@@ -386,3 +386,4 @@ After initialization, `~/.agent-sandbox/` contains:
 - [CLI Reference](sandbox/cli-reference.md) -- command synopsis, flags, and usage examples
 - [Security Model](sandbox/security-model.md) -- threat model, defense layers, credential proxy details
 - [Cheatsheet](https://github.com/RisorseArtificiali/lince/blob/main/sandbox/CHEATSHEET.md) -- quick-reference card
+- [lince-config CLI](https://github.com/RisorseArtificiali/lince/blob/main/lince-config/README.md) -- structured CLI for reading and editing LINCE configuration

--- a/lince-config/README.md
+++ b/lince-config/README.md
@@ -6,13 +6,15 @@ Structured CLI for reading and editing LINCE configuration files.
 
 `lince-config` is the programmatic interface between natural-language skills (or power users) and LINCE's TOML config files. It reads and writes both sandbox (`~/.agent-sandbox/config.toml`) and dashboard (`~/.config/lince-dashboard/config.toml`) configurations, preserving comments and formatting.
 
-## Install
+## Install / update / uninstall
 
 ```bash
-cd lince-config && ./install.sh
+cd lince-config && ./install.sh    # install to ~/.local/bin/lince-config
+./update.sh                        # refresh after pulling new changes
+./uninstall.sh                     # remove from ~/.local/bin
 ```
 
-Requires Python 3.11+ and `tomlkit` (auto-installed by `install.sh`).
+Requires Python 3.11+ and `tomlkit` (auto-installed by `install.sh` and `update.sh`).
 
 ## Commands
 

--- a/lince-config/README.md
+++ b/lince-config/README.md
@@ -1,0 +1,101 @@
+# lince-config
+
+Structured CLI for reading and editing LINCE configuration files.
+
+## What it does
+
+`lince-config` is the programmatic interface between natural-language skills (or power users) and LINCE's TOML config files. It reads and writes both sandbox (`~/.agent-sandbox/config.toml`) and dashboard (`~/.config/lince-dashboard/config.toml`) configurations, preserving comments and formatting.
+
+## Install
+
+```bash
+cd lince-config && ./install.sh
+```
+
+Requires Python 3.11+ and `tomlkit` (auto-installed by `install.sh`).
+
+## Commands
+
+```bash
+# Read
+lince-config get <dotted.key> [--target sandbox|dashboard] [--json]
+lince-config list [section]   [--target sandbox|dashboard] [--json]
+
+# Write
+lince-config set <dotted.key> <value>    [--target sandbox|dashboard] [-q]
+lince-config append <dotted.key> <value> [--target sandbox|dashboard] [-q]
+lince-config remove <dotted.key> <value> [--target sandbox|dashboard] [-q]
+lince-config unset <dotted.key>          [--target sandbox|dashboard] [-q]
+
+# Diagnostics
+lince-config check    [--target sandbox|dashboard] [--json]
+lince-config validate [--target sandbox|dashboard] [--json]
+```
+
+## Examples
+
+```bash
+# Read a value
+lince-config get sandbox.default_provider
+lince-config get security.unshare_net
+lince-config get providers.vertex --json
+
+# Set a value
+lince-config set sandbox.default_provider "vertex"
+lince-config set security.unshare_net true
+lince-config set security.credential_proxy true
+
+# Configure a provider
+lince-config set claude.providers.vertex.description "Vertex AI"
+lince-config set claude.providers.vertex.env.CLAUDE_CODE_USE_VERTEX "1"
+lince-config set claude.providers.vertex.env.ANTHROPIC_VERTEX_PROJECT_ID "my-gcp-project"
+
+# Manage lists
+lince-config append security.allow_domains "pypi.org"
+lince-config remove security.allow_domains "pypi.org"
+
+# Remove a section
+lince-config unset providers.vertex
+
+# Diagnostics
+lince-config check
+lince-config validate
+
+# Dashboard config
+lince-config get dashboard.agent_layout --target dashboard
+lince-config set dashboard.max_agents 16 --target dashboard
+```
+
+## Value coercion
+
+CLI string values are auto-coerced:
+
+| Input            | Type    |
+|------------------|---------|
+| `true` / `false` | bool    |
+| `42`             | int     |
+| `["a","b"]`      | list    |
+| everything else  | string  |
+
+## Target
+
+- `--target sandbox` (default): operates on `~/.agent-sandbox/config.toml`
+- `--target dashboard`: operates on `~/.config/lince-dashboard/config.toml`
+
+For sandbox, project-local `.agent-sandbox/config.toml` takes priority when present.
+
+## Skill integration
+
+The `--json` and `-q` (quiet) flags are designed for automated use by skills:
+
+```bash
+# Skill reads current state
+lince-config list providers --json -q
+
+# Skill makes changes quietly
+lince-config set providers.bedrock.description "AWS Bedrock" -q
+lince-config set providers.bedrock.env.AWS_REGION "us-east-1" -q
+
+# Skill verifies
+lince-config check --json
+```

--- a/lince-config/install.sh
+++ b/lince-config/install.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CMD_SRC="$SCRIPT_DIR/lince-config"
+INSTALL_DST="$HOME/.local/bin/lince-config"
+
+echo -e "${BLUE}================================================${NC}"
+echo -e "${BLUE}   lince-config — Installer${NC}"
+echo -e "${BLUE}================================================${NC}"
+echo ""
+
+# ── Prerequisites ──────────────────────────────────────────────────────
+
+echo -e "${GREEN}[1/4] Checking prerequisites...${NC}"
+
+command -v python3 >/dev/null 2>&1 || { echo -e "${RED}Missing: python3 (3.11+)${NC}"; exit 1; }
+
+PY_OK=$(python3 -c "import sys; print(1 if sys.version_info >= (3, 11) else 0)" 2>/dev/null || echo 0)
+if [ "$PY_OK" = "0" ]; then
+    echo -e "${RED}Python 3.11+ required (for tomllib)${NC}"
+    exit 1
+fi
+echo -e "${GREEN}  ✓ python3 $(python3 --version 2>&1 | awk '{print $2}')${NC}"
+
+# Check/install tomlkit
+python3 -c "import tomlkit" 2>/dev/null || {
+    echo -e "${YELLOW}  tomlkit not found. Installing...${NC}"
+    pip install --user tomlkit 2>/dev/null || \
+        pip install --user --break-system-packages tomlkit 2>/dev/null || {
+        echo -e "${RED}  Failed to install tomlkit. Install manually: pip install tomlkit${NC}"
+        exit 1
+    }
+}
+echo -e "${GREEN}  ✓ tomlkit$(python3 -c "import tomlkit; print(' ' + tomlkit.__version__)" 2>/dev/null)${NC}"
+
+# ── Install binary ─────────────────────────────────────────────────────
+
+echo ""
+echo -e "${GREEN}[2/4] Installing lince-config...${NC}"
+
+mkdir -p "$(dirname "$INSTALL_DST")"
+cp "$CMD_SRC" "$INSTALL_DST"
+chmod +x "$INSTALL_DST"
+echo -e "${GREEN}  ✓ Installed to $INSTALL_DST${NC}"
+
+# ── PATH check ─────────────────────────────────────────────────────────
+
+echo ""
+echo -e "${GREEN}[3/4] Checking PATH...${NC}"
+
+BIN_DIR="$(dirname "$INSTALL_DST")"
+case ":$PATH:" in
+    *":$BIN_DIR:"*) echo -e "${GREEN}  ✓ $BIN_DIR is in PATH${NC}" ;;
+    *)
+        echo -e "${YELLOW}  $BIN_DIR is not in PATH.${NC}"
+        echo -e "${YELLOW}  Add it to your shell profile:${NC}"
+        echo -e "${YELLOW}    export PATH=\"$BIN_DIR:\$PATH\"${NC}"
+        ;;
+esac
+
+# ── Verify ─────────────────────────────────────────────────────────────
+
+echo ""
+echo -e "${GREEN}[4/4] Verifying...${NC}"
+
+if "$INSTALL_DST" --help >/dev/null 2>&1; then
+    echo -e "${GREEN}  ✓ lince-config is working${NC}"
+else
+    echo -e "${RED}  ✗ lince-config --help failed${NC}"
+    exit 1
+fi
+
+echo ""
+echo -e "${GREEN}Done! Run 'lince-config --help' to get started.${NC}"

--- a/lince-config/lince-config
+++ b/lince-config/lince-config
@@ -5,22 +5,22 @@ Reads and writes TOML config files for both the sandbox (agent-sandbox) and
 the dashboard (lince-dashboard), preserving comments and formatting via tomlkit.
 
 Usage:
-    lince config get <dotted.key> [--target sandbox|dashboard] [--json]
-    lince config set <dotted.key> <value> [--target sandbox|dashboard]
-    lince config append <dotted.key> <value> [--target sandbox|dashboard]
-    lince config remove <dotted.key> <value> [--target sandbox|dashboard]
-    lince config unset <dotted.key> [--target sandbox|dashboard]
-    lince config list [section] [--target sandbox|dashboard] [--json]
-    lince config check [--target sandbox|dashboard] [--json]
-    lince config validate [--target sandbox|dashboard] [--json]
+    lince-config get <dotted.key> [--target sandbox|dashboard] [--json]
+    lince-config set <dotted.key> <value> [--target sandbox|dashboard]
+    lince-config append <dotted.key> <value> [--target sandbox|dashboard]
+    lince-config remove <dotted.key> <value> [--target sandbox|dashboard]
+    lince-config unset <dotted.key> [--target sandbox|dashboard]
+    lince-config list [section] [--target sandbox|dashboard] [--json]
+    lince-config check [--target sandbox|dashboard] [--json]
+    lince-config validate [--target sandbox|dashboard] [--json]
 """
 
 from __future__ import annotations
 
 import argparse
 import json
-import os
 import re
+import shutil
 import stat
 import sys
 from pathlib import Path
@@ -33,7 +33,6 @@ except ImportError:
 
 try:
     import tomlkit
-    from tomlkit.items import Table, InlineTable, AoT, Item
 except ImportError:
     print(
         "Error: 'tomlkit' is required. Install it with:\n"
@@ -41,6 +40,9 @@ except ImportError:
         file=sys.stderr,
     )
     sys.exit(1)
+
+
+__version__ = "1.0.0"
 
 
 # ── Constants ────────────────────────────────────────────────────────────
@@ -119,6 +121,7 @@ DASHBOARD_SCHEMA = {
         "agent_layout": (str, False, "How agent panes are created (floating/tiled)"),
         "focus_mode": (str, False, "How focusing works (floating/replace)"),
         "status_method": (str, False, "Status detection method (pipe/file)"),
+        "status_file_dir": (str, False, "Directory for status files when status_method = file"),
         "max_agents": (int, False, "Maximum concurrent agents"),
         "sandbox_backend": (str, False, "Sandbox backend preference"),
         "default_agent_type": (str, False, "Default agent type for new agents"),
@@ -203,15 +206,29 @@ def _resolve_all_config_paths(target: str) -> list[Path]:
 
 def _load_tomlkit(path: Path) -> tomlkit.TOMLDocument:
     """Load a TOML file preserving comments and formatting via tomlkit."""
-    with open(path, "r", encoding="utf-8") as fh:
-        return tomlkit.load(fh)
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return tomlkit.load(fh)
+    except PermissionError as exc:
+        print(f"Error: cannot read {path}: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except OSError as exc:
+        print(f"Error: failed to open {path}: {exc}", file=sys.stderr)
+        sys.exit(1)
 
 
 def _save_tomlkit(doc: tomlkit.TOMLDocument, path: Path) -> None:
     """Save a tomlkit document back to file, preserving formatting."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w", encoding="utf-8") as fh:
-        tomlkit.dump(doc, fh)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as fh:
+            tomlkit.dump(doc, fh)
+    except PermissionError as exc:
+        print(f"Error: cannot write {path}: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except OSError as exc:
+        print(f"Error: failed to write {path}: {exc}", file=sys.stderr)
+        sys.exit(1)
 
 
 def _dotted_get(doc: tomlkit.TOMLDocument, key: str):
@@ -269,11 +286,12 @@ def _coerce_value(raw: str, key_hint: str = ""):
     """Parse a CLI string value into the appropriate Python type.
 
     Rules:
-        "true"/"false"  -> bool
-        bare integer    -> int
-        [...]           -> parsed as JSON list
-        {...}           -> parsed as JSON dict
-        otherwise       -> str
+        "true"/"false"           -> bool
+        bare integer             -> int
+        decimal/scientific       -> float
+        [...]                    -> parsed as JSON list
+        {...}                    -> parsed as JSON dict
+        otherwise                -> str
     """
     s = raw.strip()
 
@@ -286,6 +304,13 @@ def _coerce_value(raw: str, key_hint: str = ""):
     # Integer
     if re.fullmatch(r"-?\d+", s):
         return int(s)
+
+    # Float (decimal or scientific notation, e.g. 3.14, 1e10, 1.5e-3)
+    if re.fullmatch(r"-?\d+\.\d+([eE][+-]?\d+)?", s) or re.fullmatch(r"-?\d+[eE][+-]?\d+", s):
+        try:
+            return float(s)
+        except ValueError:
+            pass  # fall through to string
 
     # JSON list or dict
     if s.startswith("[") or s.startswith("{"):
@@ -311,23 +336,23 @@ def _python_value_to_json(val):
     return str(val)
 
 
-def _format_value(val) -> str:
-    """Format a value for human-readable output."""
+def _format_value(val, indent: int = 0) -> str:
+    """Format a value for human-readable output (recurses into nested dicts)."""
     if val is None:
         return "(not set)"
     if isinstance(val, bool):
         return str(val).lower()
     if isinstance(val, dict):
+        if not val:
+            return "{}"
+        prefix = "  " * indent
         lines = []
         for k, v in val.items():
-            if isinstance(v, dict):
-                lines.append(f"{k}:")
-                for kk, vv in v.items():
-                    lines.append(f"  {kk} = {_format_value(vv)}")
-            elif isinstance(v, list):
-                lines.append(f"{k} = {_format_value(v)}")
+            if isinstance(v, dict) and v:
+                lines.append(f"{prefix}{k}:")
+                lines.append(_format_value(v, indent + 1))
             else:
-                lines.append(f"{k} = {_format_value(v)}")
+                lines.append(f"{prefix}{k} = {_format_value(v)}")
         return "\n".join(lines)
     if isinstance(val, list):
         if not val:
@@ -411,6 +436,9 @@ def _deep_merge_dict(base: dict, overlay: dict) -> dict:
         if k in result and isinstance(result[k], dict) and isinstance(v, dict):
             result[k] = _deep_merge_dict(result[k], v)
         elif k in result and isinstance(result[k], list) and isinstance(v, list):
+            # repr()-based dedup: safe for TOML scalars (str/int/float/bool) and
+            # nested tables since tomlkit values yield deterministic reprs. It is
+            # NOT a general object identity check.
             seen = set()
             merged = []
             for item in result[k] + v:
@@ -474,8 +502,15 @@ def cmd_append(args) -> int:
     current, found = _dotted_get(doc, key)
 
     if not found:
-        # Create the list
-        _dotted_set(doc, key, f"[{json.dumps(_coerce_value(value, key))}]")
+        # Create the list directly (no string round-trip)
+        coerced = _coerce_value(value, key)
+        parts = key.split(".")
+        cur = doc
+        for part in parts[:-1]:
+            if part not in cur:
+                cur[part] = tomlkit.table()
+            cur = cur[part]
+        cur[parts[-1]] = [coerced]
     elif isinstance(current, list):
         coerced = _coerce_value(value, key)
         if coerced not in [_python_value_to_json(v) for v in current]:
@@ -689,17 +724,35 @@ def cmd_check(args) -> int:
     return 1 if any(i["level"] == "error" for i in issues) else 0
 
 
+_SENSITIVE_KEY_KEYWORDS = ("API_KEY", "SECRET", "TOKEN", "PASSWORD", "ACCESS_KEY", "PRIVATE_KEY")
+
+# Regexes for credentials that are recognizable from the value alone, regardless
+# of the key name. Conservative — only matches well-known prefixes/structures to
+# avoid flagging arbitrary strings.
+_SENSITIVE_VALUE_PATTERNS = (
+    re.compile(r"^sk-[A-Za-z0-9_\-]{16,}"),         # Anthropic / OpenAI style
+    re.compile(r"^xai-[A-Za-z0-9_\-]{16,}"),        # xAI
+    re.compile(r"^xoxb-[A-Za-z0-9_\-]{16,}"),       # Slack bot
+    re.compile(r"^ghp_[A-Za-z0-9]{20,}"),           # GitHub personal token
+    re.compile(r"^gho_[A-Za-z0-9]{20,}"),           # GitHub OAuth
+    re.compile(r"^AKIA[0-9A-Z]{16}"),               # AWS access key
+    re.compile(r"^AIza[0-9A-Za-z_\-]{20,}"),        # Google API key
+    re.compile(r"^-----BEGIN [A-Z ]*PRIVATE KEY"),  # PEM private key
+)
+
+
 def _has_sensitive_data(doc: dict) -> bool:
-    """Check if config contains API keys or secrets."""
-    # Check provider env sections for key-like patterns
+    """Check if config contains API keys or secrets, by key name OR value pattern."""
     for key, val in doc.items():
         if isinstance(val, dict):
             if _has_sensitive_data(val):
                 return True
-        if isinstance(val, str) and any(
-            kw in key.upper() for kw in ("API_KEY", "SECRET", "TOKEN", "PASSWORD")
-        ):
-            return True
+            continue
+        if isinstance(val, str):
+            if any(kw in key.upper() for kw in _SENSITIVE_KEY_KEYWORDS):
+                return True
+            if any(p.match(val) for p in _SENSITIVE_VALUE_PATTERNS):
+                return True
     return False
 
 
@@ -784,18 +837,21 @@ def _check_sandbox(doc: dict, issues: list, info: list) -> None:
         })
 
 
+_MAX_AGENTS_LOWER = 1
+_MAX_AGENTS_UPPER = 64
+
+
 def _check_dashboard(doc: dict, issues: list, info: list) -> None:
     """Run dashboard-specific checks."""
     dashboard = doc.get("dashboard", {})
     if isinstance(dashboard, dict):
         sandbox_cmd = dashboard.get("sandbox_command", "agent-sandbox")
-        # Check if sandbox_command exists
-        import shutil
-        if shutil.which(sandbox_cmd):
+        sandbox_cmd_path = shutil.which(sandbox_cmd)
+        if sandbox_cmd_path:
             info.append({
                 "level": "ok",
                 "key": "sandbox_command",
-                "message": f"sandbox_command found: {shutil.which(sandbox_cmd)}",
+                "message": f"sandbox_command found: {sandbox_cmd_path}",
             })
         else:
             issues.append({
@@ -817,6 +873,19 @@ def _check_dashboard(doc: dict, issues: list, info: list) -> None:
                 "key": "sandbox_config",
                 "message": f"Sandbox config not found at {sandbox_config}",
             })
+
+        # max_agents bounds
+        max_agents = dashboard.get("max_agents")
+        if isinstance(max_agents, int):
+            if max_agents < _MAX_AGENTS_LOWER or max_agents > _MAX_AGENTS_UPPER:
+                issues.append({
+                    "level": "warn",
+                    "key": "max_agents",
+                    "message": (
+                        f"max_agents = {max_agents} is outside the recommended range "
+                        f"[{_MAX_AGENTS_LOWER}, {_MAX_AGENTS_UPPER}]."
+                    ),
+                })
 
     # Check agent overrides
     agents_overrides = doc.get("agents", {})
@@ -937,26 +1006,42 @@ def cmd_validate(args) -> int:
             continue
         known_keys = set(fields.keys()) | _DYNAMIC_KEYS
         for key in section:
-            if key not in known_keys and not _is_agent_or_provider_section(key):
+            if key not in known_keys and not _is_agent_or_provider_section(key, parsed):
                 issues.append({
                     "level": "warn",
                     "message": f"[{section_name}].{key} is not a recognized config key",
                 })
 
-    # Validate provider sections (top-level and agent-specific)
+    # Validate provider sections — top-level and agent-specific
+    _PROVIDER_FIELDS = set(PROVIDER_FIELDS.keys())
+    provider_sections: list[tuple[str, dict]] = []
     for section_name in ("providers", "profiles"):
         section = parsed.get(section_name)
-        if not isinstance(section, dict):
+        if isinstance(section, dict):
+            provider_sections.append((section_name, section))
+    # Agent-specific [<agent>.providers.*] / [<agent>.profiles.*]
+    for top_key, top_val in parsed.items():
+        if not isinstance(top_val, dict):
             continue
+        for sub in ("providers", "profiles"):
+            nested = top_val.get(sub)
+            if isinstance(nested, dict):
+                provider_sections.append((f"{top_key}.{sub}", nested))
+
+    for section_label, section in provider_sections:
         for prov_name, prov_val in section.items():
             if not isinstance(prov_val, dict):
                 continue
-            for key in prov_val:
-                if key not in ("description", "env", "env_unset", "default_args") and not isinstance(prov_val[key], dict):
-                    issues.append({
-                        "level": "warn",
-                        "message": f"[{section_name}.{prov_name}].{key} is not a recognized provider field",
-                    })
+            for key, val in prov_val.items():
+                if key in _PROVIDER_FIELDS:
+                    continue
+                # Allow nested sub-tables (e.g. extension fields) without warning
+                if isinstance(val, dict):
+                    continue
+                issues.append({
+                    "level": "warn",
+                    "message": f"[{section_label}.{prov_name}].{key} is not a recognized provider field",
+                })
 
     # Output
     if args.json:
@@ -978,10 +1063,23 @@ def cmd_validate(args) -> int:
     return 1 if any(i["level"] == "error" for i in issues) else 0
 
 
-def _is_agent_or_provider_section(key: str) -> bool:
-    """Check if a key looks like an agent name (which can have dynamic sub-keys)."""
-    _KNOWN_AGENTS = {"claude", "codex", "gemini", "aider", "opencode", "amp", "pi", "bash"}
-    return key in _KNOWN_AGENTS or key.replace("-", "") in _KNOWN_AGENTS
+def _is_agent_or_provider_section(key: str, parsed: dict) -> bool:
+    """Detect whether a top-level key is an agent override section.
+
+    Structural detection (no hardcoded list): a top-level key is treated as an
+    agent section when it is itself a table containing nested `providers` or
+    `profiles` sub-tables, or when it appears in `[agents.<name>]` (dashboard
+    style). This lets users define custom agents without false-positive
+    "unrecognized config key" warnings.
+    """
+    val = parsed.get(key)
+    if isinstance(val, dict):
+        if any(isinstance(val.get(sub), dict) for sub in ("providers", "profiles")):
+            return True
+    agents = parsed.get("agents")
+    if isinstance(agents, dict) and key in agents:
+        return True
+    return False
 
 
 def _check_permissions(path: Path, quiet: bool = False) -> None:
@@ -999,86 +1097,98 @@ def _check_permissions(path: Path, quiet: bool = False) -> None:
 
 # ── Argument parser ──────────────────────────────────────────────────────
 
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        prog="lince-config",
-        description="Structured CLI for reading and editing LINCE configuration.",
-    )
-    sub = parser.add_subparsers(dest="command", help="Available commands")
-
-    # ── Shared target flag ─────────────────────────────────────
-    target_flags = lambda p: p.add_argument(
+def _add_target_flag(p: argparse.ArgumentParser) -> None:
+    p.add_argument(
         "--target", "-t",
         choices=["sandbox", "dashboard"],
         default="sandbox",
         help="Which config to operate on (default: sandbox)",
     )
-    json_flags = lambda p: p.add_argument(
+
+
+def _add_json_flag(p: argparse.ArgumentParser) -> None:
+    p.add_argument(
         "--json", "-j",
         action="store_true",
         help="Output in JSON format",
     )
-    quiet_flags = lambda p: p.add_argument(
+
+
+def _add_quiet_flag(p: argparse.ArgumentParser) -> None:
+    p.add_argument(
         "--quiet", "-q",
         action="store_true",
         help="Suppress confirmation output",
     )
 
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="lince-config",
+        description="Structured CLI for reading and editing LINCE configuration.",
+    )
+    parser.add_argument(
+        "--version", "-V",
+        action="version",
+        version=f"%(prog)s {__version__}",
+    )
+    sub = parser.add_subparsers(dest="command", help="Available commands")
+
     # ── get ─────────────────────────────────────────────────────
     p_get = sub.add_parser("get", help="Read a config value")
     p_get.add_argument("key", help="Dotted key path (e.g. security.unshare_net)")
-    target_flags(p_get)
-    json_flags(p_get)
+    _add_target_flag(p_get)
+    _add_json_flag(p_get)
     p_get.set_defaults(func=cmd_get)
 
     # ── set ─────────────────────────────────────────────────────
     p_set = sub.add_parser("set", help="Set a config value")
     p_set.add_argument("key", help="Dotted key path (e.g. providers.vertex.description)")
     p_set.add_argument("value", help="Value to set (auto-coerced: bool, int, list, string)")
-    target_flags(p_set)
-    quiet_flags(p_set)
+    _add_target_flag(p_set)
+    _add_quiet_flag(p_set)
     p_set.set_defaults(func=cmd_set)
 
     # ── append ──────────────────────────────────────────────────
     p_append = sub.add_parser("append", help="Append a value to a list")
     p_append.add_argument("key", help="Dotted key path to a list")
     p_append.add_argument("value", help="Value to append")
-    target_flags(p_append)
-    quiet_flags(p_append)
+    _add_target_flag(p_append)
+    _add_quiet_flag(p_append)
     p_append.set_defaults(func=cmd_append)
 
     # ── remove ──────────────────────────────────────────────────
     p_remove = sub.add_parser("remove", help="Remove a value from a list")
     p_remove.add_argument("key", help="Dotted key path to a list")
     p_remove.add_argument("value", help="Value to remove")
-    target_flags(p_remove)
-    quiet_flags(p_remove)
+    _add_target_flag(p_remove)
+    _add_quiet_flag(p_remove)
     p_remove.set_defaults(func=cmd_remove)
 
     # ── unset ───────────────────────────────────────────────────
     p_unset = sub.add_parser("unset", help="Remove a config key or section")
     p_unset.add_argument("key", help="Dotted key path to remove")
-    target_flags(p_unset)
-    quiet_flags(p_unset)
+    _add_target_flag(p_unset)
+    _add_quiet_flag(p_unset)
     p_unset.set_defaults(func=cmd_unset)
 
     # ── list ────────────────────────────────────────────────────
     p_list = sub.add_parser("list", help="List config sections or entries")
     p_list.add_argument("section", nargs="?", help="Section to list (e.g. providers, agents)")
-    target_flags(p_list)
-    json_flags(p_list)
+    _add_target_flag(p_list)
+    _add_json_flag(p_list)
     p_list.set_defaults(func=cmd_list)
 
     # ── check ───────────────────────────────────────────────────
     p_check = sub.add_parser("check", help="Run diagnostic checks")
-    target_flags(p_check)
-    json_flags(p_check)
+    _add_target_flag(p_check)
+    _add_json_flag(p_check)
     p_check.set_defaults(func=cmd_check)
 
     # ── validate ────────────────────────────────────────────────
     p_validate = sub.add_parser("validate", help="Validate config structure")
-    target_flags(p_validate)
-    json_flags(p_validate)
+    _add_target_flag(p_validate)
+    _add_json_flag(p_validate)
     p_validate.set_defaults(func=cmd_validate)
 
     return parser

--- a/lince-config/lince-config
+++ b/lince-config/lince-config
@@ -1,0 +1,1101 @@
+#!/usr/bin/env python3
+"""lince-config — Structured CLI for reading and editing LINCE configuration files.
+
+Reads and writes TOML config files for both the sandbox (agent-sandbox) and
+the dashboard (lince-dashboard), preserving comments and formatting via tomlkit.
+
+Usage:
+    lince config get <dotted.key> [--target sandbox|dashboard] [--json]
+    lince config set <dotted.key> <value> [--target sandbox|dashboard]
+    lince config append <dotted.key> <value> [--target sandbox|dashboard]
+    lince config remove <dotted.key> <value> [--target sandbox|dashboard]
+    lince config unset <dotted.key> [--target sandbox|dashboard]
+    lince config list [section] [--target sandbox|dashboard] [--json]
+    lince config check [--target sandbox|dashboard] [--json]
+    lince config validate [--target sandbox|dashboard] [--json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import stat
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ImportError:
+    print("Error: Python 3.11+ required (for tomllib).", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    import tomlkit
+    from tomlkit.items import Table, InlineTable, AoT, Item
+except ImportError:
+    print(
+        "Error: 'tomlkit' is required. Install it with:\n"
+        "  pip install tomlkit",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+# ── Constants ────────────────────────────────────────────────────────────
+
+SANDBOX_DIR = Path.home() / ".agent-sandbox"
+DASHBOARD_DIR = Path.home() / ".config" / "lince-dashboard"
+
+CONFIG_FILES = {
+    "sandbox": [
+        Path.cwd() / ".agent-sandbox" / "config.toml",  # project-local
+        SANDBOX_DIR / "config.toml",                      # global
+    ],
+    "dashboard": [
+        DASHBOARD_DIR / "config.toml",
+    ],
+}
+
+AGENTS_DEFAULTS_SEARCH = [
+    Path.cwd() / ".agent-sandbox" / "agents-defaults.toml",
+    SANDBOX_DIR / "agents-defaults.toml",
+    Path(__file__).resolve().parent.parent / "sandbox" / "agents-defaults.toml",
+]
+
+# All known top-level sections and their schemas for validation.
+# Format: section -> {key: (type, required, description)}
+SANDBOX_SCHEMA = {
+    "sandbox": {
+        "extra_rw": (list, False, "Extra directories the agent can write to"),
+        "ro_dirs": (list, False, "Directories the agent can read but not write"),
+        "persist_toolchains": (bool, False, "Persist build-tool caches between sessions"),
+        "auto_expose_path": (bool, False, "Auto-detect $PATH entries under $HOME"),
+        "home_ro_dirs": (list, False, "Additional home subdirectories to expose read-only"),
+        "default_provider": (str, False, "Default provider when -P is not specified"),
+        "backend": (str, False, "Sandbox backend: agent-sandbox, nono, or auto"),
+    },
+    "security": {
+        "unshare_pid": (bool, False, "PID namespace: hide host processes"),
+        "new_session": (bool, False, "New terminal session"),
+        "block_git_push": (bool, False, "Block git push via wrapper script"),
+        "credential_proxy": (bool, False, "Intercept API calls and inject credentials on host"),
+        "unshare_net": (bool, False, "Network namespace isolation"),
+        "allow_domains": (list, False, "Extra hosts the credential proxy allows"),
+    },
+    "credential_proxy": {
+        "blocked_hosts": (list, False, "Extra hosts to block"),
+    },
+    "git": {
+        "strip_sections": (list, False, "Regex patterns for .gitconfig section stripping"),
+    },
+    "env": {
+        "passthrough": (list, False, "Host environment variables to pass into sandbox"),
+    },
+    "logging": {
+        "enabled": (bool, False, "Enable transcript logging by default"),
+        "dir": (str, False, "Directory for log files"),
+    },
+    "snapshot": {
+        "auto_project": (bool, False, "Auto-snapshot project before each run"),
+        "auto_config": (bool, False, "Auto-snapshot agent config before each run"),
+        "max_project_snapshots": (int, False, "Max project snapshots to keep"),
+        "max_config_snapshots": (int, False, "Max config snapshots to keep"),
+        "project_exclude": (list, False, "Directories excluded from snapshots"),
+    },
+    "claude": {
+        "config_dir": (str, False, "Sandbox isolated copy of Claude config directory"),
+        "use_real_config": (bool, False, "Use real ~/.claude directly"),
+    },
+}
+
+DASHBOARD_SCHEMA = {
+    "dashboard": {
+        "default_provider": (str, False, "Default provider for new agents"),
+        "sandbox_config_path": (str, False, "Path to sandbox config"),
+        "default_project_dir": (str, False, "Default working directory for new agents"),
+        "sandbox_command": (str, False, "Path to agent-sandbox binary"),
+        "agent_layout": (str, False, "How agent panes are created (floating/tiled)"),
+        "focus_mode": (str, False, "How focusing works (floating/replace)"),
+        "status_method": (str, False, "Status detection method (pipe/file)"),
+        "max_agents": (int, False, "Maximum concurrent agents"),
+        "sandbox_backend": (str, False, "Sandbox backend preference"),
+        "default_agent_type": (str, False, "Default agent type for new agents"),
+    },
+}
+
+# Agent fields (shared between sandbox agents.* and dashboard agents.*)
+AGENT_FIELDS = {
+    "command": (str, True, "Binary name to execute"),
+    "default_args": (list, False, "Default CLI arguments"),
+    "env": (dict, False, "Extra environment variables"),
+    "home_ro_dirs": (list, False, "Home subdirs to bind read-only"),
+    "home_rw_dirs": (list, False, "Home subdirs to bind read-write"),
+    "bwrap_conflict": (bool, False, "Agent uses bwrap internally"),
+    "disable_inner_sandbox_args": (list, False, "Args to disable agent's own sandbox"),
+}
+
+DASHBOARD_AGENT_FIELDS = {
+    "command": (list, True, "Command template with placeholders"),
+    "pane_title_pattern": (str, True, "Pattern to match Zellij pane titles"),
+    "status_pipe_name": (str, True, "Zellij pipe name for status messages"),
+    "display_name": (str, True, "Full name shown in UI"),
+    "short_label": (str, True, "3-char label for table column"),
+    "color": (str, True, "ANSI color name"),
+    "sandboxed": (bool, True, "Whether agent runs inside sandbox"),
+    "has_native_hooks": (bool, False, "Agent sends its own status events"),
+    "providers": (list, False, "Provider discovery mode"),
+    "sandbox_backend": (str, False, "Per-agent sandbox backend override"),
+    "sandbox_level": (str, False, "Sandbox isolation level"),
+    "env_vars": (dict, False, "Environment variables for the agent"),
+    "event_map": (dict, False, "Custom event-to-status mapping"),
+}
+
+PROVIDER_FIELDS = {
+    "description": (str, False, "Human-readable label"),
+    "env": (dict, False, "Environment variables injected via --setenv"),
+    "env_unset": (list, False, "Environment variables to explicitly unset"),
+    "default_args": (list, False, "Override agent default_args when active"),
+}
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+def _aggregate_dynamic_section(doc: dict, section: str) -> dict | None:
+    """For dynamic sections like 'providers'/'profiles'/'agents', aggregate
+    from top-level and all agent-specific sub-sections."""
+    if section not in ("providers", "profiles", "agents"):
+        return None
+
+    result = {}
+    # Top-level [providers.*] / [profiles.*] / [agents.*]
+    top = doc.get(section)
+    if isinstance(top, dict):
+        for k, v in top.items():
+            result[k] = _python_value_to_json(v)
+
+    # Agent-specific [<agent>.providers.*] / [<agent>.profiles.*]
+    if section in ("providers", "profiles"):
+        for agent_key, agent_val in doc.items():
+            if isinstance(agent_val, dict):
+                sub = agent_val.get(section)
+                if isinstance(sub, dict):
+                    for pk, pv in sub.items():
+                        full_key = f"{agent_key}.{pk}"
+                        result[full_key] = _python_value_to_json(pv)
+
+    return result if result else None
+
+
+def _resolve_config_path(target: str) -> Path | None:
+    """Find the primary config file for the given target."""
+    for candidate in CONFIG_FILES.get(target, []):
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _resolve_all_config_paths(target: str) -> list[Path]:
+    """Return all existing config files for the target (project-local first)."""
+    return [p for p in CONFIG_FILES.get(target, []) if p.is_file()]
+
+
+def _load_tomlkit(path: Path) -> tomlkit.TOMLDocument:
+    """Load a TOML file preserving comments and formatting via tomlkit."""
+    with open(path, "r", encoding="utf-8") as fh:
+        return tomlkit.load(fh)
+
+
+def _save_tomlkit(doc: tomlkit.TOMLDocument, path: Path) -> None:
+    """Save a tomlkit document back to file, preserving formatting."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        tomlkit.dump(doc, fh)
+
+
+def _dotted_get(doc: tomlkit.TOMLDocument, key: str):
+    """Navigate a dotted key path into a tomlkit document.
+
+    Supports:
+        "security.unshare_net"  -> doc["security"]["unshare_net"]
+        "providers.vertex.env"  -> doc["providers"]["vertex"]["env"]
+        "agents.claude"         -> doc["agents"]["claude"]
+
+    Returns (value, found).
+    """
+    parts = key.split(".")
+    current = doc
+    for part in parts:
+        if isinstance(current, dict) and part in current:
+            current = current[part]
+        else:
+            return None, False
+    return current, True
+
+
+def _dotted_set(doc: tomlkit.TOMLDocument, key: str, value) -> None:
+    """Set a value at a dotted key path, creating intermediate tables as needed."""
+    parts = key.split(".")
+    current = doc
+    for part in parts[:-1]:
+        if part not in current:
+            current[part] = tomlkit.table()
+        current = current[part]
+
+    leaf = parts[-1]
+    current[leaf] = _coerce_value(value, leaf)
+
+
+def _dotted_unset(doc: tomlkit.TOMLDocument, key: str) -> bool:
+    """Remove a key or section at a dotted path. Returns True if anything was removed."""
+    parts = key.split(".")
+    current = doc
+    # Navigate to parent
+    for part in parts[:-1]:
+        if isinstance(current, dict) and part in current:
+            current = current[part]
+        else:
+            return False
+
+    leaf = parts[-1]
+    if isinstance(current, dict) and leaf in current:
+        del current[leaf]
+        return True
+    return False
+
+
+def _coerce_value(raw: str, key_hint: str = ""):
+    """Parse a CLI string value into the appropriate Python type.
+
+    Rules:
+        "true"/"false"  -> bool
+        bare integer    -> int
+        [...]           -> parsed as JSON list
+        {...}           -> parsed as JSON dict
+        otherwise       -> str
+    """
+    s = raw.strip()
+
+    # Boolean
+    if s.lower() == "true":
+        return True
+    if s.lower() == "false":
+        return False
+
+    # Integer
+    if re.fullmatch(r"-?\d+", s):
+        return int(s)
+
+    # JSON list or dict
+    if s.startswith("[") or s.startswith("{"):
+        try:
+            return json.loads(s)
+        except json.JSONDecodeError:
+            pass  # fall through to string
+
+    return s
+
+
+def _python_value_to_json(val):
+    """Convert a tomlkit value to a JSON-serializable Python value."""
+    if isinstance(val, (bool, int, float, str)):
+        return val
+    if isinstance(val, (list, tuple)):
+        return [_python_value_to_json(v) for v in val]
+    if isinstance(val, dict):
+        return {k: _python_value_to_json(v) for k, v in val.items()}
+    # tomlkit item types
+    if hasattr(val, "value"):
+        return _python_value_to_json(val.value)
+    return str(val)
+
+
+def _format_value(val) -> str:
+    """Format a value for human-readable output."""
+    if val is None:
+        return "(not set)"
+    if isinstance(val, bool):
+        return str(val).lower()
+    if isinstance(val, dict):
+        lines = []
+        for k, v in val.items():
+            if isinstance(v, dict):
+                lines.append(f"{k}:")
+                for kk, vv in v.items():
+                    lines.append(f"  {kk} = {_format_value(vv)}")
+            elif isinstance(v, list):
+                lines.append(f"{k} = {_format_value(v)}")
+            else:
+                lines.append(f"{k} = {_format_value(v)}")
+        return "\n".join(lines)
+    if isinstance(val, list):
+        if not val:
+            return "[]"
+        return "[" + ", ".join(str(v) for v in val) + "]"
+    return str(val)
+
+
+def _find_schema_section(key: str, target: str) -> dict | None:
+    """Find the schema definition for a dotted key's parent section."""
+    parts = key.split(".")
+    schema = SANDBOX_SCHEMA if target == "sandbox" else DASHBOARD_SCHEMA
+    if parts[0] in schema:
+        return schema[parts[0]]
+    return None
+
+
+# ── Commands ─────────────────────────────────────────────────────────────
+
+def cmd_get(args) -> int:
+    """Read and print a config value."""
+    target = args.target
+    key = args.key
+
+    config_path = _resolve_config_path(target)
+    if config_path is None:
+        print(f"Error: no {target} config file found.", file=sys.stderr)
+        return 1
+
+    doc = _load_tomlkit(config_path)
+    val, found = _dotted_get(doc, key)
+
+    if not found:
+        # Also check merged view for sandbox
+        if target == "sandbox":
+            merged = _get_merged_sandbox_view()
+            val, found = _dotted_get_dict(merged, key)
+        if not found:
+            print(f"(not set): {key}", file=sys.stderr)
+            return 1
+
+    if args.json:
+        print(json.dumps(_python_value_to_json(val), indent=2))
+    else:
+        print(_format_value(val))
+    return 0
+
+
+def _dotted_get_dict(d: dict, key: str):
+    """Like _dotted_get but for plain dicts."""
+    parts = key.split(".")
+    current = d
+    for part in parts:
+        if isinstance(current, dict) and part in current:
+            current = current[part]
+        else:
+            return None, False
+    return current, True
+
+
+def _get_merged_sandbox_view() -> dict:
+    """Load sandbox config with merge (global + project-local), plain dict."""
+    global_path = SANDBOX_DIR / "config.toml"
+    local_path = Path.cwd() / ".agent-sandbox" / "config.toml"
+
+    result = {}
+    if global_path.is_file():
+        with open(global_path, "rb") as fh:
+            result = tomllib.load(fh)
+    if local_path.is_file():
+        with open(local_path, "rb") as fh:
+            overlay = tomllib.load(fh)
+        result = _deep_merge_dict(result, overlay)
+    return result
+
+
+def _deep_merge_dict(base: dict, overlay: dict) -> dict:
+    """Deep-merge overlay into base (lists append, scalars replace)."""
+    result = dict(base)
+    for k, v in overlay.items():
+        if k in result and isinstance(result[k], dict) and isinstance(v, dict):
+            result[k] = _deep_merge_dict(result[k], v)
+        elif k in result and isinstance(result[k], list) and isinstance(v, list):
+            seen = set()
+            merged = []
+            for item in result[k] + v:
+                key = repr(item)
+                if key not in seen:
+                    seen.add(key)
+                    merged.append(item)
+            result[k] = merged
+        else:
+            result[k] = v
+    return result
+
+
+def cmd_set(args) -> int:
+    """Set a config value."""
+    target = args.target
+    key = args.key
+    value = args.value
+
+    config_path = _resolve_config_path(target)
+    if config_path is None:
+        # If user is setting something on the global sandbox config and it
+        # doesn't exist yet, try to create it
+        if target == "sandbox":
+            config_path = SANDBOX_DIR / "config.toml"
+            if not config_path.is_file():
+                print(
+                    f"Error: {config_path} does not exist. "
+                    f"Run 'agent-sandbox init' first.",
+                    file=sys.stderr,
+                )
+                return 1
+        else:
+            print(f"Error: no {target} config file found.", file=sys.stderr)
+            return 1
+
+    doc = _load_tomlkit(config_path)
+    _dotted_set(doc, key, value)
+    _save_tomlkit(doc, config_path)
+
+    # Verify file permissions (config may contain API keys)
+    _check_permissions(config_path, quiet=args.quiet)
+
+    if not args.quiet:
+        print(f"Set {key} in {config_path}")
+    return 0
+
+
+def cmd_append(args) -> int:
+    """Append a value to a list config key."""
+    target = args.target
+    key = args.key
+    value = args.value
+
+    config_path = _resolve_config_path(target)
+    if config_path is None:
+        print(f"Error: no {target} config file found.", file=sys.stderr)
+        return 1
+
+    doc = _load_tomlkit(config_path)
+    current, found = _dotted_get(doc, key)
+
+    if not found:
+        # Create the list
+        _dotted_set(doc, key, f"[{json.dumps(_coerce_value(value, key))}]")
+    elif isinstance(current, list):
+        coerced = _coerce_value(value, key)
+        if coerced not in [_python_value_to_json(v) for v in current]:
+            current.append(coerced)
+        else:
+            if not args.quiet:
+                print(f"Value already in {key}, skipping.")
+            return 0
+    else:
+        print(f"Error: {key} is not a list (found {type(current).__name__}).", file=sys.stderr)
+        return 1
+
+    _save_tomlkit(doc, config_path)
+    if not args.quiet:
+        print(f"Appended to {key} in {config_path}")
+    return 0
+
+
+def cmd_remove(args) -> int:
+    """Remove a value from a list config key."""
+    target = args.target
+    key = args.key
+    value = args.value
+
+    config_path = _resolve_config_path(target)
+    if config_path is None:
+        print(f"Error: no {target} config file found.", file=sys.stderr)
+        return 1
+
+    doc = _load_tomlkit(config_path)
+    current, found = _dotted_get(doc, key)
+
+    if not found or not isinstance(current, list):
+        print(f"Error: {key} is not a list or not set.", file=sys.stderr)
+        return 1
+
+    coerced = _coerce_value(value, key)
+    json_vals = [_python_value_to_json(v) for v in current]
+    if coerced not in json_vals:
+        print(f"Value not found in {key}.", file=sys.stderr)
+        return 1
+
+    idx = json_vals.index(coerced)
+    del current[idx]
+
+    _save_tomlkit(doc, config_path)
+    if not args.quiet:
+        print(f"Removed from {key} in {config_path}")
+    return 0
+
+
+def cmd_unset(args) -> int:
+    """Remove a config key or entire section."""
+    target = args.target
+    key = args.key
+
+    config_path = _resolve_config_path(target)
+    if config_path is None:
+        print(f"Error: no {target} config file found.", file=sys.stderr)
+        return 1
+
+    doc = _load_tomlkit(config_path)
+    if _dotted_unset(doc, key):
+        _save_tomlkit(doc, config_path)
+        if not args.quiet:
+            print(f"Unset {key} in {config_path}")
+        return 0
+    else:
+        print(f"Key not found: {key}", file=sys.stderr)
+        return 1
+
+
+def cmd_list(args) -> int:
+    """List config sections or entries."""
+    target = args.target
+    section = args.section
+
+    config_path = _resolve_config_path(target)
+    if config_path is None:
+        print(f"Error: no {target} config file found.", file=sys.stderr)
+        return 1
+
+    doc = _load_tomlkit(config_path)
+
+    if section:
+        val, found = _dotted_get(doc, section)
+        if not found:
+            # Try merged view for sandbox
+            if target == "sandbox":
+                merged = _get_merged_sandbox_view()
+                val, found = _dotted_get_dict(merged, section)
+        if not found:
+            # For common dynamic sections (providers, profiles, agents),
+            # try aggregating from all agent-specific sub-sections
+            val = _aggregate_dynamic_section(doc, section)
+            if val is not None:
+                found = True
+        if not found:
+            if args.json:
+                print(json.dumps({}))
+            else:
+                print(f"  (section '{section}' not found)")
+            return 0
+
+        if args.json:
+            print(json.dumps(_python_value_to_json(val) if val is not None else {}, indent=2))
+        else:
+            if isinstance(val, dict):
+                if not val:
+                    print("  (empty)")
+                else:
+                    for k, v in val.items():
+                        print(f"  {k} = {_format_value(v)}")
+            elif isinstance(val, list):
+                for v in val:
+                    print(f"  {_format_value(v)}")
+            else:
+                print(_format_value(val))
+    else:
+        # List all top-level sections
+        if args.json:
+            sections = {}
+            for k, v in doc.items():
+                sections[k] = _python_value_to_json(v) if isinstance(v, (dict, list)) else str(v)
+            # Add merged info for sandbox
+            if target == "sandbox":
+                paths = _resolve_all_config_paths("sandbox")
+                sections["_files"] = [str(p) for p in paths]
+            print(json.dumps(sections, indent=2))
+        else:
+            print(f"Config: {config_path}")
+            if target == "sandbox":
+                paths = _resolve_all_config_paths("sandbox")
+                if len(paths) > 1:
+                    print(f"  (merged from: {', '.join(str(p) for p in paths)})")
+            print()
+            for k, v in doc.items():
+                if isinstance(v, dict):
+                    key_count = len(v)
+                    print(f"  [{k}]  ({key_count} keys)")
+                elif isinstance(v, list):
+                    print(f"  {k} = [{len(v)} items]")
+                else:
+                    print(f"  {k} = {_format_value(v)}")
+    return 0
+
+
+def cmd_check(args) -> int:
+    """Run diagnostic checks on the configuration."""
+    target = args.target
+    issues: list[dict] = []
+    info: list[dict] = []
+
+    config_path = _resolve_config_path(target)
+    if config_path is None:
+        msg = f"No {target} config file found."
+        if args.json:
+            print(json.dumps({"error": msg}))
+        else:
+            print(f"✗ {msg}")
+        return 1
+
+    doc = _load_tomlkit(config_path)
+
+    # ── File permissions ─────────────────────────────────────────────
+    mode = config_path.stat().st_mode
+    perms = stat.filemode(mode)
+    has_api_keys = _has_sensitive_data(doc)
+    world_readable = bool(mode & stat.S_IROTH)
+    if has_api_keys and world_readable:
+        issues.append({
+            "level": "warn",
+            "key": "permissions",
+            "message": f"{config_path} is world-readable. Run: chmod 600 {config_path}",
+        })
+    else:
+        info.append({"level": "ok", "key": "permissions", "message": f"File permissions: {perms}"})
+
+    # ── Sandbox-specific checks ──────────────────────────────────────
+    if target == "sandbox":
+        _check_sandbox(doc, issues, info)
+
+    # ── Dashboard-specific checks ────────────────────────────────────
+    if target == "dashboard":
+        _check_dashboard(doc, issues, info)
+
+    # ── Output ───────────────────────────────────────────────────────
+    if args.json:
+        result = {
+            "config_file": str(config_path),
+            "issues": issues,
+            "info": info,
+            "ok": len(issues) == 0,
+        }
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"Config: {config_path}")
+        print()
+        for i in info:
+            icon = "✓" if i["level"] == "ok" else "ℹ"
+            print(f"  {icon} {i['message']}")
+        for i in issues:
+            icon = "✗" if i["level"] == "error" else "⚠"
+            print(f"  {icon} {i['message']}")
+        print()
+        if issues:
+            print(f"  {len(issues)} issue(s) found.")
+        else:
+            print(f"  All checks passed.")
+
+    return 1 if any(i["level"] == "error" for i in issues) else 0
+
+
+def _has_sensitive_data(doc: dict) -> bool:
+    """Check if config contains API keys or secrets."""
+    # Check provider env sections for key-like patterns
+    for key, val in doc.items():
+        if isinstance(val, dict):
+            if _has_sensitive_data(val):
+                return True
+        if isinstance(val, str) and any(
+            kw in key.upper() for kw in ("API_KEY", "SECRET", "TOKEN", "PASSWORD")
+        ):
+            return True
+    return False
+
+
+def _check_sandbox(doc: dict, issues: list, info: list) -> None:
+    """Run sandbox-specific checks."""
+    # Provider check
+    providers = _find_providers(doc)
+    if providers:
+        info.append({
+            "level": "ok",
+            "key": "providers",
+            "message": f"Providers configured: {', '.join(providers)}",
+        })
+    else:
+        info.append({
+            "level": "info",
+            "key": "providers",
+            "message": "No providers configured. Set API keys via [providers.*] or [<agent>.providers.*].",
+        })
+
+    # Default provider
+    sandbox_section = doc.get("sandbox", {})
+    if isinstance(sandbox_section, dict):
+        default = sandbox_section.get("default_provider", "")
+        if default:
+            info.append({
+                "level": "ok",
+                "key": "default_provider",
+                "message": f"Default provider: {default}",
+            })
+        else:
+            info.append({
+                "level": "info",
+                "key": "default_provider",
+                "message": "No default_provider set. Pass -P each time or set sandbox.default_provider.",
+            })
+
+    # Security checks
+    security = doc.get("security", {})
+    if isinstance(security, dict):
+        if security.get("unshare_net") and not security.get("credential_proxy"):
+            issues.append({
+                "level": "warn",
+                "key": "security.unshare_net",
+                "message": "unshare_net is enabled but credential_proxy is off. "
+                           "Paranoid mode requires credential_proxy = true.",
+            })
+        if security.get("credential_proxy"):
+            if not providers:
+                issues.append({
+                    "level": "warn",
+                    "key": "security.credential_proxy",
+                    "message": "credential_proxy is on but no providers with API keys found.",
+                })
+
+    # Agent defaults
+    agents_defaults_path = _find_agents_defaults_path()
+    if agents_defaults_path:
+        info.append({
+            "level": "ok",
+            "key": "agents-defaults",
+            "message": f"Agent defaults: {agents_defaults_path}",
+        })
+
+    # Toolchain dir
+    toolchain_dir = SANDBOX_DIR / "toolchains"
+    if toolchain_dir.is_dir():
+        info.append({
+            "level": "ok",
+            "key": "toolchains",
+            "message": f"Toolchain cache: {toolchain_dir}",
+        })
+
+    # Logging
+    logging_section = doc.get("logging", {})
+    if isinstance(logging_section, dict) and logging_section.get("enabled"):
+        log_dir = logging_section.get("dir", str(SANDBOX_DIR / "logs"))
+        info.append({
+            "level": "ok",
+            "key": "logging",
+            "message": f"Session logging: enabled → {log_dir}",
+        })
+
+
+def _check_dashboard(doc: dict, issues: list, info: list) -> None:
+    """Run dashboard-specific checks."""
+    dashboard = doc.get("dashboard", {})
+    if isinstance(dashboard, dict):
+        sandbox_cmd = dashboard.get("sandbox_command", "agent-sandbox")
+        # Check if sandbox_command exists
+        import shutil
+        if shutil.which(sandbox_cmd):
+            info.append({
+                "level": "ok",
+                "key": "sandbox_command",
+                "message": f"sandbox_command found: {shutil.which(sandbox_cmd)}",
+            })
+        else:
+            issues.append({
+                "level": "warn",
+                "key": "sandbox_command",
+                "message": f"sandbox_command '{sandbox_cmd}' not found in PATH.",
+            })
+
+        sandbox_config = dashboard.get("sandbox_config_path", str(SANDBOX_DIR / "config.toml"))
+        if Path(sandbox_config).expanduser().is_file():
+            info.append({
+                "level": "ok",
+                "key": "sandbox_config",
+                "message": f"Sandbox config: {sandbox_config}",
+            })
+        else:
+            issues.append({
+                "level": "warn",
+                "key": "sandbox_config",
+                "message": f"Sandbox config not found at {sandbox_config}",
+            })
+
+    # Check agent overrides
+    agents_overrides = doc.get("agents", {})
+    if isinstance(agents_overrides, dict) and agents_overrides:
+        info.append({
+            "level": "ok",
+            "key": "agents",
+            "message": f"Agent overrides: {', '.join(agents_overrides.keys())}",
+        })
+
+
+def _find_providers(doc: dict) -> list[str]:
+    """Find all provider names in the config."""
+    providers = []
+    # Top-level [providers.*] and legacy [profiles.*]
+    for section_name in ("providers", "profiles"):
+        section = doc.get(section_name)
+        if isinstance(section, dict):
+            providers.extend(section.keys())
+
+    # Agent-specific [<agent>.providers.*]
+    for key, val in doc.items():
+        if isinstance(val, dict):
+            for subkey in ("providers", "profiles"):
+                sub = val.get(subkey)
+                if isinstance(sub, dict):
+                    for pk in sub.keys():
+                        full = f"{key}.{pk}"
+                        if full not in providers:
+                            providers.append(full)
+
+    return providers
+
+
+def _find_agents_defaults_path() -> Path | None:
+    """Find the agents-defaults.toml path."""
+    for p in AGENTS_DEFAULTS_SEARCH:
+        if p.is_file():
+            return p
+    return None
+
+
+def cmd_validate(args) -> int:
+    """Validate config structure and semantics."""
+    target = args.target
+    issues: list[dict] = []
+
+    config_path = _resolve_config_path(target)
+    if config_path is None:
+        msg = f"No {target} config file found."
+        if args.json:
+            print(json.dumps({"valid": False, "issues": [{"level": "error", "message": msg}]}))
+        else:
+            print(f"✗ {msg}")
+        return 1
+
+    # Parse check
+    try:
+        with open(config_path, "rb") as fh:
+            parsed = tomllib.load(fh)
+    except tomllib.TOMLDecodeError as exc:
+        msg = f"TOML parse error: {exc}"
+        if args.json:
+            print(json.dumps({"valid": False, "issues": [{"level": "error", "message": msg}]}))
+        else:
+            print(f"✗ {msg}")
+        return 1
+
+    # Schema check
+    schema = SANDBOX_SCHEMA if target == "sandbox" else DASHBOARD_SCHEMA
+    for section_name, fields in schema.items():
+        section = parsed.get(section_name)
+        if section is None:
+            continue
+        if not isinstance(section, dict):
+            issues.append({
+                "level": "error",
+                "message": f"[{section_name}] is not a table (found {type(section).__name__})",
+            })
+            continue
+        for key, (expected_type, required, desc) in fields.items():
+            if key not in section:
+                if required:
+                    issues.append({
+                        "level": "error",
+                        "message": f"[{section_name}].{key} is required but missing. {desc}",
+                    })
+                continue
+            val = section[key]
+            if expected_type == bool and not isinstance(val, bool):
+                issues.append({
+                    "level": "error",
+                    "message": f"[{section_name}].{key} should be a boolean, got {type(val).__name__}",
+                })
+            elif expected_type == int and not isinstance(val, int):
+                issues.append({
+                    "level": "error",
+                    "message": f"[{section_name}].{key} should be an integer, got {type(val).__name__}",
+                })
+            elif expected_type == str and not isinstance(val, str):
+                issues.append({
+                    "level": "error",
+                    "message": f"[{section_name}].{key} should be a string, got {type(val).__name__}",
+                })
+            elif expected_type == list and not isinstance(val, list):
+                issues.append({
+                    "level": "error",
+                    "message": f"[{section_name}].{key} should be a list, got {type(val).__name__}",
+                })
+
+    # Check for unknown keys in known sections
+    # Dynamic sub-keys that are valid in any section (providers, profiles, env, etc.)
+    _DYNAMIC_KEYS = {"providers", "profiles", "env", "extra", "overrides", "env_vars"}
+
+    for section_name, fields in schema.items():
+        section = parsed.get(section_name)
+        if not isinstance(section, dict):
+            continue
+        known_keys = set(fields.keys()) | _DYNAMIC_KEYS
+        for key in section:
+            if key not in known_keys and not _is_agent_or_provider_section(key):
+                issues.append({
+                    "level": "warn",
+                    "message": f"[{section_name}].{key} is not a recognized config key",
+                })
+
+    # Validate provider sections (top-level and agent-specific)
+    for section_name in ("providers", "profiles"):
+        section = parsed.get(section_name)
+        if not isinstance(section, dict):
+            continue
+        for prov_name, prov_val in section.items():
+            if not isinstance(prov_val, dict):
+                continue
+            for key in prov_val:
+                if key not in ("description", "env", "env_unset", "default_args") and not isinstance(prov_val[key], dict):
+                    issues.append({
+                        "level": "warn",
+                        "message": f"[{section_name}.{prov_name}].{key} is not a recognized provider field",
+                    })
+
+    # Output
+    if args.json:
+        print(json.dumps({
+            "valid": len([i for i in issues if i["level"] == "error"]) == 0,
+            "issues": issues,
+            "config_file": str(config_path),
+        }, indent=2))
+    else:
+        if issues:
+            for i in issues:
+                icon = "✗" if i["level"] == "error" else "⚠"
+                print(f"  {icon} {i['message']}")
+            errors = len([i for i in issues if i["level"] == "error"])
+            print(f"\n  {errors} error(s), {len(issues) - errors} warning(s).")
+        else:
+            print(f"  ✓ {config_path} is valid.")
+
+    return 1 if any(i["level"] == "error" for i in issues) else 0
+
+
+def _is_agent_or_provider_section(key: str) -> bool:
+    """Check if a key looks like an agent name (which can have dynamic sub-keys)."""
+    _KNOWN_AGENTS = {"claude", "codex", "gemini", "aider", "opencode", "amp", "pi", "bash"}
+    return key in _KNOWN_AGENTS or key.replace("-", "") in _KNOWN_AGENTS
+
+
+def _check_permissions(path: Path, quiet: bool = False) -> None:
+    """Warn if config file containing secrets is world-readable."""
+    if quiet:
+        return
+    mode = path.stat().st_mode
+    if mode & stat.S_IROTH:
+        print(
+            f"⚠ {path} is world-readable. API keys may be exposed.\n"
+            f"  Fix: chmod 600 {path}",
+            file=sys.stderr,
+        )
+
+
+# ── Argument parser ──────────────────────────────────────────────────────
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="lince-config",
+        description="Structured CLI for reading and editing LINCE configuration.",
+    )
+    sub = parser.add_subparsers(dest="command", help="Available commands")
+
+    # ── Shared target flag ─────────────────────────────────────
+    target_flags = lambda p: p.add_argument(
+        "--target", "-t",
+        choices=["sandbox", "dashboard"],
+        default="sandbox",
+        help="Which config to operate on (default: sandbox)",
+    )
+    json_flags = lambda p: p.add_argument(
+        "--json", "-j",
+        action="store_true",
+        help="Output in JSON format",
+    )
+    quiet_flags = lambda p: p.add_argument(
+        "--quiet", "-q",
+        action="store_true",
+        help="Suppress confirmation output",
+    )
+
+    # ── get ─────────────────────────────────────────────────────
+    p_get = sub.add_parser("get", help="Read a config value")
+    p_get.add_argument("key", help="Dotted key path (e.g. security.unshare_net)")
+    target_flags(p_get)
+    json_flags(p_get)
+    p_get.set_defaults(func=cmd_get)
+
+    # ── set ─────────────────────────────────────────────────────
+    p_set = sub.add_parser("set", help="Set a config value")
+    p_set.add_argument("key", help="Dotted key path (e.g. providers.vertex.description)")
+    p_set.add_argument("value", help="Value to set (auto-coerced: bool, int, list, string)")
+    target_flags(p_set)
+    quiet_flags(p_set)
+    p_set.set_defaults(func=cmd_set)
+
+    # ── append ──────────────────────────────────────────────────
+    p_append = sub.add_parser("append", help="Append a value to a list")
+    p_append.add_argument("key", help="Dotted key path to a list")
+    p_append.add_argument("value", help="Value to append")
+    target_flags(p_append)
+    quiet_flags(p_append)
+    p_append.set_defaults(func=cmd_append)
+
+    # ── remove ──────────────────────────────────────────────────
+    p_remove = sub.add_parser("remove", help="Remove a value from a list")
+    p_remove.add_argument("key", help="Dotted key path to a list")
+    p_remove.add_argument("value", help="Value to remove")
+    target_flags(p_remove)
+    quiet_flags(p_remove)
+    p_remove.set_defaults(func=cmd_remove)
+
+    # ── unset ───────────────────────────────────────────────────
+    p_unset = sub.add_parser("unset", help="Remove a config key or section")
+    p_unset.add_argument("key", help="Dotted key path to remove")
+    target_flags(p_unset)
+    quiet_flags(p_unset)
+    p_unset.set_defaults(func=cmd_unset)
+
+    # ── list ────────────────────────────────────────────────────
+    p_list = sub.add_parser("list", help="List config sections or entries")
+    p_list.add_argument("section", nargs="?", help="Section to list (e.g. providers, agents)")
+    target_flags(p_list)
+    json_flags(p_list)
+    p_list.set_defaults(func=cmd_list)
+
+    # ── check ───────────────────────────────────────────────────
+    p_check = sub.add_parser("check", help="Run diagnostic checks")
+    target_flags(p_check)
+    json_flags(p_check)
+    p_check.set_defaults(func=cmd_check)
+
+    # ── validate ────────────────────────────────────────────────
+    p_validate = sub.add_parser("validate", help="Validate config structure")
+    target_flags(p_validate)
+    json_flags(p_validate)
+    p_validate.set_defaults(func=cmd_validate)
+
+    return parser
+
+
+# ── Main ─────────────────────────────────────────────────────────────────
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        return 1
+
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lince-config/uninstall.sh
+++ b/lince-config/uninstall.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+INSTALL_DST="$HOME/.local/bin/lince-config"
+
+if [ -f "$INSTALL_DST" ]; then
+    rm "$INSTALL_DST"
+    echo "Removed $INSTALL_DST"
+else
+    echo "lince-config is not installed."
+fi

--- a/lince-config/update.sh
+++ b/lince-config/update.sh
@@ -1,10 +1,35 @@
 #!/usr/bin/env bash
 set -e
 
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INSTALL_DST="$HOME/.local/bin/lince-config"
 
 echo "Updating lince-config..."
+
+# Prerequisites — same checks as install.sh, so a Python downgrade or a missing
+# tomlkit doesn't leave a broken install.
+command -v python3 >/dev/null 2>&1 || { echo -e "${RED}Missing: python3 (3.11+)${NC}"; exit 1; }
+
+PY_OK=$(python3 -c "import sys; print(1 if sys.version_info >= (3, 11) else 0)" 2>/dev/null || echo 0)
+if [ "$PY_OK" = "0" ]; then
+    echo -e "${RED}Python 3.11+ required (for tomllib)${NC}"
+    exit 1
+fi
+
+python3 -c "import tomlkit" 2>/dev/null || {
+    echo -e "${YELLOW}tomlkit not found. Installing...${NC}"
+    pip install --user tomlkit 2>/dev/null || \
+        pip install --user --break-system-packages tomlkit 2>/dev/null || {
+        echo -e "${RED}Failed to install tomlkit. Install manually: pip install tomlkit${NC}"
+        exit 1
+    }
+}
+
 cp "$SCRIPT_DIR/lince-config" "$INSTALL_DST"
 chmod +x "$INSTALL_DST"
-echo "Done. Updated $INSTALL_DST"
+echo -e "${GREEN}Done. Updated $INSTALL_DST${NC}"

--- a/lince-config/update.sh
+++ b/lince-config/update.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_DST="$HOME/.local/bin/lince-config"
+
+echo "Updating lince-config..."
+cp "$SCRIPT_DIR/lince-config" "$INSTALL_DST"
+chmod +x "$INSTALL_DST"
+echo "Done. Updated $INSTALL_DST"

--- a/lince-dashboard/install.sh
+++ b/lince-dashboard/install.sh
@@ -99,7 +99,7 @@ setup_clipboard_backend() {
 }
 
 # ── Step 1: Prerequisites ─────────────────────────────────────────────
-echo -e "${GREEN}[1/12] Checking prerequisites...${NC}"
+echo -e "${GREEN}[1/14] Checking prerequisites...${NC}"
 
 MISSING=()
 
@@ -133,7 +133,7 @@ fi
 echo ""
 
 # ── Step 2: WASM target ───────────────────────────────────────────────
-echo -e "${GREEN}[2/12] Checking wasm32-wasip1 target...${NC}"
+echo -e "${GREEN}[2/14] Checking wasm32-wasip1 target...${NC}"
 
 # Ensure rustup toolchain takes precedence
 export PATH="$HOME/.cargo/bin:$PATH"
@@ -150,7 +150,7 @@ fi
 echo ""
 
 # ── Step 3: Build plugin ──────────────────────────────────────────────
-echo -e "${GREEN}[3/12] Building plugin...${NC}"
+echo -e "${GREEN}[3/14] Building plugin...${NC}"
 
 if ! "$SCRIPT_DIR/plugin/build.sh"; then
     echo -e "${RED}Build failed. Check errors above.${NC}"
@@ -159,7 +159,7 @@ fi
 echo ""
 
 # ── Step 4: Install WASM plugin ───────────────────────────────────────
-echo -e "${GREEN}[4/12] Installing plugin...${NC}"
+echo -e "${GREEN}[4/14] Installing plugin...${NC}"
 
 PLUGIN_DIR="$HOME/.config/zellij/plugins"
 mkdir -p "$PLUGIN_DIR"
@@ -213,7 +213,7 @@ fi
 echo ""
 
 # ── Step 5: Install layouts ───────────────────────────────────────────
-echo -e "${GREEN}[5/12] Installing layouts...${NC}"
+echo -e "${GREEN}[5/14] Installing layouts...${NC}"
 
 LAYOUT_DIR="$HOME/.config/zellij/layouts"
 mkdir -p "$LAYOUT_DIR"
@@ -229,7 +229,7 @@ done
 echo ""
 
 # ── Step 6: Zellij keybinding configuration ──────────────────────────
-echo -e "${GREEN}[6/12] Zellij keybinding configuration...${NC}"
+echo -e "${GREEN}[6/14] Zellij keybinding configuration...${NC}"
 
 ZELLIJ_CONFIG="$HOME/.config/zellij/config.kdl"
 LINCE_ZELLIJ_CONFIG="$SCRIPT_DIR/zellij-config/config.kdl"
@@ -270,7 +270,7 @@ fi
 echo ""
 
 # ── Step 7: Install config ────────────────────────────────────────────
-echo -e "${GREEN}[7/12] Installing configuration...${NC}"
+echo -e "${GREEN}[7/14] Installing configuration...${NC}"
 
 CONFIG_DIR="$HOME/.config/lince-dashboard"
 CONFIG_DST="$CONFIG_DIR/config.toml"
@@ -287,7 +287,7 @@ echo -e "${GREEN}  ✓ Installed: $CONFIG_DST${NC}"
 echo ""
 
 # ── Step 8: Install hooks ─────────────────────────────────────────────
-echo -e "${GREEN}[8/12] Installing agent platform hooks...${NC}"
+echo -e "${GREEN}[8/14] Installing agent platform hooks...${NC}"
 
 if [ -f "$SCRIPT_DIR/hooks/install-hooks.sh" ]; then
     bash "$SCRIPT_DIR/hooks/install-hooks.sh"
@@ -297,7 +297,7 @@ fi
 echo ""
 
 # ── Step 9: Install agents-defaults.toml + agents-template.toml ──────
-echo -e "${GREEN}[9/12] Installing agent defaults and templates...${NC}"
+echo -e "${GREEN}[9/14] Installing agent defaults and templates...${NC}"
 
 AGENTS_DEFAULTS_SRC="$SCRIPT_DIR/agents-defaults.toml"
 AGENTS_DEFAULTS_DST="$CONFIG_DIR/agents-defaults.toml"
@@ -343,7 +343,7 @@ fi
 echo ""
 
 # ── Step 10: Install nono profiles ────────────────────────────────────
-echo -e "${GREEN}[10/13] Installing nono sandbox profiles...${NC}"
+echo -e "${GREEN}[10/14] Installing nono sandbox profiles...${NC}"
 
 NONO_PROFILES_SRC="$SCRIPT_DIR/nono-profiles"
 NONO_PROFILES_DST="$HOME/.config/nono/profiles"
@@ -363,7 +363,7 @@ fi
 echo ""
 
 # ── Step 11: Install lince-setup skill ────────────────────────────────
-echo -e "${GREEN}[11/13] Installing lince-setup skill...${NC}"
+echo -e "${GREEN}[11/14] Installing lince-setup skill...${NC}"
 
 SKILL_SRC="$SCRIPT_DIR/skills/lince-setup"
 SKILL_DST="$HOME/.claude/skills/lince-setup"
@@ -377,8 +377,24 @@ else
 fi
 echo ""
 
-# ── Step 12: Shell aliases ────────────────────────────────────────────
-echo -e "${GREEN}[12/13] Setting up shell aliases...${NC}"
+# ── Step 12: Install lince-configure skill ────────────────────────────
+echo -e "${GREEN}[12/14] Installing lince-configure skill...${NC}"
+
+CONFIGURE_SKILL_SRC="$SCRIPT_DIR/skills/lince-configure"
+CONFIGURE_SKILL_DST="$HOME/.claude/skills/lince-configure"
+
+if [ -d "$CONFIGURE_SKILL_SRC" ]; then
+    mkdir -p "$CONFIGURE_SKILL_DST"
+    cp -r "$CONFIGURE_SKILL_SRC/." "$CONFIGURE_SKILL_DST/"
+    echo -e "${GREEN}  ✓ Installed: $CONFIGURE_SKILL_DST${NC}"
+    echo -e "  ${BLUE}  Requires lince-config CLI (installed by quickstart.sh).${NC}"
+else
+    echo -e "${YELLOW}  ⚠ skills/lince-configure/ not found — skipping${NC}"
+fi
+echo ""
+
+# ── Step 13: Shell aliases ────────────────────────────────────────────
+echo -e "${GREEN}[13/14] Setting up shell aliases...${NC}"
 
 ALIAS_LINES='alias zd="zellij --layout dashboard"
 alias z="zellij"
@@ -399,8 +415,8 @@ for rc in "$HOME/.bashrc" "$HOME/.zshrc"; do
 done
 echo ""
 
-# ── Step 13: VoxCode layout selection ─────────────────────────────────
-echo -e "${GREEN}[13/13] VoxCode layout configuration...${NC}"
+# ── Step 14: VoxCode layout selection ─────────────────────────────────
+echo -e "${GREEN}[14/14] VoxCode layout configuration...${NC}"
 
 if command -v voxcode >/dev/null 2>&1; then
     echo -e "${GREEN}  ✓ voxcode detected${NC}"
@@ -468,7 +484,8 @@ if [ -n "$SELECTED_LEVELS" ]; then
     echo "  Levels:   $SELECTED_LEVELS (added to ~/.config/lince-dashboard/config.toml)"
 fi
 echo "  Nono:     ~/.config/nono/profiles/lince-*.json"
-echo "  Skill:    ~/.claude/skills/lince-setup/"
+echo "  Skills:   ~/.claude/skills/lince-setup/"
+echo "            ~/.claude/skills/lince-configure/"
 echo ""
 echo -e "${GREEN}Sandbox backend:${NC}"
 if [ "$OS_NAME" = "Darwin" ]; then

--- a/lince-dashboard/skills/lince-configure/SKILL.md
+++ b/lince-dashboard/skills/lince-configure/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: lince-configure
+description: Configure LINCE sandbox and dashboard settings in natural language. Use when asked to set up providers, change security levels, modify agent settings, configure API keys, adjust sandbox behavior, or any "how do I configure" question about LINCE. Handles both sandbox (~/.agent-sandbox/config.toml) and dashboard (~/.config/lince-dashboard/config.toml) configuration.
+license: MIT
+compatibility: Requires lince-config CLI installed (lince-config/install.sh). Python 3.11+ with tomlkit.
+metadata:
+  author: lince
+  version: "1.0"
+allowed-tools: Bash(lince-config:*) Read(//home/maeste/.agent-sandbox/**) Read(//home/maeste/.config/lince-dashboard/**)
+---
+
+# lince-configure: Natural Language Configuration for LINCE
+
+Configure LINCE (sandbox + dashboard) through conversation. This skill reads the
+documentation, understands the user's intent, and uses `lince-config` CLI to make
+changes safely — never editing TOML files directly.
+
+## Available Tools
+
+| Tool | Path | Description |
+|------|------|-------------|
+| CLI | `lince-config` | Structured read/write for TOML config (preserves comments/formatting) |
+| Docs | `references/` | Configuration reference docs loaded on-demand |
+
+## CLI Reference (lince-config)
+
+All commands accept `--target sandbox` (default) or `--target dashboard`.
+
+```bash
+# Read
+lince-config get <dotted.key> [--json]                  # e.g. security.unshare_net
+lince-config list [section] [--json]                    # e.g. providers, agents
+
+# Write
+lince-config set <dotted.key> <value> [-q]              # auto-coerces bool/int/str
+lince-config append <dotted.key> <value> [-q]           # append to list (dedup)
+lince-config remove <dotted.key> <value> [-q]           # remove from list
+lince-config unset <dotted.key> [-q]                    # remove key/section
+
+# Diagnostics
+lince-config check [--json]                             # doctor-style checks
+lince-config validate [--json]                          # schema validation
+```
+
+Always use `-q` (quiet) for write operations during guided setup to keep output clean.
+Always use `--json` for read operations to parse results programmatically.
+
+## Configuration Targets
+
+| Target | File | Purpose |
+|--------|------|---------|
+| `sandbox` | `~/.agent-sandbox/config.toml` | Sandbox behavior, providers, agents, security |
+| `dashboard` | `~/.config/lince-dashboard/config.toml` | Dashboard UI, agent types, layout |
+
+## Workflow
+
+### Step 0: Understand Intent
+
+Listen to what the user wants. Common intents:
+
+| User says | They want |
+|-----------|-----------|
+| "Configure Vertex AI" / "Add a provider" | Add/edit a provider (env-var bundle) |
+| "Use paranoid mode" / "Increase security" | Change sandbox level or security settings |
+| "Add API key for..." | Configure a provider env section |
+| "Change default agent" | Set dashboard.default_agent_type |
+| "Allow git push" / "Less restrictive" | Modify security settings |
+| "Configure Codex" / "Add Gemini" | Agent-specific setup |
+| "Show my config" / "What's configured?" | Read and present current config |
+| "Fix this error" / "Something's broken" | Run check + diagnose |
+| "What sandbox level should I use?" | Explain levels, help choose |
+
+### Step 1: Read Current State
+
+Before making changes, always check the current configuration:
+
+```bash
+lince-config list --json                          # all sections
+lince-config list providers --json                # existing providers
+lince-config get <relevant.key> --json            # specific value
+lince-config check --json                         # any issues?
+```
+
+### Step 2: Consult Documentation
+
+Load the relevant reference file for detailed field docs:
+
+| Topic | Reference File |
+|-------|---------------|
+| Sandbox config keys | [references/sandbox-config.md](references/sandbox-config.md) |
+| Dashboard config keys | [references/dashboard-config.md](references/dashboard-config.md) |
+| Sandbox levels explained | [references/sandbox-levels.md](references/sandbox-levels.md) |
+| Provider setup | [references/providers.md](references/providers.md) |
+| Security model | [references/security.md](references/security.md) |
+
+Load the reference ONLY when you need details you don't already know. The most common
+operations are documented inline below.
+
+### Step 3: Make Changes
+
+Use `lince-config set` / `append` / `unset` with `-q` for clean output. Make changes
+one at a time, in logical order.
+
+### Step 4: Verify
+
+After changes, always verify:
+
+```bash
+lince-config check --json
+lince-config validate --json
+lince-config get <changed.key> --json              # confirm the value
+```
+
+### Step 5: Explain
+
+Tell the user what was changed and why, in plain language. Mention any warnings
+from `check` and suggest follow-up actions.
+
+## Common Operations
+
+### Add a Provider (env-var bundle)
+
+Providers are named env-var bundles that switch model provider/account.
+
+**Anthropic Direct API:**
+```bash
+lince-config set providers.anthropic.description "Anthropic Direct API" -q
+lince-config set providers.anthropic.env.ANTHROPIC_API_KEY "sk-ant-..." -q
+```
+
+**Vertex AI for Claude:**
+```bash
+lince-config set claude.providers.vertex.description "Vertex AI" -q
+lince-config set claude.providers.vertex.env.CLAUDE_CODE_USE_VERTEX "1" -q
+lince-config set claude.providers.vertex.env.ANTHROPIC_VERTEX_PROJECT_ID "<project-id>" -q
+lince-config set claude.providers.vertex.env.ANTHROPIC_VERTEX_REGION "us-east5" -q
+```
+
+**Z.AI / GLM:**
+```bash
+lince-config set providers.zai.description "Z.AI / GLM" -q
+lince-config set providers.zai.env.OPENAI_API_KEY "$ZAI_API_KEY" -q
+lince-config set providers.zai.env.OPENAI_BASE_URL "https://open.bigmodel.cn/api/paas/v4" -q
+```
+
+**Set as default:**
+```bash
+lince-config set sandbox.default_provider "<name>" -q
+```
+
+### Configure Security / Sandbox Level
+
+**Enable paranoid (kernel network isolation + credential proxy):**
+```bash
+lince-config set security.unshare_net true -q
+lince-config set security.credential_proxy true -q
+```
+
+**Add network allowlist entries:**
+```bash
+lince-config append security.allow_domains "pypi.org" -q
+lince-config append security.allow_domains "files.pythonhosted.org" -q
+```
+
+**Disable git push blocking (per-project only!):**
+```bash
+# In project-local .agent-sandbox/config.toml:
+lince-config set security.block_git_push false -q
+```
+
+**Enable session logging:**
+```bash
+lince-config set logging.enabled true -q
+lince-config set logging.dir "~/.agent-sandbox/logs" -q
+```
+
+### Configure an Agent
+
+**Change default agent args:**
+```bash
+lince-config set agents.codex.default_args '["--full-auto", "--model", "o4-mini"]' -q
+```
+
+**Add home directory access:**
+```bash
+lince-config append agents.claude.home_ro_dirs ".config/gcloud" -q
+lince-config append agents.codex.home_rw_dirs ".codex" -q
+```
+
+### Dashboard Settings
+
+**Default agent type:**
+```bash
+lince-config set dashboard.default_agent_type "claude" --target dashboard -q
+```
+
+**Agent layout (floating/tiled):**
+```bash
+lince-config set dashboard.agent_layout "tiled" --target dashboard -q
+```
+
+**Max concurrent agents:**
+```bash
+lince-config set dashboard.max_agents 12 --target dashboard -q
+```
+
+### Remove a Provider
+
+```bash
+lince-config unset providers.vertex -q
+# If it was the default, clear that too:
+lince-config get sandbox.default_provider --json
+lince-config set sandbox.default_provider "" -q
+```
+
+## Sandbox Levels Quick Reference
+
+| Level | Network | Filesystem | Use When |
+|-------|---------|------------|----------|
+| `paranoid` | Kernel-isolated, proxy only | Scratch home dirs | Untrusted input, unfamiliar repos |
+| `normal` | Open (inherited) | Standard mounts | Daily work (default) |
+| `permissive` | Open | + gh CLI, cache, known_hosts | Need PRs/GitHub from agent |
+
+Selected per run: `agent-sandbox run --sandbox-level paranoid`
+Or per agent in dashboard config: `sandbox_level = "paranoid"`
+
+## Provider Naming
+
+Providers can be top-level (`[providers.<name>]`) or agent-specific
+(`[<agent>.providers.<name>]`). Agent-specific providers override top-level
+for that agent only. If both exist for the same name, the agent-specific one wins.
+
+```bash
+# Top-level (shared by all agents):
+lince-config set providers.openai.description "OpenAI" -q
+
+# Agent-specific (claude only):
+lince-config set claude.providers.vertex.description "Vertex AI" -q
+```
+
+## Security Notes
+
+- **Never display full API keys in conversation.** If reading a provider env that
+  contains a key, mask it (show first 8 chars + "...").
+- API keys in TOML are fine — the file should be `chmod 600`. `lince-config check`
+  warns if permissions are too open.
+- The `$VAR` syntax in env values means "resolve from host at spawn time" — tell
+  the user they can use literal values or `$VAR` references.
+- When the user sets `security.unshare_net = true`, always remind them that
+  `security.credential_proxy = true` is also needed (paranoid mode).
+
+## Important Rules
+
+1. **Never edit TOML files directly** — always use `lince-config` CLI
+2. **Always read before writing** — check current state first
+3. **Always verify after writing** — run `check` and `validate`
+4. **Mask API keys** when displaying config values
+5. **Use `-q` for writes** during guided setup
+6. **Use `--json` for reads** to parse programmatically
+7. **Explain in plain language** what each change does
+8. **Suggest follow-ups** — e.g. "Now run `agent-sandbox check`" or "Restart the dashboard to apply"

--- a/lince-dashboard/skills/lince-configure/SKILL.md
+++ b/lince-dashboard/skills/lince-configure/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires lince-config CLI installed (lince-config/install.sh). Py
 metadata:
   author: lince
   version: "1.0"
-allowed-tools: Bash(lince-config:*) Read(//home/maeste/.agent-sandbox/**) Read(//home/maeste/.config/lince-dashboard/**)
+allowed-tools: Bash(lince-config:*) Read(//home/**/.agent-sandbox/**) Read(//home/**/.config/lince-dashboard/**)
 ---
 
 # lince-configure: Natural Language Configuration for LINCE
@@ -54,7 +54,28 @@ Always use `--json` for read operations to parse results programmatically.
 
 ## Workflow
 
-### Step 0: Understand Intent
+### Step 0: Choose Interaction Style (FIRST ACTION)
+
+**Before doing anything else**, unless the user has already stated a clear intent
+(e.g. "configure Vertex AI", "enable paranoid mode"), ask the user how they want
+to proceed using `AskUserQuestion`:
+
+- **Conversational** — free-form natural language back-and-forth
+- **Guided menu** — multiple-choice menus driving them through the configuration
+
+If the user's first message already contains a specific configuration request,
+skip this step and go straight to Step 1 (intent is clear). The choice question
+is only for ambiguous "help me configure LINCE" openings.
+
+When in **guided menu** mode, use `AskUserQuestion` at every decision point
+(area to configure, specific option, confirmation) rather than free-text prompts.
+When in **conversational** mode, ask open questions and infer intent.
+
+**Language**: Match the language the user is using in the current session. Do not
+hardcode a language in the skill — if they write in Italian, respond in Italian;
+if English, respond in English.
+
+### Step 1: Understand Intent
 
 Listen to what the user wants. Common intents:
 
@@ -70,7 +91,7 @@ Listen to what the user wants. Common intents:
 | "Fix this error" / "Something's broken" | Run check + diagnose |
 | "What sandbox level should I use?" | Explain levels, help choose |
 
-### Step 1: Read Current State
+### Step 2: Read Current State
 
 Before making changes, always check the current configuration:
 

--- a/lince-dashboard/skills/lince-configure/references/dashboard-config.md
+++ b/lince-dashboard/skills/lince-configure/references/dashboard-config.md
@@ -1,0 +1,72 @@
+# Dashboard Configuration Reference
+
+Quick reference for `~/.config/lince-dashboard/config.toml`. Loaded by `lince-config --target dashboard`.
+
+## [dashboard]
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `default_provider` | str | `""` | Default provider for new agents |
+| `sandbox_config_path` | str | `"~/.agent-sandbox/config.toml"` | Path to sandbox config |
+| `default_project_dir` | str | `""` | Default working dir (empty = cwd) |
+| `sandbox_command` | str | `"agent-sandbox"` | Path to agent-sandbox binary |
+| `agent_layout` | str | `"floating"` | `"floating"` or `"tiled"` |
+| `focus_mode` | str | `"floating"` | `"floating"` or `"replace"` |
+| `status_method` | str | `"pipe"` | `"pipe"` (recommended) or `"file"` |
+| `status_file_dir` | str | `"/tmp/lince-dashboard"` | Dir for status files (file mode) |
+| `max_agents` | int | `8` | Max concurrent agents |
+| `sandbox_backend` | str | `"auto"` | `"auto"`, `"agent-sandbox"`, or `"nono"` |
+| `default_agent_type` | str | `"claude"` | Default agent type for new agents |
+
+## [dashboard.sandbox_colors]
+
+Customize wizard colors per sandbox level:
+
+```toml
+[dashboard.sandbox_colors]
+paranoid = "green"
+normal = "blue"
+permissive = "yellow"
+default = "white"
+```
+
+Valid colors: red, green, yellow, blue, magenta, cyan, white.
+
+## [agents.\<name\>] — Agent Type Overrides
+
+Override shipped presets or define custom agents. Full replacement (no per-field merge).
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `command` | list | Yes | Command template with `{agent_id}`, `{project_dir}`, `{provider}` |
+| `pane_title_pattern` | str | Yes | Pattern to match pane titles |
+| `status_pipe_name` | str | Yes | Zellij pipe name |
+| `display_name` | str | Yes | Full name in UI |
+| `short_label` | str | Yes | 3-char label |
+| `color` | str | Yes | ANSI color: red/green/yellow/blue/magenta/cyan/white |
+| `sandboxed` | bool | Yes | Run inside sandbox |
+| `has_native_hooks` | bool | No | `true` only for Claude Code |
+| `bwrap_conflict` | bool | No | Agent uses bwrap internally |
+| `disable_inner_sandbox_args` | list | No | Args to disable inner sandbox |
+| `providers` | list | No | `["__discover__"]`, `[]`, or explicit list |
+| `home_ro_dirs` | list | No | Read-only bind mounts |
+| `home_rw_dirs` | list | No | Read-write bind mounts |
+| `env_vars` | dict | No | Env vars ($VAR expansion) |
+| `event_map` | dict | No | Custom event→status mapping |
+| `sandbox_backend` | str | No | Per-agent backend override |
+| `sandbox_level` | str | No | `"paranoid"`, `"normal"`, `"permissive"`, or custom |
+
+## Hot-Reload
+
+These settings apply immediately (no restart):
+- `focus_mode`, `status_method`, `max_agents`, `agent_layout`, `default_provider`, `default_project_dir`
+
+Requires restart:
+- `sandbox_command`
+
+## agents-defaults.toml
+
+Shipped presets at `~/.agent-sandbox/agents-defaults.toml`. Overwritten on updates.
+Customize in `config.toml` instead.
+
+Default agent types: claude, claude-unsandboxed, codex, gemini, opencode, pi.

--- a/lince-dashboard/skills/lince-configure/references/providers.md
+++ b/lince-dashboard/skills/lince-configure/references/providers.md
@@ -1,0 +1,128 @@
+# Provider Configuration Reference
+
+Providers are named env-var bundles that switch model provider/account at runtime.
+
+## Structure
+
+```toml
+# Top-level (shared):
+[providers.<name>]
+description = "Human-readable label"
+
+[providers.<name>.env]
+API_KEY_VAR = "literal-value-or-$VAR"
+
+# Agent-specific (scoped to one agent):
+[<agent>.providers.<name>]
+description = "..."
+
+[<agent>.providers.<name>.env]
+API_KEY_VAR = "..."
+```
+
+## Provider Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `description` | str | Label shown in run banner and wizard |
+| `env` | dict | Env vars injected via `--setenv`. Use `$VAR` for host expansion |
+| `env_unset` | list | Env vars to remove (unsandboxed agents only) |
+| `default_args` | list | Override agent's default_args when this provider is active |
+
+## Common Provider Templates
+
+### Anthropic Direct API
+```toml
+[providers.anthropic]
+description = "Anthropic Direct API"
+
+[providers.anthropic.env]
+ANTHROPIC_API_KEY = "sk-ant-..."
+```
+
+### Vertex AI (Claude-specific)
+```toml
+[claude.providers.vertex]
+description = "Vertex AI"
+
+[claude.providers.vertex.env]
+CLAUDE_CODE_USE_VERTEX = "1"
+ANTHROPIC_VERTEX_PROJECT_ID = "my-gcp-project"
+ANTHROPIC_VERTEX_REGION = "us-east5"
+```
+
+### OpenAI Direct
+```toml
+[providers.openai]
+description = "OpenAI Direct API"
+
+[providers.openai.env]
+OPENAI_API_KEY = "sk-..."
+```
+
+### Z.AI / GLM
+```toml
+[providers.zai]
+description = "Z.AI / GLM"
+
+[providers.zai.env]
+OPENAI_API_KEY = "$ZAI_API_KEY"
+OPENAI_BASE_URL = "https://open.bigmodel.cn/api/paas/v4"
+```
+
+### AWS Bedrock (Claude-specific)
+```toml
+[claude.providers.bedrock]
+description = "AWS Bedrock"
+
+[claude.providers.bedrock.env]
+ANTHROPIC_BASE_URL = "https://bedrock-runtime.us-east-1.amazonaws.com"
+AWS_REGION = "us-east-1"
+AWS_ACCESS_KEY_ID = "$AWS_ACCESS_KEY_ID"
+AWS_SECRET_ACCESS_KEY = "$AWS_SECRET_ACCESS_KEY"
+```
+
+## Selecting a Provider
+
+Default (no flag needed):
+```bash
+lince-config set sandbox.default_provider "vertex" -q
+```
+
+Per run:
+```bash
+agent-sandbox run -P vertex
+agent-sandbox run --provider anthropic
+```
+
+## $VAR Syntax
+
+Env values starting with `$` are resolved from the **host environment** at spawn time:
+
+- `"$ANTHROPIC_API_KEY"` → reads host's ANTHROPIC_API_KEY
+- `"sk-ant-literal"` → literal string
+
+For sandboxed agents, the sandbox starts with `--clearenv`, so only declared vars are visible.
+For unsandboxed agents, the full host env is inherited plus provider overrides.
+
+## env_unset
+
+Only relevant for **unsandboxed** agents. When switching providers, you may need to
+remove conflicting vars from the inherited host environment:
+
+```toml
+[claude.providers.vertex]
+description = "Vertex AI"
+env_unset = ["ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL"]
+
+[claude.providers.vertex.env]
+CLAUDE_CODE_USE_VERTEX = "1"
+CLOUD_ML_REGION = "us-east5"
+```
+
+For sandboxed agents, `env_unset` is a no-op (environment is already clean).
+
+## Legacy
+
+`[profiles.*]` / `[<agent>.profiles.*]` is the legacy spelling.
+Run `agent-sandbox migrate-providers` to rewrite in place.

--- a/lince-dashboard/skills/lince-configure/references/sandbox-config.md
+++ b/lince-dashboard/skills/lince-configure/references/sandbox-config.md
@@ -1,0 +1,112 @@
+# Sandbox Configuration Reference
+
+Quick reference for `~/.agent-sandbox/config.toml` keys. Loaded by `lince-config --target sandbox`.
+
+## [sandbox]
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `extra_rw` | list | `[]` | Extra writable dirs besides project |
+| `ro_dirs` | list | `["~/project"]` | Read-only dirs |
+| `persist_toolchains` | bool | `true` | Keep cargo/npm/go caches between runs |
+| `auto_expose_path` | bool | `true` | Auto-detect $PATH under $HOME |
+| `home_ro_dirs` | list | `[".config/gcloud"]` | Home subdirs to expose read-only |
+| `default_provider` | str | `""` | Default provider name (no -P needed) |
+| `backend` | str | `"auto"` | `"agent-sandbox"`, `"nono"`, or `"auto"` |
+
+## [security]
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `unshare_pid` | bool | `true` | Hide host processes |
+| `new_session` | bool | `false` | New terminal session (may break Ctrl+C) |
+| `block_git_push` | bool | `true` | Block via wrapper in PATH |
+| `credential_proxy` | bool | `false` | Inject API keys on host side |
+| `unshare_net` | bool | `false` | Kernel network isolation |
+| `allow_domains` | list | `[]` | Extra hosts for credential proxy |
+
+## [credential_proxy]
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `blocked_hosts` | list | `["169.254.169.254", ...]` | Extra hosts to block |
+
+## [git]
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `strip_sections` | list | `['credential', 'url ".*"']` | Regex patterns for .gitconfig |
+
+## [git.overrides]
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `"push.default"` | str | `"nothing"` | Forces bare git push to no-op |
+
+## [env]
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `passthrough` | list | `["TERM", "COLORTERM", ...]` | Host vars to pass into sandbox |
+
+## [env.extra]
+
+Static key=value pairs injected via `--setenv`.
+
+## [logging]
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | bool | `false` | Enable transcript logging |
+| `dir` | str | `"~/.agent-sandbox/logs"` | Log directory |
+
+## [snapshot]
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `auto_project` | bool | `false` | Auto-snapshot project before each run |
+| `auto_config` | bool | `true` | Auto-snapshot agent config |
+| `max_project_snapshots` | int | `3` | Max project snapshots |
+| `max_config_snapshots` | int | `5` | Max config snapshots |
+| `project_exclude` | list | `[".git", "node_modules", ...]` | Excluded dirs |
+
+## [claude]
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `config_dir` | str | `"~/.agent-sandbox/claude-config"` | Isolated config copy |
+| `use_real_config` | bool | `false` | Use real ~/.claude directly |
+
+## [agents.\<name\>]
+
+Per-agent overrides. Key = agent name (claude, codex, gemini, aider, opencode, amp, pi, bash).
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `command` | str | Binary to execute |
+| `default_args` | list | CLI arguments |
+| `env` | dict | Extra env vars ($VAR expansion supported) |
+| `home_ro_dirs` | list | Read-only home subdirs |
+| `home_rw_dirs` | list | Read-write home subdirs |
+| `bwrap_conflict` | bool | Agent uses bwrap internally |
+| `disable_inner_sandbox_args` | list | Args to disable agent's inner sandbox |
+
+## Providers
+
+### Top-level: [providers.\<name\>]
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `description` | str | Human-readable label |
+| `env` | dict | Env vars to inject |
+| `env_unset` | list | Env vars to remove (for unsandboxed) |
+| `default_args` | list | Override agent default_args |
+
+### Agent-specific: [\<agent\>.providers.\<name\>]
+
+Same fields as top-level, scoped to one agent. Takes priority over top-level with same name.
+
+### Legacy
+
+`[profiles.*]` and `[<agent>.profiles.*]` still work (deprecated since gh#81).
+Run `agent-sandbox migrate-providers` to rewrite.

--- a/lince-dashboard/skills/lince-configure/references/sandbox-levels.md
+++ b/lince-dashboard/skills/lince-configure/references/sandbox-levels.md
@@ -1,0 +1,91 @@
+# Sandbox Levels Reference
+
+Three isolation levels, selectable per agent per run.
+
+## Comparison
+
+| Aspect | paranoid | normal | permissive |
+|--------|----------|--------|------------|
+| **Network** | Kernel-isolated (netns/Landlock) | Inherited | Open |
+| **Credential proxy** | Required (API keys on host only) | Opt-in | Off by default |
+| **Home dirs** | Scratch (per-run, ephemeral) | Standard mounts | + gh, cache, known_hosts |
+| **gh CLI** | No | No | Yes |
+| **git push** | Blocked | Blocked | Blocked (use gh) |
+| **Use when** | Untrusted input, unfamiliar repos | Daily work | Need PRs/GitHub from agent |
+
+## Selecting a Level
+
+Per run (CLI):
+```bash
+agent-sandbox run --sandbox-level paranoid
+agent-sandbox run --sandbox-level permissive -a codex
+```
+
+Per agent (dashboard config):
+```bash
+lince-config set agents.claude.sandbox_level "paranoid" --target dashboard -q
+```
+
+## Paranoid Details
+
+- `unshare_net = true` + `credential_proxy = true`
+- Only API endpoint reachable (api.anthropic.com, api.openai.com, etc.)
+- Agent's config dir is a per-run scratch copy (rsync-seeded, discarded on exit)
+- API key never enters the sandbox process tree
+- **Requires** an API key on the host (not OAuth)
+- **Requires** `socat` installed (for bwrap backend)
+
+Extend allowlist without forking the level:
+```bash
+lince-config append security.allow_domains "pypi.org" -q
+lince-config append security.allow_domains "files.pythonhosted.org" -q
+```
+
+## Permissive Details
+
+- Network open, credential proxy off by default
+- `~/.config/gh` read-only (gh finds its token)
+- `~/.cache` read-only (tool cache reuse)
+- `~/.ssh/known_hosts` read-only (SSH remotes work)
+- `git push` still blocked — use `gh pr create` instead
+- Recommended: fine-grained PAT scoped to specific repos
+
+## Custom Levels
+
+Any string works as a level name, as long as a profile fragment exists:
+
+- bwrap: `~/.agent-sandbox/profiles/<level>.toml` or `<agent>-<level>.toml`
+- nono: `~/.config/nono/profiles/lince-<agent>-<level>.json`
+
+Fragments support `extends` for inheritance:
+```toml
+# ~/.agent-sandbox/profiles/paranoid-with-ssh.toml
+extends = "paranoid"
+
+[sandbox]
+home_ro_dirs = [".ssh"]
+```
+
+## Per-Agent Quirks
+
+### Claude
+- `[claude] use_real_config` only applies at normal/permissive
+- Paranoid always uses scratch (ignores use_real_config)
+
+### Codex
+- `bwrap_conflict = true` — always needs `--sandbox danger-full-access`
+- `~/.codex` is scratch in paranoid
+
+### Gemini
+- Paranoid requires API key auth (not OAuth/browser login)
+- `GEMINI_API_KEY` or `GOOGLE_API_KEY` must be set on host
+
+## Trust Model
+
+| Property | Paranoid + API key | Paranoid + OAuth | Normal/Permissive |
+|----------|-------------------|------------------|-------------------|
+| Kernel network isolation | ✅ | ✅ | ❌ |
+| Credentials never in sandbox | ✅ | ❌ | ❌ |
+| Prompt injection can exfiltrate creds | No | Yes | Depends |
+
+OAuth users should use `normal` or `permissive`, not `paranoid`.

--- a/lince-dashboard/skills/lince-configure/references/security.md
+++ b/lince-dashboard/skills/lince-configure/references/security.md
@@ -1,0 +1,60 @@
+# Security Model Reference
+
+## Defense Layers (innermost to outermost)
+
+1. **Filesystem isolation** — agent sees only project dir + curated home paths
+2. **PID namespace** — agent cannot see host processes (`unshare_pid`)
+3. **Network isolation** — kernel-level via netns (bwrap) or Landlock (nono)
+4. **Credential proxy** — API keys never enter the sandbox; injected on host side
+5. **Git push blocking** — wrapper script in sandbox PATH intercepts `git push`
+6. **Environment isolation** — `--clearenv`, only declared vars pass through
+
+## Credential Proxy
+
+When `credential_proxy = true`:
+- Host-side proxy listens on a unix socket
+- Socket is bind-mounted into sandbox
+- Agent routes HTTPS through proxy (`HTTP_PROXY=http://127.0.0.1:8118`)
+- Proxy injects `Authorization`/`x-api-key` header on outbound requests
+- Proxy enforces `allow_domains` allowlist
+- API key is stripped from sandbox environment
+
+Auto-mapped env vars → domains:
+- `ANTHROPIC_API_KEY` → `api.anthropic.com`
+- `OPENAI_API_KEY` → `api.openai.com`
+- `GEMINI_API_KEY` / `GOOGLE_API_KEY` → `googleapis.com`
+
+## Network Namespaces
+
+When `unshare_net = true` (paranoid):
+- Agent runs in fresh network namespace (only loopback)
+- No route to host or internet
+- Proxy reached via bind-mounted unix socket
+- `socat` bridges TCP localhost → unix socket inside sandbox
+- DNS for non-allowlisted hosts fails at kernel level
+
+## Filesystem Mounts
+
+| Path | Mode | What |
+|------|------|------|
+| `$PROJECT` | rw | Project working directory |
+| `~/.claude` (or scratch) | rw | Agent config (scratch in paranoid) |
+| `~/.agent-sandbox/toolchains/` | rw | Build caches |
+| `~/.agent-sandbox/bin/git` | ro | Git push blocking wrapper |
+| `~/.agent-sandbox/gitconfig` | ro | Sanitized git config |
+| `$PATH entries under $HOME` | ro | Auto-exposed tools |
+| `home_ro_dirs` entries | ro | User-configured read-only paths |
+| `extra_rw` entries | rw | User-configured writable paths |
+
+## Threat Model
+
+| Attack Vector | Mitigation |
+|---------------|------------|
+| Agent reads SSH keys | Keys not mounted |
+| Agent exfiltrates via network | Network namespace isolation |
+| Agent reads API key from env | Credential proxy strips keys |
+| Agent pushes to git | Git wrapper blocks push |
+| Agent modifies host git config | Sanitized copy is read-only |
+| Agent escapes via /proc | PID namespace hides host |
+| Agent writes to arbitrary paths | Only declared paths are writable |
+| Prompt injection via model response | Paranoid: no creds in sandbox to exfiltrate |

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -472,6 +472,7 @@ confirm_installation() {
     fi
 
     echo -e "  ${GREEN}✓${NC} lince-dashboard  ${DIM}(multi-agent TUI)${NC}"
+    echo -e "  ${GREEN}✓${NC} lince-config     ${DIM}(config CLI + lince-configure skill)${NC}"
 
     if [ "$INSTALL_VOXCODE" = true ]; then
         echo -e "  ${GREEN}✓${NC} voxcode          ${DIM}(voice input via Whisper)${NC}"
@@ -631,6 +632,23 @@ do_install_sandbox() {
     fi
 }
 
+# ── Install lince-config CLI ────────────────────────────────────────
+do_install_lince_config() {
+    echo ""
+    print_separator
+    echo -e "${BOLD}Installing lince-config CLI...${NC}"
+    echo ""
+
+    cd "$SCRIPT_DIR/lince-config"
+    if bash install.sh; then
+        echo -e "${GREEN}✓ lince-config installed${NC}"
+    else
+        echo -e "${RED}✗ lince-config installation failed${NC}"
+        echo -e "  ${DIM}The lince-configure skill will not be functional without it.${NC}"
+        if ! confirm "Continue anyway?"; then exit 1; fi
+    fi
+}
+
 # ── Install dashboard ───────────────────────────────────────────────
 do_install_dashboard() {
     echo ""
@@ -682,6 +700,16 @@ check_prerequisites() {
         else
             echo -e "      ${DIM}# Fedora/RHEL: sudo dnf install python3.11${NC}"
             echo -e "      ${DIM}# Ubuntu/Debian: sudo apt install python3.11${NC}"
+        fi
+    fi
+
+    # tomlkit (for lince-config CLI). Informational only — lince-config/install.sh
+    # will pip-install it if missing.
+    if command -v python3 >/dev/null 2>&1; then
+        if python3 -c "import tomlkit" 2>/dev/null; then
+            echo -e "  ${GREEN}✓${NC} python tomlkit"
+        else
+            echo -e "  ${YELLOW}✗${NC} python tomlkit — ${DIM}will be installed by lince-config${NC}"
         fi
     fi
 
@@ -821,6 +849,9 @@ print_summary() {
     if has_backend unsandboxed; then
         echo -e "  ${RED}!${NC} unsandboxed mode"
     fi
+    if [ -x "$HOME/.local/bin/lince-config" ]; then
+        echo -e "  ${GREEN}✓${NC} lince-config CLI (powers /lince-configure)"
+    fi
     if command -v voxcode >/dev/null 2>&1; then
         echo -e "  ${GREEN}✓${NC} voxcode (voice input)"
     fi
@@ -909,6 +940,7 @@ check_prerequisites
 print_separator
 
 do_install_sandbox
-do_install_voxcode    # before dashboard so step 12 detects voxcode
+do_install_voxcode        # before dashboard so step 14 detects voxcode
 do_install_dashboard
+do_install_lince_config   # CLI required by the lince-configure skill
 print_summary


### PR DESCRIPTION
## Summary

Users currently need to read extensive documentation and manually edit TOML files to configure LINCE. This PR adds two components that enable natural-language configuration guided by an AI agent.

Closes #86

## Components

### 1. `lince-config/` — Structured configuration CLI

A standalone Python CLI that reads and writes TOML config files for both sandbox and dashboard, preserving comments and formatting via `tomlkit`.

| Command | Description |
|---------|-------------|
| `get <key>` | Read a config value |
| `set <key> <value>` | Write a config value |
| `append <key> <value>` | Append to a list (dedup) |
| `remove <key> <value>` | Remove from a list |
| `unset <key>` | Remove a key or section |
| `list [section]` | List sections or contents |
| `check` | Diagnostic checks (`brew doctor` style) |
| `validate` | Schema validation |

### 2. `lince-dashboard/skills/lince-configure/` — Agent skill (agentskills.io)

A skill that teaches any AI agent how to configure LINCE through natural language, using `lince-config` as the programmatic interface.

```
User: "I want to configure Vertex AI for Claude"
  → Agent loads skill, reads docs
  → Agent calls lince-config list providers --json
  → Agent calls lince-config set claude.providers.vertex.* -q
  → Agent calls lince-config check --json
  → Agent explains what was done in plain language
```

## Files

```
lince-config/
├── lince-config          # CLI (Python 3.11+, 1100 lines)
├── install.sh / update.sh / uninstall.sh
└── README.md

lince-dashboard/skills/lince-configure/
├── SKILL.md              # Skill instructions + workflow
└── references/           # On-demand docs for the agent
    ├── sandbox-config.md
    ├── dashboard-config.md
    ├── sandbox-levels.md
    ├── providers.md
    └── security.md
```