### PR TITLE
feat: configurable default_agent_type for dashboard (gh#62)

### DIFF
--- a/docs/documentation/dashboard/config-reference.md
+++ b/docs/documentation/dashboard/config-reference.md
@@ -42,7 +42,7 @@ The plugin checks `config.toml` for changes every 5 seconds and applies them wit
 **Hot-reloadable** (applied immediately):
 
 - `focus_mode`, `status_method`, `max_agents`, `status_file_dir`
-- `agent_layout`, `default_provider`, `default_project_dir`
+- `agent_layout`, `default_provider`, `default_project_dir`, `default_agent_type`
 
 **Not hot-reloadable** (requires restart, only affects new agents):
 

--- a/lince-dashboard/plugin/src/config.rs
+++ b/lince-dashboard/plugin/src/config.rs
@@ -249,6 +249,12 @@ pub struct DashboardConfig {
     pub sandbox_config_path: Option<String>,
     #[serde(default)]
     pub default_project_dir: Option<String>,
+    /// Default agent type for the `n` shortcut and the `N` wizard's initial
+    /// selection. Must match a key in `agent_types` (loaded from
+    /// `agents-defaults.toml` + user overrides). Unknown values silently fall
+    /// back to `DEFAULT_AGENT_TYPE` then to the first registered type.
+    #[serde(default)]
+    pub default_agent_type: Option<String>,
     #[serde(default = "default_sandbox_command")]
     pub sandbox_command: String,
     #[serde(default)]
@@ -293,6 +299,7 @@ impl Default for DashboardConfig {
             provider_details_by_agent: HashMap::new(),
             sandbox_config_path: None,
             default_project_dir: None,
+            default_agent_type: None,
             sandbox_command: default_sandbox_command(),
             agent_layout: AgentLayout::default(),
             focus_mode: FocusMode::default(),
@@ -1029,6 +1036,28 @@ mod tests {
             Some("https://canonical.example.com"),
             "namespaced canonical must replace top-level legacy",
         );
+    }
+
+    /// `default_agent_type` (gh#62) round-trips through TOML so the `n`
+    /// shortcut + `N` wizard can pick it up from the user's config.
+    #[test]
+    fn dashboard_config_parses_default_agent_type() {
+        let toml_text = r#"
+            [dashboard]
+            default_agent_type = "codex"
+        "#;
+        let (cfg, err) = DashboardConfig::parse_toml(toml_text);
+        assert!(err.is_none(), "parse error: {err:?}");
+        assert_eq!(cfg.default_agent_type.as_deref(), Some("codex"));
+    }
+
+    /// Absent `default_agent_type` must deserialize to `None`, preserving the
+    /// pre-#62 behaviour for users who never touched the field.
+    #[test]
+    fn dashboard_config_default_agent_type_absent_is_none() {
+        let (cfg, err) = DashboardConfig::parse_toml("[dashboard]\n");
+        assert!(err.is_none(), "parse error: {err:?}");
+        assert!(cfg.default_agent_type.is_none());
     }
 
     /// Both forms in the same file must each contribute their distinct

--- a/lince-dashboard/plugin/src/main.rs
+++ b/lince-dashboard/plugin/src/main.rs
@@ -95,9 +95,20 @@ fn wrap_prev(current: usize, len: usize) -> usize {
 
 impl State {
     /// Resolve the effective default agent type.
-    /// Returns `DEFAULT_AGENT_TYPE` if it exists in the loaded agent_types,
-    /// otherwise falls back to the first available key (sorted).
+    ///
+    /// Precedence (gh#62):
+    /// 1. User-configured `[dashboard].default_agent_type`, if it names a
+    ///    registered agent type.
+    /// 2. `DEFAULT_AGENT_TYPE` ("claude") if registered.
+    /// 3. First registered type whose base name matches `DEFAULT_AGENT_TYPE`
+    ///    (e.g. `claude-unsandboxed`).
+    /// 4. First available type (sorted), as a last-resort fallback.
     fn effective_default_agent_type(&self) -> &str {
+        if let Some(configured) = self.config.default_agent_type.as_deref() {
+            if self.config.agent_types.contains_key(configured) {
+                return configured;
+            }
+        }
         if self.config.agent_types.contains_key(DEFAULT_AGENT_TYPE) {
             return DEFAULT_AGENT_TYPE;
         }
@@ -558,8 +569,13 @@ impl State {
                     .unwrap_or_default();
                 // Step 1 list: deduplicated base agents (e.g. "claude", not "claude-unsandboxed").
                 let agent_type_list = self.config.base_agents();
-                let default_at_index = agent_type_list.iter()
-                    .position(|(k, _)| k == DEFAULT_AGENT_TYPE)
+                // Prefer the configured default_agent_type's base (gh#62) when it
+                // appears in the list; fall back to DEFAULT_AGENT_TYPE; fall back to 0.
+                let configured_base = self.config.default_agent_type.as_deref()
+                    .map(agent::agent_type_base_name);
+                let default_at_index = configured_base
+                    .and_then(|base| agent_type_list.iter().position(|(k, _)| k == base))
+                    .or_else(|| agent_type_list.iter().position(|(k, _)| k == DEFAULT_AGENT_TYPE))
                     .unwrap_or(0);
                 let default_base = agent_type_list.get(default_at_index)
                     .map(|(k, _)| k.as_str())


### PR DESCRIPTION
## Summary

- Add `default_agent_type: Option<String>` to `DashboardConfig` so users can pick which agent type the `n` shortcut spawns without recompiling.
- `effective_default_agent_type()` now consults the config first, then falls back to `"claude"`, then the existing base-match / first-available chain. Unknown values are silently ignored.
- The `N` wizard's initial agent-type selection follows the same configured base (consistent with how `default_provider` seeds the wizard's provider step).
- Docs and the shipped sample `config.toml` already advertised this field; this PR finishes the wiring on the plugin side.

## Test plan

- [x] `cargo build --target wasm32-wasip1` (debug + release) compiles cleanly.
- [x] `cargo check --tests --target wasm32-wasip1` — added two unit tests in `config.rs` covering `default_agent_type` TOML round-trip and the absent-field case.
- [ ] Manual: set `default_agent_type = "codex"` in `~/.config/lince-dashboard/config.toml`, reload the dashboard, press `n` — name prompt should default to `codex-<N>`. Press `N` — wizard should open on codex.
- [ ] Manual: set `default_agent_type = "bogus"` — `n` still works, falls back to claude. No status-bar error.
- [ ] Manual: omit the field — behavior identical to pre-PR (defaults to claude when registered).

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)