### PR TITLE
feat: configurable default agent — static config + wizard `!` (gh#62)

### DIFF
--- a/docs/documentation/dashboard/config-reference.md
+++ b/docs/documentation/dashboard/config-reference.md
@@ -35,6 +35,20 @@ Created by `install.sh`. Holds dashboard-wide settings and optional agent type o
 | `sandbox_backend` | string | `"auto"` | Sandbox backend preference. `"auto"`, `"agent-sandbox"`, or `"nono"`. Auto prefers agent-sandbox on Linux, nono on macOS. |
 | `default_agent_type` | string | `"claude"` | Default agent type for new agents. Must match a key in agents-defaults.toml or an `[agents.*]` section. |
 
+### Session defaults (per-project, dynamic)
+
+In addition to the static `default_*` keys above, the `N` wizard's final
+**Confirm** step accepts `!` instead of `Enter` to spawn the agent **and**
+save all wizard choices (type, sandbox backend, sandbox level, provider,
+project dir) as the active `n` quick-spawn defaults for the current
+session. Defaults are persisted in `.lince-dashboard` next to the open
+agents when the user exits with `Q`, and reapplied on the next launch in
+the same directory. Press `!` again from a later wizard to overwrite.
+
+Session defaults take precedence over the static `[dashboard].default_*`
+fields — they cover the case where one project wants codex/permissive and
+another wants claude/paranoid without editing the global config.
+
 ### Hot-Reload
 
 The plugin checks `config.toml` for changes every 5 seconds and applies them without restart. A "Config reloaded" notification appears in the status bar.

--- a/docs/documentation/dashboard/config-reference.md
+++ b/docs/documentation/dashboard/config-reference.md
@@ -42,7 +42,7 @@ The plugin checks `config.toml` for changes every 5 seconds and applies them wit
 **Hot-reloadable** (applied immediately):
 
 - `focus_mode`, `status_method`, `max_agents`, `status_file_dir`
-- `agent_layout`, `default_provider`, `default_project_dir`
+- `agent_layout`, `default_provider`, `default_project_dir`, `default_agent_type`
 
 **Not hot-reloadable** (requires restart, only affects new agents):
 

--- a/lince-dashboard/plugin/src/config.rs
+++ b/lince-dashboard/plugin/src/config.rs
@@ -249,6 +249,12 @@ pub struct DashboardConfig {
     pub sandbox_config_path: Option<String>,
     #[serde(default)]
     pub default_project_dir: Option<String>,
+    /// Default agent type for the `n` shortcut and the `N` wizard's initial
+    /// selection. Must match a key in `agent_types` (loaded from
+    /// `agents-defaults.toml` + user overrides). Unknown values silently fall
+    /// back to `DEFAULT_AGENT_TYPE` then to the first registered type.
+    #[serde(default)]
+    pub default_agent_type: Option<String>,
     #[serde(default = "default_sandbox_command")]
     pub sandbox_command: String,
     #[serde(default)]
@@ -293,6 +299,7 @@ impl Default for DashboardConfig {
             provider_details_by_agent: HashMap::new(),
             sandbox_config_path: None,
             default_project_dir: None,
+            default_agent_type: None,
             sandbox_command: default_sandbox_command(),
             agent_layout: AgentLayout::default(),
             focus_mode: FocusMode::default(),
@@ -1029,6 +1036,28 @@ mod tests {
             Some("https://canonical.example.com"),
             "namespaced canonical must replace top-level legacy",
         );
+    }
+
+    /// `default_agent_type` (gh#62) round-trips through TOML so the `n`
+    /// shortcut + `N` wizard can pick it up from the user's config.
+    #[test]
+    fn dashboard_config_parses_default_agent_type() {
+        let toml_text = r#"
+            [dashboard]
+            default_agent_type = "codex"
+        "#;
+        let (cfg, err) = DashboardConfig::parse_toml(toml_text);
+        assert!(err.is_none(), "parse error: {err:?}");
+        assert_eq!(cfg.default_agent_type.as_deref(), Some("codex"));
+    }
+
+    /// Absent `default_agent_type` must deserialize to `None`, preserving the
+    /// pre-#62 behaviour for users who never touched the field.
+    #[test]
+    fn dashboard_config_default_agent_type_absent_is_none() {
+        let (cfg, err) = DashboardConfig::parse_toml("[dashboard]\n");
+        assert!(err.is_none(), "parse error: {err:?}");
+        assert!(cfg.default_agent_type.is_none());
     }
 
     /// Both forms in the same file must each contribute their distinct

--- a/lince-dashboard/plugin/src/dashboard.rs
+++ b/lince-dashboard/plugin/src/dashboard.rs
@@ -923,7 +923,11 @@ pub fn render_wizard(
             push_box_line(&mut lines, &format!("  Provider: {}", provider_display), box_width);
             push_box_line(&mut lines, &format!("  Dir:      {}", dir_display), box_width);
             push_box_line(&mut lines, "", box_width);
-            push_box_line(&mut lines, "  [Enter] Create  [Bksp] Back  [Esc] Cancel", box_width);
+            push_box_line(
+                &mut lines,
+                "  [Enter] Create  [!] Create+save defaults  [Bksp] Back  [Esc] Cancel",
+                box_width,
+            );
         }
         WizardStep::Provider => {
             // Render provider list with selection marker. Providers named

--- a/lince-dashboard/plugin/src/main.rs
+++ b/lince-dashboard/plugin/src/main.rs
@@ -19,7 +19,7 @@ const CMD_GET_CWD: &str = "get_cwd";
 const CMD_LOAD_CONFIG: &str = "load_config";
 
 use crate::types::{
-    AgentInfo, AgentStatus, NamePromptState, SavedAgentInfo,
+    AgentInfo, AgentStatus, NamePromptState, SavedAgentInfo, SessionDefaults,
     StatusMessage, WizardState, WizardStep,
 };
 
@@ -54,6 +54,10 @@ struct State {
     cwd_retries: u8,
     /// Stop retrying CWD after max attempts.
     cwd_retry_exhausted: bool,
+    /// Per-project `n` quick-spawn defaults captured via wizard `!` (gh#62).
+    /// When `Some`, the `n` shortcut spawns with these values instead of
+    /// resolving from `[dashboard].default_*` config fields.
+    session_defaults: Option<SessionDefaults>,
 }
 
 impl Default for State {
@@ -80,6 +84,7 @@ impl Default for State {
             init_kicked: false,
             cwd_retries: 0,
             cwd_retry_exhausted: false,
+            session_defaults: None,
         }
     }
 }
@@ -284,6 +289,7 @@ impl ZellijPlugin for State {
                             match state_file::parse_loaded_state(&stdout) {
                                 Ok(saved) => {
                                     self.next_agent_id = saved.next_agent_id;
+                                    self.session_defaults = saved.session_defaults;
                                     if self.agent_types_loaded {
                                         // Agent types already available — restore immediately.
                                         self.restore_agents(saved.agents);
@@ -543,8 +549,15 @@ impl State {
 
         match bare {
             BareKey::Char('n') => {
-                let effective_type = self.effective_default_agent_type();
-                let base = agent::agent_type_base_name(effective_type);
+                // gh#62: when session_defaults is set, use the session's agent_type
+                // to seed the default name; otherwise fall back to the static default.
+                let effective_type: String = match self.session_defaults.as_ref() {
+                    Some(sd) if self.config.agent_types.contains_key(&sd.agent_type) => {
+                        sd.agent_type.clone()
+                    }
+                    _ => self.effective_default_agent_type().to_string(),
+                };
+                let base = agent::agent_type_base_name(&effective_type);
                 let default_name = format!("{}-{}", base, self.next_agent_id + 1);
                 self.name_prompt = Some(NamePromptState {
                     input: String::new(),
@@ -766,22 +779,38 @@ impl State {
                     }
                     self.sort_agents_by_dir();
                 } else {
-                    // New agent mode: spawn (no wizard, no sandbox overrides).
-                    let effective_type = self.effective_default_agent_type().to_string();
+                    // New agent mode (gh#62): session_defaults wins over static config.
+                    // Use the saved wizard choices verbatim (agent_type, provider,
+                    // project_dir, sandbox_level, sandbox_backend); fall back to
+                    // the static `[dashboard].default_*` chain otherwise.
+                    let (effective_type, provider, project_dir, sandbox_level, sandbox_backend) =
+                        match self.session_defaults.as_ref() {
+                            Some(sd) if self.config.agent_types.contains_key(&sd.agent_type) => (
+                                sd.agent_type.clone(),
+                                sd.provider.clone(),
+                                sd.project_dir.clone(),
+                                sd.sandbox_level.clone(),
+                                sd.sandbox_backend.clone(),
+                            ),
+                            _ => (
+                                self.effective_default_agent_type().to_string(),
+                                self.config.default_provider.clone(),
+                                self.config.default_project_dir.clone().unwrap_or_default(),
+                                None,
+                                None,
+                            ),
+                        };
                     match agent::spawn_agent_custom(
                         &self.config,
                         &mut self.next_agent_id,
                         &self.agents,
                         name,
                         &effective_type,
-                        self.config.default_provider.clone(),
-                        self.config
-                            .default_project_dir
-                            .clone()
-                            .unwrap_or_default(),
+                        provider,
+                        project_dir,
                         self.launch_dir.as_deref(),
-                        None,
-                        None,
+                        sandbox_level,
+                        sandbox_backend,
                     ) {
                         Ok(info) => {
                             self.status_message = Some(format!("Spawned {}", info.name));
@@ -1058,7 +1087,7 @@ impl State {
                 _ => {}
             },
             WizardStep::Confirm => match bare {
-                BareKey::Enter => {
+                BareKey::Enter | BareKey::Char('!') => {
                     // Clone values out before dropping the borrow.
                     let name = wizard.name.clone();
                     let agent_type = wizard.effective_agent_type();
@@ -1072,6 +1101,19 @@ impl State {
                         wizard.selected_sandbox_level().map(|s| s.to_string())
                     };
                     let sandbox_backend = backend_choice;
+                    // gh#62: `!` makes these choices the active `n` quick-spawn
+                    // defaults for the rest of the session and persists them in
+                    // `.lince-dashboard` on the next `Q`.
+                    let save_defaults = matches!(bare, BareKey::Char('!'));
+                    if save_defaults {
+                        self.session_defaults = Some(SessionDefaults {
+                            agent_type: agent_type.clone(),
+                            provider: provider.clone(),
+                            project_dir: project_dir.clone(),
+                            sandbox_level: sandbox_level.clone(),
+                            sandbox_backend: sandbox_backend.clone(),
+                        });
+                    }
                     self.wizard = None;
                     self.spawn_wizard_agent(
                         name,
@@ -1081,6 +1123,16 @@ impl State {
                         sandbox_level,
                         sandbox_backend,
                     );
+                    if save_defaults {
+                        // Append the defaults-saved note to whatever spawn_wizard_agent
+                        // wrote (typically "Spawned <name>") to keep both signals visible.
+                        let prev = self.status_message.take().unwrap_or_default();
+                        self.status_message = Some(if prev.is_empty() {
+                            "Defaults saved for n".to_string()
+                        } else {
+                            format!("{} · defaults saved for n", prev)
+                        });
+                    }
                     return true;
                 }
                 BareKey::Backspace => {
@@ -1313,7 +1365,7 @@ impl State {
             .map(SavedAgentInfo::from)
             .collect();
 
-        match state_file::save_state_async(dir, saved, self.next_agent_id) {
+        match state_file::save_state_async(dir, saved, self.next_agent_id, self.session_defaults.clone()) {
             Ok(()) => {
                 self.status_message = Some("Saving state...".to_string());
             }

--- a/lince-dashboard/plugin/src/main.rs
+++ b/lince-dashboard/plugin/src/main.rs
@@ -95,9 +95,20 @@ fn wrap_prev(current: usize, len: usize) -> usize {
 
 impl State {
     /// Resolve the effective default agent type.
-    /// Returns `DEFAULT_AGENT_TYPE` if it exists in the loaded agent_types,
-    /// otherwise falls back to the first available key (sorted).
+    ///
+    /// Precedence (gh#62):
+    /// 1. User-configured `[dashboard].default_agent_type`, if it names a
+    ///    registered agent type.
+    /// 2. `DEFAULT_AGENT_TYPE` ("claude") if registered.
+    /// 3. First registered type whose base name matches `DEFAULT_AGENT_TYPE`
+    ///    (e.g. `claude-unsandboxed`).
+    /// 4. First available type (sorted), as a last-resort fallback.
     fn effective_default_agent_type(&self) -> &str {
+        if let Some(configured) = self.config.default_agent_type.as_deref() {
+            if self.config.agent_types.contains_key(configured) {
+                return configured;
+            }
+        }
         if self.config.agent_types.contains_key(DEFAULT_AGENT_TYPE) {
             return DEFAULT_AGENT_TYPE;
         }
@@ -558,8 +569,13 @@ impl State {
                     .unwrap_or_default();
                 // Step 1 list: deduplicated base agents (e.g. "claude", not "claude-unsandboxed").
                 let agent_type_list = self.config.base_agents();
-                let default_at_index = agent_type_list.iter()
-                    .position(|(k, _)| k == DEFAULT_AGENT_TYPE)
+                // Prefer the configured default_agent_type's base (gh#62) when it
+                // appears in the list; fall back to DEFAULT_AGENT_TYPE; fall back to 0.
+                let configured_base = self.config.default_agent_type.as_deref()
+                    .map(agent::agent_type_base_name);
+                let default_at_index = configured_base
+                    .and_then(|base| agent_type_list.iter().position(|(k, _)| k == base))
+                    .or_else(|| agent_type_list.iter().position(|(k, _)| k == DEFAULT_AGENT_TYPE))
                     .unwrap_or(0);
                 let default_base = agent_type_list.get(default_at_index)
                     .map(|(k, _)| k.as_str())

--- a/lince-dashboard/plugin/src/state_file.rs
+++ b/lince-dashboard/plugin/src/state_file.rs
@@ -1,8 +1,8 @@
 use crate::config::{run_typed_command, shell_escape};
-use crate::types::{SavedAgentInfo, SavedState};
+use crate::types::{SavedAgentInfo, SavedState, SessionDefaults};
 
 const STATE_FILE_NAME: &str = ".lince-dashboard";
-const STATE_VERSION: u32 = 2;
+const STATE_VERSION: u32 = 3;
 
 pub const CMD_SAVE_STATE: &str = "save_state";
 pub const CMD_LOAD_STATE: &str = "load_state";
@@ -21,6 +21,7 @@ pub fn save_state_async(
     launch_dir: &str,
     agents: Vec<SavedAgentInfo>,
     next_agent_id: u32,
+    session_defaults: Option<SessionDefaults>,
 ) -> Result<(), String> {
     let path = state_file_path(launch_dir);
 
@@ -28,6 +29,7 @@ pub fn save_state_async(
         version: STATE_VERSION,
         agents,
         next_agent_id,
+        session_defaults,
     };
 
     let json =
@@ -98,6 +100,43 @@ mod tests {
         let state = parse_loaded_state(json).expect("legacy state must load");
         assert_eq!(state.agents.len(), 1);
         assert_eq!(state.agents[0].provider.as_deref(), Some("vertex"));
+    }
+
+    /// gh#62: v2 state files (no `session_defaults`) must load and yield
+    /// `None` for the new field — backward compat for existing projects.
+    #[test]
+    fn v2_state_file_loads_with_none_session_defaults() {
+        let json = br#"{
+            "version": 2,
+            "agents": [],
+            "next_agent_id": 0
+        }"#;
+        let state = parse_loaded_state(json).expect("v2 state must load");
+        assert!(state.session_defaults.is_none());
+    }
+
+    /// gh#62: v3 state file with `session_defaults` round-trips through
+    /// serde so the `n` shortcut can reapply the wizard's last choice.
+    #[test]
+    fn v3_session_defaults_round_trip() {
+        let json = br#"{
+            "version": 3,
+            "agents": [],
+            "next_agent_id": 0,
+            "session_defaults": {
+                "agent_type": "codex",
+                "provider": "zai",
+                "project_dir": "/tmp/proj",
+                "sandbox_level": "permissive",
+                "sandbox_backend": "nono"
+            }
+        }"#;
+        let state = parse_loaded_state(json).expect("v3 state must load");
+        let sd = state.session_defaults.expect("session_defaults must be Some");
+        assert_eq!(sd.agent_type, "codex");
+        assert_eq!(sd.provider.as_deref(), Some("zai"));
+        assert_eq!(sd.project_dir, "/tmp/proj");
+        assert_eq!(sd.sandbox_level.as_deref(), Some("permissive"));
     }
 
     /// New state files use `provider`. Round-trip serialization writes

--- a/lince-dashboard/plugin/src/types.rs
+++ b/lince-dashboard/plugin/src/types.rs
@@ -387,10 +387,28 @@ impl From<&AgentInfo> for SavedAgentInfo {
     }
 }
 
+/// Per-project session defaults captured by the `N` wizard's `!` confirm
+/// shortcut (gh#62). Persisted in `.lince-dashboard` alongside open agents
+/// and reapplied to the `n` quick-spawn shortcut. `None` means: fall back to
+/// `[dashboard].default_agent_type` / `default_provider` / `default_project_dir`.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SessionDefaults {
+    /// Effective agent type key (e.g. `"claude"` or `"claude-unsandboxed"`).
+    pub agent_type: String,
+    pub provider: Option<String>,
+    pub project_dir: String,
+    pub sandbox_level: Option<String>,
+    pub sandbox_backend: Option<crate::sandbox_backend::SandboxBackend>,
+}
+
 /// Top-level saved state written to `.lince-dashboard`.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SavedState {
     pub version: u32,
     pub agents: Vec<SavedAgentInfo>,
     pub next_agent_id: u32,
+    /// Per-project `n` quick-spawn defaults captured via wizard `!` (gh#62).
+    /// Optional + serde-default so v2 state files load transparently.
+    #[serde(default)]
+    pub session_defaults: Option<SessionDefaults>,
 }


### PR DESCRIPTION
## Summary

Two complementary layers for gh#62 — pick whichever fits your project.

**Layer 1 — static** (`[dashboard].default_agent_type` in `config.toml`)
Sets the agent type pressed `n` will spawn, mirroring how `default_provider` / `default_project_dir` already work. Hot-reloadable. Unknown values fall back to `claude`.

**Layer 2 — dynamic** (`!` in the wizard's Confirm step)
Pressing `!` instead of `Enter` spawns the agent **and** stores the full wizard choice (agent type, sandbox backend, sandbox level, provider, project dir) as the active `n` quick-spawn defaults for the session. Persisted to `.lince-dashboard` v3 on `Q`, restored on next launch in the same directory. `!` always overwrites; no separate reset key (per design discussion).

Session defaults win over the static config field — they cover the case where one project wants codex/permissive and another wants claude/paranoid without editing the global config.

## UI

- Wizard footer at Confirm step: `[Enter] Create  [!] Create+save defaults  [Bksp] Back  [Esc] Cancel`
- After `!` spawn: status bar reads `Spawned <name> · defaults saved for n`
- No permanent header indicator (intentionally minimal-invasive)

## File changes

| Layer | File | Purpose |
|-------|------|---------|
| 1 | `lince-dashboard/plugin/src/config.rs` | `default_agent_type: Option<String>` field + 2 round-trip tests |
| 1 | `lince-dashboard/plugin/src/main.rs` | `effective_default_agent_type()` consults config; wizard's initial selection honors it |
| 2 | `lince-dashboard/plugin/src/types.rs` | `SessionDefaults` struct; `SavedState.session_defaults` |
| 2 | `lince-dashboard/plugin/src/state_file.rs` | Version bump to v3; v2→v3 + v3 round-trip tests |
| 2 | `lince-dashboard/plugin/src/main.rs` | `!` handler; `n` flow consults `session_defaults`; load/save plumbing |
| 2 | `lince-dashboard/plugin/src/dashboard.rs` | Wizard footer hint |
|   | `docs/documentation/dashboard/config-reference.md` | Both layers documented |

## Test plan

- [x] `cargo build --target wasm32-wasip1` (debug + release) — clean
- [x] `cargo check --tests --target wasm32-wasip1` — clean (native tests are blocked by zellij_tile's WASI-only shim; pre-existing constraint, no CI runs native tests here)
- [ ] Manual: set `default_agent_type = "codex"` in `~/.config/lince-dashboard/config.toml`; press `n` → spawns codex-N
- [ ] Manual: open `N` wizard, pick a non-default combo, press `!` → spawn happens + status reads "defaults saved for n"
- [ ] Manual: press `n` after `!` → name prompt defaults to the chosen base + next id; confirm → spawned with full session defaults
- [ ] Manual: `Q` (save+quit), restart → `n` still uses the saved session defaults; `.lince-dashboard` JSON shows `version: 3` + `session_defaults` block
- [ ] Manual: open older `.lince-dashboard` (v2) file → loads cleanly, `n` falls back to static config defaults

Replaces #117 (single PR for both layers, per design discussion).

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)