### PR TITLE
fix: drop ~/.cache RO bind from claude-permissive (breaks claude-cli)

### DIFF
--- a/sandbox/profiles/claude-permissive.toml
+++ b/sandbox/profiles/claude-permissive.toml
@@ -22,7 +22,13 @@
 #   credential_proxy = true
 
 [sandbox]
-home_ro_dirs = [".config/gh", ".cache", ".ssh/known_hosts"]
+# NOTE: ~/.cache is intentionally NOT exposed read-only here. claude-cli
+# writes per-project state to ~/.cache/claude-cli-nodejs/<project>/ at
+# startup; an RO bind on ~/.cache makes that write fail and claude-cli
+# exits silently from its TUI alt-screen, leaving the dashboard with a
+# bare "exit 1". Tool-specific caches (cargo, npm, uv, go) are exposed
+# via persist_toolchains, so a blanket ~/.cache mount is unnecessary.
+home_ro_dirs = [".config/gh", ".ssh/known_hosts"]
 
 [env]
 # Pass host-env GitHub tokens through. gh CLI authenticated via


### PR DESCRIPTION
claude-cli writes per-project state to ~/.cache/claude-cli-nodejs/<project>/ at startup. The permissive fragment exposed ~/.cache as read-only via home_ro_dirs, which made that first write fail. Because claude is in TUI alt-screen mode at that point, the error was wiped on screen restore and the user only saw "exit 1" in the dashboard (or a bare prompt with empty stderr from the CLI).

Removing ".cache" from home_ro_dirs lets bwrap leave ~/.cache out of the sandbox view (so claude-cli falls back to its own writable path under the sandbox's tmpfs HOME, or accesses the tool-specific caches that persist_toolchains exposes individually). Tool-specific caches (cargo, npm, uv, go) were already mounted via persist_toolchains, so a blanket ~/.cache mount served no documented purpose for permissive.

Note: same ".cache" entry exists in codex-/gemini-/opencode-/pi-permissive.toml — left unchanged here, since only claude was reproduced. They can be addressed in a follow-up if the same symptom shows up there.