### PR TITLE
feat: raw bash/zsh/fish shell agents (gh#91)

### DIFF
--- a/docs/documentation/dashboard/agent-examples.md
+++ b/docs/documentation/dashboard/agent-examples.md
@@ -14,8 +14,23 @@ The following agent types ship in `agents-defaults.toml` and are available in th
 | `gemini` | Google Gemini CLI | GEM | Yes | No | |
 | `opencode` | OpenCode | OPC | Yes | No | |
 | `pi` | Pi (multi-provider) | PI  | Yes | No | Provider env vars passed through (`OPENAI_API_KEY`, etc.). |
+| `bash` | Bash Shell | BSH | Yes | No | Raw shell session in the project dir (gh#91). Pinned to `sandbox_level = "normal"`. |
+| `bash-unsandboxed` | Bash Shell (unsandboxed) | BSU | No | No | Raw bash on the host, no isolation. |
+| `zsh` | Zsh Shell | ZSH | Yes | No | Zsh equivalent of `bash` — typical default on macOS. |
+| `zsh-unsandboxed` | Zsh Shell (unsandboxed) | ZSU | No | No | Raw zsh on the host, no isolation. |
 
 Each sandboxed agent ships at `sandbox_level = "normal"` by default. `paranoid` and `permissive` variants are available as commented blocks in `agents-defaults.toml` — uncomment to add them as separate entries to the N-picker. See [Sandbox Levels](dashboard/sandbox-levels.md) for what each level enforces.
+
+### Shell Agents (bash / zsh)
+
+The `bash` and `zsh` agents open a raw shell pane in the project directory (gh#91). They behave like the AI coding agents in every other respect — backend selection (bwrap / nono / unsandboxed), pane lifecycle, focus/hide, dashboard color cues — except for two intentional restrictions:
+
+- **Sandbox level: only `normal`.** Shell agents declare `sandbox_levels = ["normal"]`, so the wizard's *Sandbox Level* step is auto-skipped (a one-row picker would be useless). `paranoid` and `permissive` aren't offered: a paranoid shell with no agent state dir is pointless, and a permissive one is no different from `normal` for an interactive shell.
+- **No providers.** Shells don't talk to AI APIs, so the wizard's *Provider* step is also skipped.
+
+What you *do* still pick: backend (any installed: `bwrap`, `nono`, or unsandboxed), name, and project directory.
+
+Both `bash` and `zsh` ship on every install regardless of platform — pick whichever matches your default shell (typically `bash` on Linux, `zsh` on macOS).
 
 ## Backend and Level Selection
 

--- a/docs/documentation/dashboard/agent-examples.md
+++ b/docs/documentation/dashboard/agent-examples.md
@@ -18,19 +18,21 @@ The following agent types ship in `agents-defaults.toml` and are available in th
 | `bash-unsandboxed` | Bash Shell (unsandboxed) | BSU | No | No | Raw bash on the host, no isolation. |
 | `zsh` | Zsh Shell | ZSH | Yes | No | Zsh equivalent of `bash` — typical default on macOS. |
 | `zsh-unsandboxed` | Zsh Shell (unsandboxed) | ZSU | No | No | Raw zsh on the host, no isolation. |
+| `fish` | Fish Shell | FSH | Yes | No | Fish equivalent of `bash`. |
+| `fish-unsandboxed` | Fish Shell (unsandboxed) | FSU | No | No | Raw fish on the host, no isolation. |
 
 Each sandboxed agent ships at `sandbox_level = "normal"` by default. `paranoid` and `permissive` variants are available as commented blocks in `agents-defaults.toml` — uncomment to add them as separate entries to the N-picker. See [Sandbox Levels](dashboard/sandbox-levels.md) for what each level enforces.
 
-### Shell Agents (bash / zsh)
+### Shell Agents (bash / zsh / fish)
 
-The `bash` and `zsh` agents open a raw shell pane in the project directory (gh#91). They behave like the AI coding agents in every other respect — backend selection (bwrap / nono / unsandboxed), pane lifecycle, focus/hide, dashboard color cues — except for two intentional restrictions:
+The shell agents (`bash`, `zsh`, `fish`) open a raw shell pane in the project directory (gh#91). They behave like the AI coding agents in every other respect — backend selection (bwrap / nono / unsandboxed), pane lifecycle, focus/hide, dashboard color cues — except for two intentional restrictions:
 
 - **Sandbox level: only `normal`.** Shell agents declare `sandbox_levels = ["normal"]`, so the wizard's *Sandbox Level* step is auto-skipped (a one-row picker would be useless). `paranoid` and `permissive` aren't offered: a paranoid shell with no agent state dir is pointless, and a permissive one is no different from `normal` for an interactive shell.
 - **No providers.** Shells don't talk to AI APIs, so the wizard's *Provider* step is also skipped.
 
 What you *do* still pick: backend (any installed: `bwrap`, `nono`, or unsandboxed), name, and project directory.
 
-Both `bash` and `zsh` ship on every install regardless of platform — pick whichever matches your default shell (typically `bash` on Linux, `zsh` on macOS).
+The `quickstart.sh` installer asks which shells to configure (multi-select, host `$SHELL` pre-checked) and which one to use as the **default shell** for the tiled layout's right-hand placeholder pane. Only the chosen shells are written to `agents-defaults.toml` and `~/.agent-sandbox/agents-defaults.toml`; the default shell is hardcoded into `~/.local/bin/lince-viewport-placeholder`.
 
 ## Backend and Level Selection
 

--- a/lince-dashboard/agents-defaults.toml
+++ b/lince-dashboard/agents-defaults.toml
@@ -293,24 +293,8 @@ AWS_SESSION_TOKEN = "$AWS_SESSION_TOKEN"
 AWS_BEARER_TOKEN_BEDROCK = "$AWS_BEARER_TOKEN_BEDROCK"
 AWS_ENDPOINT_URL_BEDROCK_RUNTIME = "$AWS_ENDPOINT_URL_BEDROCK_RUNTIME"
 
-# ── Bash / Zsh ──────────────────────────────────────────────────────
-#
-# Raw shell sessions inside the sandbox. Useful for quick command execution
-# or file inspection in the project directory without firing up a full coding
-# agent (gh#91).
-#
-# Constraints (intentional):
-#   * sandbox_level supports only "normal" — paranoid/permissive levels and
-#     custom levels are not offered for shells. `sandbox_levels = ["normal"]`
-#     restricts the wizard's SandboxLevel step (which is then auto-skipped
-#     since it has only one option).
-#   * No providers (env-var bundles): a shell doesn't talk to AI APIs.
-#   * Backend selection: any installed backend works, plus the unsandboxed
-#     entry below for "no isolation" sessions.
-#
-# Linux installs ship bash; macOS installs typically use zsh. Both entries are
-# always available — pick the one that matches your default shell.
-
+# Raw shell agents (gh#91). Pinned to sandbox_level=normal, no providers.
+# See docs/documentation/dashboard/agent-examples.md §"Shell Agents".
 [agents.bash]
 command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}", "--agent", "bash"]
 pane_title_pattern = "agent-sandbox"
@@ -354,6 +338,30 @@ pane_title_pattern = "zsh"
 status_pipe_name = "lince-status"
 display_name = "Zsh Shell (unsandboxed)"
 short_label = "ZSU"
+color = "red"
+sandboxed = false
+has_native_hooks = false
+providers = []
+
+[agents.fish]
+command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}", "--agent", "fish"]
+pane_title_pattern = "agent-sandbox"
+status_pipe_name = "lince-status"
+display_name = "Fish Shell"
+short_label = "FSH"
+color = "blue"
+sandboxed = true
+has_native_hooks = false
+providers = []
+sandbox_level = "normal"
+sandbox_levels = ["normal"]
+
+[agents.fish-unsandboxed]
+command = ["fish"]
+pane_title_pattern = "fish"
+status_pipe_name = "lince-status"
+display_name = "Fish Shell (unsandboxed)"
+short_label = "FSU"
 color = "red"
 sandboxed = false
 has_native_hooks = false

--- a/lince-dashboard/agents-defaults.toml
+++ b/lince-dashboard/agents-defaults.toml
@@ -292,3 +292,69 @@ AWS_SECRET_ACCESS_KEY = "$AWS_SECRET_ACCESS_KEY"
 AWS_SESSION_TOKEN = "$AWS_SESSION_TOKEN"
 AWS_BEARER_TOKEN_BEDROCK = "$AWS_BEARER_TOKEN_BEDROCK"
 AWS_ENDPOINT_URL_BEDROCK_RUNTIME = "$AWS_ENDPOINT_URL_BEDROCK_RUNTIME"
+
+# ── Bash / Zsh ──────────────────────────────────────────────────────
+#
+# Raw shell sessions inside the sandbox. Useful for quick command execution
+# or file inspection in the project directory without firing up a full coding
+# agent (gh#91).
+#
+# Constraints (intentional):
+#   * sandbox_level supports only "normal" — paranoid/permissive levels and
+#     custom levels are not offered for shells. `sandbox_levels = ["normal"]`
+#     restricts the wizard's SandboxLevel step (which is then auto-skipped
+#     since it has only one option).
+#   * No providers (env-var bundles): a shell doesn't talk to AI APIs.
+#   * Backend selection: any installed backend works, plus the unsandboxed
+#     entry below for "no isolation" sessions.
+#
+# Linux installs ship bash; macOS installs typically use zsh. Both entries are
+# always available — pick the one that matches your default shell.
+
+[agents.bash]
+command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}", "--agent", "bash"]
+pane_title_pattern = "agent-sandbox"
+status_pipe_name = "lince-status"
+display_name = "Bash Shell"
+short_label = "BSH"
+color = "blue"
+sandboxed = true
+has_native_hooks = false
+providers = []
+sandbox_level = "normal"
+sandbox_levels = ["normal"]
+
+[agents.bash-unsandboxed]
+command = ["bash"]
+pane_title_pattern = "bash"
+status_pipe_name = "lince-status"
+display_name = "Bash Shell (unsandboxed)"
+short_label = "BSU"
+color = "red"
+sandboxed = false
+has_native_hooks = false
+providers = []
+
+[agents.zsh]
+command = ["agent-sandbox", "run", "-p", "{project_dir}", "--id", "{agent_id}", "--agent", "zsh"]
+pane_title_pattern = "agent-sandbox"
+status_pipe_name = "lince-status"
+display_name = "Zsh Shell"
+short_label = "ZSH"
+color = "blue"
+sandboxed = true
+has_native_hooks = false
+providers = []
+sandbox_level = "normal"
+sandbox_levels = ["normal"]
+
+[agents.zsh-unsandboxed]
+command = ["zsh"]
+pane_title_pattern = "zsh"
+status_pipe_name = "lince-status"
+display_name = "Zsh Shell (unsandboxed)"
+short_label = "ZSU"
+color = "red"
+sandboxed = false
+has_native_hooks = false
+providers = []

--- a/lince-dashboard/nono-profiles/lince-bash.json
+++ b/lince-dashboard/nono-profiles/lince-bash.json
@@ -1,0 +1,43 @@
+{
+  "extends": "default",
+  "meta": {
+    "name": "lince-bash",
+    "description": "LINCE sandbox profile for raw bash sessions (gh#91). Workdir-scoped read/write, broad command passthrough so the shell is actually useful, and a developer network profile that lets git/curl/ssh/etc. reach common dev domains."
+  },
+  "filesystem": {
+    "allow": [
+      "$WORKDIR"
+    ],
+    "read": [
+      "$HOME/.local/lib",
+      "$HOME/.bashrc",
+      "$HOME/.bash_profile",
+      "$HOME/.profile",
+      "$HOME/.inputrc",
+      "$HOME/.config/gh",
+      "$HOME/.cache",
+      "$HOME/.ssh/known_hosts"
+    ]
+  },
+  "environment": {
+    "passthrough": [
+      "TERM",
+      "COLORTERM",
+      "TERM_PROGRAM",
+      "LANG",
+      "LC_ALL",
+      "EDITOR",
+      "VISUAL",
+      "PAGER",
+      "ZELLIJ",
+      "ZELLIJ_SESSION_NAME",
+      "LINCE_AGENT_ID"
+    ]
+  },
+  "network": {
+    "network_profile": "developer"
+  },
+  "security": {
+    "signal_mode": "allow_same_sandbox"
+  }
+}

--- a/lince-dashboard/nono-profiles/lince-fish.json
+++ b/lince-dashboard/nono-profiles/lince-fish.json
@@ -1,0 +1,42 @@
+{
+  "extends": "default",
+  "meta": {
+    "name": "lince-fish",
+    "description": "LINCE sandbox profile for raw fish sessions (gh#91). Workdir-scoped read/write, broad command passthrough so the shell is actually useful, and a developer network profile that lets git/curl/ssh/etc. reach common dev domains."
+  },
+  "filesystem": {
+    "allow": [
+      "$WORKDIR"
+    ],
+    "read": [
+      "$HOME/.local/lib",
+      "$HOME/.config/fish",
+      "$HOME/.profile",
+      "$HOME/.inputrc",
+      "$HOME/.config/gh",
+      "$HOME/.cache",
+      "$HOME/.ssh/known_hosts"
+    ]
+  },
+  "environment": {
+    "passthrough": [
+      "TERM",
+      "COLORTERM",
+      "TERM_PROGRAM",
+      "LANG",
+      "LC_ALL",
+      "EDITOR",
+      "VISUAL",
+      "PAGER",
+      "ZELLIJ",
+      "ZELLIJ_SESSION_NAME",
+      "LINCE_AGENT_ID"
+    ]
+  },
+  "network": {
+    "network_profile": "developer"
+  },
+  "security": {
+    "signal_mode": "allow_same_sandbox"
+  }
+}

--- a/lince-dashboard/nono-profiles/lince-zsh.json
+++ b/lince-dashboard/nono-profiles/lince-zsh.json
@@ -1,0 +1,45 @@
+{
+  "extends": "default",
+  "meta": {
+    "name": "lince-zsh",
+    "description": "LINCE sandbox profile for raw zsh sessions (gh#91). Workdir-scoped read/write, broad command passthrough so the shell is actually useful, and a developer network profile that lets git/curl/ssh/etc. reach common dev domains."
+  },
+  "filesystem": {
+    "allow": [
+      "$WORKDIR"
+    ],
+    "read": [
+      "$HOME/.local/lib",
+      "$HOME/.zshrc",
+      "$HOME/.zprofile",
+      "$HOME/.zshenv",
+      "$HOME/.zlogin",
+      "$HOME/.profile",
+      "$HOME/.inputrc",
+      "$HOME/.config/gh",
+      "$HOME/.cache",
+      "$HOME/.ssh/known_hosts"
+    ]
+  },
+  "environment": {
+    "passthrough": [
+      "TERM",
+      "COLORTERM",
+      "TERM_PROGRAM",
+      "LANG",
+      "LC_ALL",
+      "EDITOR",
+      "VISUAL",
+      "PAGER",
+      "ZELLIJ",
+      "ZELLIJ_SESSION_NAME",
+      "LINCE_AGENT_ID"
+    ]
+  },
+  "network": {
+    "network_profile": "developer"
+  },
+  "security": {
+    "signal_mode": "allow_same_sandbox"
+  }
+}

--- a/lince-dashboard/plugin/src/agent.rs
+++ b/lince-dashboard/plugin/src/agent.rs
@@ -203,6 +203,15 @@ fn synthesize_sandboxed_command(
             ".config/opencode",
         ),
         "pi" => (vec!["pi".to_string()], ".pi"),
+        // Raw shells (gh#91). No agent state dir — the scratch HOME used by
+        // the paranoid wrapper would be empty, so we never enter the paranoid
+        // branch (shells are pinned to sandbox_level=normal in
+        // agents-defaults.toml). The empty subdir is benign for the other
+        // branches: the bwrap path is built directly from the sandbox config
+        // (it doesn't read agent_home_subdir), and the non-paranoid nono
+        // branch ignores it entirely.
+        "bash" => (vec!["bash".to_string()], ""),
+        "zsh" => (vec!["zsh".to_string()], ""),
         _ => return None,
     };
 

--- a/lince-dashboard/plugin/src/agent.rs
+++ b/lince-dashboard/plugin/src/agent.rs
@@ -212,6 +212,7 @@ fn synthesize_sandboxed_command(
         // branch ignores it entirely.
         "bash" => (vec!["bash".to_string()], ""),
         "zsh" => (vec!["zsh".to_string()], ""),
+        "fish" => (vec!["fish".to_string()], ""),
         _ => return None,
     };
 

--- a/lince-dashboard/plugin/src/config.rs
+++ b/lince-dashboard/plugin/src/config.rs
@@ -87,6 +87,13 @@ pub struct AgentTypeConfig {
     /// `(agent_type, sandbox_backend, sandbox_level)`.
     #[serde(default)]
     pub sandbox_level: Option<String>,
+    /// Restrict the wizard's SandboxLevel picker to a fixed set instead of the
+    /// shipped default trio (paranoid/normal/permissive). Empty = use defaults.
+    /// Set to `["normal"]` for agents that have only one meaningful level
+    /// (e.g. shells, gh#91); the SandboxLevel step is auto-skipped when only
+    /// one option remains so the user never sees a single-choice picker.
+    #[serde(default)]
+    pub sandbox_levels: Vec<String>,
 }
 
 /// Agent pane layout mode.
@@ -828,6 +835,13 @@ impl DashboardConfig {
         };
         if !cfg.sandboxed || cfg.sandbox_level.is_none() {
             return Vec::new();
+        }
+        // Per-agent override: a non-empty `sandbox_levels` replaces the shipped
+        // trio. Custom-level discovery is intentionally skipped here — agents
+        // that opt in (e.g. shells, gh#91) want a fixed set, not surprise
+        // additions from `~/.agent-sandbox/profiles/`.
+        if !cfg.sandbox_levels.is_empty() {
+            return cfg.sandbox_levels.clone();
         }
         let mut levels: Vec<String> = vec![
             "paranoid".to_string(),

--- a/lince-dashboard/plugin/src/types.rs
+++ b/lince-dashboard/plugin/src/types.rs
@@ -204,9 +204,12 @@ impl WizardState {
         self.available_sandbox_backends.get(self.sandbox_backend_index).cloned()
     }
 
-    /// Whether there are sandbox levels to choose from.
+    /// Whether there are sandbox levels to choose from in the wizard.
+    /// A single-option list is treated as "no choice" so the step is skipped —
+    /// the lone level still applies, just without a useless one-row picker
+    /// (see gh#91 shells, which pin `sandbox_levels = ["normal"]`).
     pub fn has_sandbox_levels(&self) -> bool {
-        !self.available_sandbox_levels.is_empty()
+        self.available_sandbox_levels.len() > 1
     }
 
     /// Return the currently selected sandbox level, or None if no levels available.

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -64,6 +64,19 @@ LEVELS=(
 )
 LEVEL_SELECTED=(1 0 0)
 
+# Shell agents (gh#91): key|display|description. Pre-selection is computed
+# at runtime from $SHELL by select_shells() so it tracks the host's actual
+# default shell instead of hard-coding bash.
+SHELLS=(
+    "bash|Bash|GNU bash — Linux default shell"
+    "zsh|Zsh|Z shell — macOS default shell"
+    "fish|Fish|Friendly interactive shell — auto-suggestions, syntax highlighting"
+)
+SHELL_SELECTED=(0 0 0)
+SELECTED_SHELLS=()         # ordered subset of {bash,zsh,fish}
+DEFAULT_SHELL=""           # one of SELECTED_SHELLS, used by the tiled placeholder
+DEFAULT_SHELL_BIN=""       # absolute path resolved via `command -v`
+
 # ── Helpers ──────────────────────────────────────────────────────────
 confirm() {
     local prompt="$1"
@@ -394,11 +407,198 @@ select_agents() {
     fi
 }
 
+# ── TUI: Shell selection (multi-select) + default shell ─────────────
+#
+# Configures the gh#91 shell agents. Picks (a) which shells become dashboard
+# agents and (b) which one runs in the tiled layout's right-hand placeholder
+# pane (the ASCII-art viewport B). Pre-selection follows `$SHELL`: a user
+# whose login shell is zsh sees zsh pre-checked, etc.
+select_shells() {
+    echo ""
+    print_separator
+    echo -e "${BOLD}Step 4: Select shell agents${NC}"
+    echo ""
+    echo -e "  ${DIM}Shell agents open a raw shell pane in the project dir —${NC}"
+    echo -e "  ${DIM}useful for quick command execution alongside coding agents.${NC}"
+    echo -e "  ${DIM}Skip this step (Enter with nothing selected) if you don't want any.${NC}"
+    echo ""
+
+    # Auto-detect host shell and pre-check the matching entry. basename($SHELL)
+    # so "/usr/bin/zsh" → "zsh". Falls back to bash if $SHELL is unset/unknown.
+    local host_shell
+    host_shell=$(basename "${SHELL:-/bin/bash}" 2>/dev/null)
+    for i in "${!SHELLS[@]}"; do
+        IFS='|' read -r key _ _ <<< "${SHELLS[$i]}"
+        if [ "$key" = "$host_shell" ]; then
+            SHELL_SELECTED[$i]=1
+        fi
+    done
+    # If $SHELL didn't match any of our entries (e.g. dash, ksh), fall back
+    # to bash — universally available, safe default.
+    local any_preselected=0
+    for v in "${SHELL_SELECTED[@]}"; do
+        [ "$v" = "1" ] && any_preselected=1
+    done
+    if [ "$any_preselected" = "0" ]; then
+        SHELL_SELECTED[0]=1   # bash
+    fi
+
+    echo -e "  ${DIM}Toggle with number keys, press Enter when done:${NC}"
+    echo ""
+
+    while true; do
+        for i in "${!SHELLS[@]}"; do
+            IFS='|' read -r key name desc <<< "${SHELLS[$i]}"
+            local marker=""
+            if command -v "$key" >/dev/null 2>&1; then
+                marker="${GREEN}(installed)${NC}"
+            else
+                marker="${YELLOW}(not in PATH)${NC}"
+            fi
+            if [ "${SHELL_SELECTED[$i]}" = "1" ]; then
+                echo -e "  ${GREEN}[x]${NC} ${BOLD}$((i+1))) $name${NC} ${DIM}— $desc${NC} $marker"
+            else
+                echo -e "  ${DIM}[ ] $((i+1))) $name — $desc${NC} $marker"
+            fi
+        done
+        echo ""
+        echo -e "  ${DIM}Press 1-${#SHELLS[@]} to toggle, Enter to confirm, 'a' for all, 'n' for none${NC}"
+        read -p "  > " -n 1 -r
+        echo ""
+
+        case "$REPLY" in
+            [1-9])
+                local idx=$((REPLY - 1))
+                if [ $idx -lt ${#SHELLS[@]} ]; then
+                    if [ "${SHELL_SELECTED[$idx]}" = "1" ]; then
+                        SHELL_SELECTED[$idx]=0
+                    else
+                        SHELL_SELECTED[$idx]=1
+                    fi
+                fi
+                ;;
+            a|A)
+                for i in "${!SHELLS[@]}"; do SHELL_SELECTED[$i]=1; done
+                ;;
+            n|N)
+                for i in "${!SHELLS[@]}"; do SHELL_SELECTED[$i]=0; done
+                ;;
+            "")
+                break
+                ;;
+        esac
+
+        redraw_up $(( ${#SHELLS[@]} + 3 ))
+    done
+
+    SELECTED_SHELLS=()
+    for i in "${!SHELLS[@]}"; do
+        if [ "${SHELL_SELECTED[$i]}" = "1" ]; then
+            IFS='|' read -r key _ _ <<< "${SHELLS[$i]}"
+            SELECTED_SHELLS+=("$key")
+        fi
+    done
+
+    if [ ${#SELECTED_SHELLS[@]} -eq 0 ]; then
+        echo -e "  ${DIM}No shell agents selected — placeholder will use \$SHELL.${NC}"
+        return
+    fi
+
+    echo -e "  ${GREEN}✓${NC} Shells: ${BOLD}${SELECTED_SHELLS[*]}${NC}"
+
+    # Warn for shells that aren't installed on this host. Don't block — pre-staging
+    # configs is a legitimate use case.
+    for sh in "${SELECTED_SHELLS[@]}"; do
+        if ! command -v "$sh" >/dev/null 2>&1; then
+            echo -e "  ${YELLOW}⚠${NC} ${BOLD}$sh${NC} ${YELLOW}is not in PATH${NC} — install it on this host before spawning the agent."
+        fi
+    done
+
+    # Append to SELECTED_AGENTS so generate_agent_defaults / generate_sandbox_defaults
+    # emit their TOML blocks. De-dup in case the user runs interactively twice.
+    for sh in "${SELECTED_SHELLS[@]}"; do
+        local already=0
+        for a in "${SELECTED_AGENTS[@]}"; do
+            [ "$a" = "$sh" ] && already=1 && break
+        done
+        [ $already -eq 0 ] && SELECTED_AGENTS+=("$sh")
+    done
+}
+
+# Single-select default shell. Only invoked when ≥1 shell was chosen above.
+# The chosen shell's absolute path is written into $DEFAULT_SHELL_BIN and used
+# by do_install_dashboard to rewrite lince-viewport-placeholder's exec line.
+select_default_shell() {
+    if [ ${#SELECTED_SHELLS[@]} -eq 0 ]; then
+        return
+    fi
+
+    echo ""
+    print_separator
+    echo -e "${BOLD}Step 4b: Default shell for the dashboard placeholder${NC}"
+    echo ""
+    echo -e "  ${DIM}The right-hand pane in the tiled layout (the ASCII-art one)${NC}"
+    echo -e "  ${DIM}drops into a shell after the banner. Pick which one:${NC}"
+    echo ""
+
+    # Pre-select the host shell if it's in the chosen set, otherwise the first.
+    local host_shell
+    host_shell=$(basename "${SHELL:-/bin/bash}" 2>/dev/null)
+    local default_idx=0
+    for i in "${!SELECTED_SHELLS[@]}"; do
+        if [ "${SELECTED_SHELLS[$i]}" = "$host_shell" ]; then
+            default_idx=$i
+            break
+        fi
+    done
+
+    local idx=$default_idx
+    while true; do
+        for i in "${!SELECTED_SHELLS[@]}"; do
+            local sh="${SELECTED_SHELLS[$i]}"
+            if [ "$i" = "$idx" ]; then
+                echo -e "  ${GREEN}(•)${NC} ${BOLD}$((i+1))) $sh${NC}"
+            else
+                echo -e "  ${DIM}( ) $((i+1))) $sh${NC}"
+            fi
+        done
+        echo ""
+        echo -e "  ${DIM}Press 1-${#SELECTED_SHELLS[@]} to pick, Enter to confirm${NC}"
+        read -p "  > " -n 1 -r
+        echo ""
+
+        case "$REPLY" in
+            [1-9])
+                local pick=$((REPLY - 1))
+                if [ $pick -lt ${#SELECTED_SHELLS[@]} ]; then
+                    idx=$pick
+                fi
+                ;;
+            "")
+                break
+                ;;
+        esac
+
+        redraw_up $(( ${#SELECTED_SHELLS[@]} + 3 ))
+    done
+
+    DEFAULT_SHELL="${SELECTED_SHELLS[$idx]}"
+    # Resolve absolute path. If `command -v` fails (shell not installed),
+    # leave DEFAULT_SHELL_BIN empty — do_install_dashboard skips the rewrite
+    # so the placeholder keeps its current `exec "${SHELL:-/bin/bash}"` line.
+    DEFAULT_SHELL_BIN=$(command -v "$DEFAULT_SHELL" 2>/dev/null || true)
+    if [ -n "$DEFAULT_SHELL_BIN" ]; then
+        echo -e "  ${GREEN}✓${NC} Default shell: ${BOLD}$DEFAULT_SHELL${NC} ${DIM}($DEFAULT_SHELL_BIN)${NC}"
+    else
+        echo -e "  ${YELLOW}⚠${NC} ${BOLD}$DEFAULT_SHELL${NC} ${YELLOW}not in PATH — placeholder will fall back to \$SHELL${NC}"
+    fi
+}
+
 # ── TUI: VoxCode (voice input) ───────────────────────────────────────
 select_voxcode() {
     echo ""
     print_separator
-    echo -e "${BOLD}Step 4: Voice input (VoxCode)${NC}"
+    echo -e "${BOLD}Step 5: Voice input (VoxCode)${NC}"
     echo ""
     echo -e "  VoxCode lets you speak to your agents — transcriptions are"
     echo -e "  routed to the focused agent via the dashboard."
@@ -496,6 +696,18 @@ confirm_installation() {
         fi
     done
 
+    if [ ${#SELECTED_SHELLS[@]} -gt 0 ]; then
+        echo ""
+        echo -e "  Shells:"
+        for sh in "${SELECTED_SHELLS[@]}"; do
+            local marker=""
+            if [ "$sh" = "$DEFAULT_SHELL" ]; then
+                marker=" ${DIM}(default for tiled placeholder)${NC}"
+            fi
+            echo -e "    ${GREEN}✓${NC} $sh$marker"
+        done
+    fi
+
     echo ""
     if ! confirm "  Proceed with installation?"; then
         echo "  Cancelled."
@@ -551,25 +763,47 @@ generate_agent_defaults() {
     done
 }
 
-# Extract a TOML block from [agents.X] to the next [agents.Y] or EOF
+# Extract a TOML block from [agents.X] to the next TOML section or EOF.
+#
+# Captures the matched [agents.X] header plus any of its sub-tables
+# (e.g. [agents.X.env_vars]). Trailing blank lines and standalone `#`
+# comments after the section's last in-section line are buffered and
+# dropped on the next section boundary — without that, a freestanding
+# comment block before the *next* [agents.Y] would leak into this
+# extraction (see gh#91 regression).
 extract_agent_block() {
     local file="$1"
     local section="$2"
 
-    # Use awk to extract from [section] to next [agents.*] or EOF.
-    # Also captures sub-tables like [agents.codex.env_vars].
-    # We match the exact section header and any sub-table whose name
-    # starts with "section." (e.g. agents.codex.env_vars for agents.codex).
     awk -v sec="[$section]" -v secpfx="[$section." '
-        BEGIN { printing=0 }
-        /^\[agents\./ {
+        BEGIN { printing=0; buf="" }
+        # Any TOML section header is a potential boundary — not just [agents.*],
+        # so future top-level sections (e.g. [providers]) cant slip through.
+        /^\[/ {
             if ($0 == sec || (printing && index($0, secpfx) == 1)) {
+                # Flush buffered blanks/comments (they belong inside the section
+                # since real content followed them).
+                if (buf != "") { printf "%s", buf; buf="" }
                 printing=1
             } else if (printing) {
+                # Crossed into a different section. Discard the trailing buffer
+                # — those blanks/comments belong to whatever comes next.
                 printing=0
+                buf=""
             }
         }
-        printing { print }
+        printing {
+            if ($0 ~ /^[[:space:]]*$/ || $0 ~ /^[[:space:]]*#/) {
+                # Buffer; emit only if more in-section content follows.
+                buf = buf $0 "\n"
+            } else {
+                if (buf != "") { printf "%s", buf; buf="" }
+                print
+            }
+        }
+        # Intentionally no END flush: a section that runs to EOF with only
+        # trailing blanks/comments still drops them, which is what we want
+        # for clean output.
     ' "$file"
 }
 
@@ -611,6 +845,35 @@ do_install_voxcode() {
     fi
 }
 
+# Filter sandbox/agents-defaults.toml the same way we filter the dashboard's,
+# so `agent-sandbox run --agent <x>` only resolves the agents the user picked.
+# Sandbox schema is one block per agent (no `-unsandboxed` siblings) so this is
+# simpler than generate_agent_defaults — we just emit each [agents.<name>]
+# block. install.sh writes the file to two locations; we overwrite both.
+generate_sandbox_defaults() {
+    local src="$SCRIPT_DIR/sandbox/agents-defaults.toml"
+    local dst="$1"
+
+    if [ ! -f "$src" ]; then
+        return
+    fi
+
+    # Preserve the file header (top comment block) so the schema docs survive.
+    # The header runs from line 1 until the first [agents.*] line.
+    local header_end
+    header_end=$(grep -n '^\[agents\.' "$src" | head -1 | cut -d: -f1)
+    if [ -z "$header_end" ]; then
+        # No agent blocks in source — nothing to filter, leave file alone.
+        return
+    fi
+    head -n $((header_end - 1)) "$src" > "$dst"
+
+    for agent in "${SELECTED_AGENTS[@]}"; do
+        echo "" >> "$dst"
+        extract_agent_block "$src" "agents.${agent}" >> "$dst"
+    done
+}
+
 # ── Install sandbox ─────────────────────────────────────────────────
 do_install_sandbox() {
     # Only install agent-sandbox if bwrap backend is selected
@@ -629,6 +892,22 @@ do_install_sandbox() {
     else
         echo -e "${RED}✗ agent-sandbox installation failed${NC}"
         if ! confirm "Continue anyway?"; then exit 1; fi
+    fi
+
+    # Overwrite both copies install.sh wrote with a SELECTED_AGENTS-filtered
+    # version. Without this, the sandbox would happily resolve agents the
+    # user explicitly opted out of (e.g. zsh on a bash-only Linux setup).
+    if [ ${#SELECTED_AGENTS[@]} -gt 0 ]; then
+        local sandbox_targets=(
+            "$HOME/.agent-sandbox/agents-defaults.toml"
+            "$HOME/.local/bin/agents-defaults.toml"
+        )
+        for target in "${sandbox_targets[@]}"; do
+            if [ -f "$target" ]; then
+                generate_sandbox_defaults "$target"
+            fi
+        done
+        echo -e "  ${GREEN}✓ Sandbox agents filtered: ${SELECTED_AGENTS[*]}${NC}"
     fi
 }
 
@@ -674,6 +953,24 @@ do_install_dashboard() {
         generate_agent_defaults "$defaults_dst"
         echo -e "${GREEN}✓ Agent defaults written: $defaults_dst${NC}"
         echo -e "  ${DIM}Configured: ${SELECTED_AGENTS[*]}${NC}"
+    fi
+
+    # Hardcode the chosen default shell into lince-viewport-placeholder.
+    # The source ships with `exec "${SHELL:-/bin/bash}"` as a sentinel; we
+    # rewrite that line to `exec "<absolute-path>"` so the tiled layout's
+    # right-hand pane drops into the user-chosen shell instead of guessing
+    # from $SHELL (which may differ between the install host and the user's
+    # interactive sessions, e.g. when login=bash but interactive=zsh).
+    if [ -n "$DEFAULT_SHELL_BIN" ]; then
+        local placeholder="$HOME/.local/bin/lince-viewport-placeholder"
+        if [ -f "$placeholder" ]; then
+            # Match `exec "..."` lines — covers both the original
+            # `exec "${SHELL:-/bin/bash}"` and any prior rewrite of ours,
+            # so re-running quickstart with a different choice is idempotent.
+            sed -i.bak -E "s|^exec \".*\"\$|exec \"$DEFAULT_SHELL_BIN\"|" "$placeholder"
+            rm -f "${placeholder}.bak"
+            echo -e "${GREEN}✓ Tiled placeholder shell: ${BOLD}$DEFAULT_SHELL${NC} ${DIM}($DEFAULT_SHELL_BIN)${NC}"
+        fi
     fi
 }
 
@@ -924,12 +1221,23 @@ if [ "$USE_DEFAULTS" = true ]; then
         IFS='|' read -r key _ _ <<< "${AGENTS[$i]}"
         SELECTED_AGENTS+=("$key")
     done
+    # Ship the host's default shell as the only shell agent; everything else stays opt-in.
+    DEFAULT_SHELL=$(basename "${SHELL:-/bin/bash}" 2>/dev/null)
+    case "$DEFAULT_SHELL" in
+        bash|zsh|fish) ;;
+        *) DEFAULT_SHELL=bash ;;
+    esac
+    SELECTED_SHELLS=("$DEFAULT_SHELL")
+    SELECTED_AGENTS+=("$DEFAULT_SHELL")
+    DEFAULT_SHELL_BIN=$(command -v "$DEFAULT_SHELL" 2>/dev/null || true)
     SELECTED_LEVELS=""  # normal-only by default
-    echo -e "  ${DIM}Using defaults: all agents, bwrap sandbox, normal level only${NC}"
+    echo -e "  ${DIM}Using defaults: all agents, $DEFAULT_SHELL shell, bwrap sandbox, normal level only${NC}"
 else
     select_backends
     select_sandbox_levels
     select_agents
+    select_shells
+    select_default_shell
     if [ "$(uname -s)" != "Darwin" ]; then
         select_voxcode
     fi

--- a/sandbox/agents-defaults.toml
+++ b/sandbox/agents-defaults.toml
@@ -132,8 +132,21 @@ AWS_SESSION_TOKEN = "$AWS_SESSION_TOKEN"
 AWS_BEARER_TOKEN_BEDROCK = "$AWS_BEARER_TOKEN_BEDROCK"
 AWS_ENDPOINT_URL_BEDROCK_RUNTIME = "$AWS_ENDPOINT_URL_BEDROCK_RUNTIME"
 
+# Raw shell sessions inside the sandbox (gh#91). Useful for quick command
+# execution or file inspection in the project dir without firing up a full
+# coding agent. The dashboard restricts shell agents to sandbox_level=normal —
+# paranoid/permissive aren't offered for shells.
 [agents.bash]
 command = "bash"
+default_args = []
+env = {}
+home_ro_dirs = []
+home_rw_dirs = []
+bwrap_conflict = false
+disable_inner_sandbox_args = []
+
+[agents.zsh]
+command = "zsh"
 default_args = []
 env = {}
 home_ro_dirs = []

--- a/sandbox/agents-defaults.toml
+++ b/sandbox/agents-defaults.toml
@@ -153,3 +153,12 @@ home_ro_dirs = []
 home_rw_dirs = []
 bwrap_conflict = false
 disable_inner_sandbox_args = []
+
+[agents.fish]
+command = "fish"
+default_args = []
+env = {}
+home_ro_dirs = []
+home_rw_dirs = []
+bwrap_conflict = false
+disable_inner_sandbox_args = []


### PR DESCRIPTION
## Summary

Adds raw shell agents (bash, zsh, fish) to the dashboard's N-picker so users can drop into a shell session in the project directory without firing up a coding agent. Supports all installed sandbox backends (bwrap / nono / unsandboxed). Quickstart picks which shells to configure and which one runs in the tiled layout's right-hand placeholder pane.

## What's in the box

**Plugin / config** (`d7c2739b`)
- New `[agents.bash]` / `[agents.zsh]` (+ `-unsandboxed` siblings) in `lince-dashboard/agents-defaults.toml`
- `[agents.bash]` / `[agents.zsh]` in `sandbox/agents-defaults.toml`
- New `sandbox_levels: Vec<String>` field on `AgentTypeConfig` — pins shells to `["normal"]`
- `has_sandbox_levels()` returns false for ≤1 levels so the wizard auto-skips the SandboxLevel step
- `bash` / `zsh` arms in `synthesize_sandboxed_command` for bwrap/nono/unsandboxed backends
- `nono-profiles/lince-bash.json`, `lince-zsh.json` — workdir-scoped, developer network profile
- Docs added to `agent-examples.md`

**Quickstart + sandbox install** (`6ca6d72e`)
- Tightened `extract_agent_block` awk so trailing comment/blank runs don't leak into the previous extraction (root cause of "only the comment got installed")
- New Step 4 `select_shells` (multi-select; `$SHELL` pre-detection; warns for shells not in PATH)
- New Step 4b `select_default_shell` (single-select among the chosen ones; only when ≥1 shell picked)
- New `generate_sandbox_defaults()` filters `~/.agent-sandbox/agents-defaults.toml` and `~/.local/bin/agents-defaults.toml` by `SELECTED_AGENTS` after sandbox install
- The chosen default shell is sed-hardcoded into `~/.local/bin/lince-viewport-placeholder` (the tiled layout's ASCII-art right pane). Idempotent across re-runs.
- Fish added as a third shell agent (entry in both defaults files, `fish` arm in synthesizer, `lince-fish.json` nono profile)

## Test plan

- [ ] `./quickstart.sh` on Linux: pick bash only → only `[agents.bash]` ends up in `~/.config/lince-dashboard/agents-defaults.toml` and `~/.agent-sandbox/agents-defaults.toml`; placeholder execs `/usr/bin/bash`
- [ ] `./quickstart.sh` on Linux: pick bash + fish, default = fish → both blocks present in both files; placeholder execs the absolute path of fish
- [ ] `./quickstart.sh --defaults`: uses host `$SHELL` for the single shell agent
- [ ] Re-run `./quickstart.sh` with a different default shell → placeholder is rewritten cleanly (no `.bak` left behind, no duplicate exec lines)
- [ ] `./quickstart.sh` on macOS: zsh pre-checked; default ends up zsh; sandbox + dashboard files configured for zsh only
- [ ] In the dashboard, `n` → bash → wizard skips SandboxLevel step (only one option), skips Provider step (no env-var bundles); spawn lands in a sandboxed bash shell at `$WORKDIR`
- [ ] Same flow with backend = unsandboxed: bypasses agent-sandbox; pane title shows `[NON-SANDBOXED]`
- [ ] With nono backend installed: shell agent uses `nono run --profile lince-bash --workdir <dir> -- bash`

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)