### PR TITLE
feat: pane title close hint + status bar 1-9 quick focus hint

### DIFF
--- a/lince-dashboard/plugin/src/agent.rs
+++ b/lince-dashboard/plugin/src/agent.rs
@@ -12,6 +12,10 @@ use crate::sandbox_backend::SandboxBackend;
 const AGENT_WRAPPER: &str = "lince-agent-wrapper";
 use crate::types::{AgentInfo, AgentStatus};
 
+/// Close-pane keybinding hint appended to every agent pane title.
+/// Keep in sync with the actual binding in `config.kdl` (`bind "Alt f" { ToggleFloatingPanes; }`).
+const CLOSE_PANE_HINT: &str = " │ Alt+f to close";
+
 /// Variant suffixes stripped by `agent_type_base_name()`.
 /// Add new suffixes here when new sandbox variants are introduced.
 const AGENT_TYPE_SUFFIXES: &[&str] = &[
@@ -62,13 +66,13 @@ pub fn pane_title(
     let cfg = agent_types.get(agent_type);
     let sandboxed = cfg.map_or(true, |c| c.sandboxed);
     if !sandboxed {
-        return format!("[NON-SANDBOXED] {}", name);
+        return format!("[NON-SANDBOXED] {}{}", name, CLOSE_PANE_HINT);
     }
     let level = sandbox_level_override
         .or_else(|| cfg.and_then(|c| c.sandbox_level.as_deref()));
     match level {
-        Some(level) => format!("{} [{}] {}", sandbox_level_glyph(level), level, name),
-        None => name.to_string(),
+        Some(level) => format!("{} [{}] {}{}", sandbox_level_glyph(level), level, name, CLOSE_PANE_HINT),
+        None => format!("{}{}", name, CLOSE_PANE_HINT),
     }
 }
 

--- a/lince-dashboard/plugin/src/dashboard.rs
+++ b/lince-dashboard/plugin/src/dashboard.rs
@@ -735,11 +735,11 @@ fn status_bar_hints(empty: bool, focused: bool, detail: bool) -> Vec<KeyHint> {
     if empty {
         vec![("n", "New-defaults"), ("N", "New-wizard"), ("Q", "Save+Quit"), ("?", "Help")]
     } else if focused {
-        vec![("Alt-f", "Unfocus"), ("[]", "Cycle"), ("r", "Rename"), ("x", "Kill"), ("i", "Info"), ("n", "New"), ("Q", "Save+Quit"), ("?", "Help")]
+        vec![("Alt-f", "Unfocus"), ("Alt+1-9", "Switch-agent"), ("[]", "Cycle"), ("r", "Rename"), ("x", "Kill"), ("i", "Info"), ("n", "New"), ("Q", "Save+Quit"), ("?", "Help")]
     } else if detail {
-        vec![("i", "Hide info"), ("f/Enter", "Focus"), ("j/k", "Nav"), ("r", "Rename"), ("x", "Kill"), ("n", "New"), ("Q", "Save+Quit"), ("?", "Help")]
+        vec![("i", "Hide info"), ("f/Enter", "Focus"), ("1-9", "Focus-N"), ("j/k", "Nav"), ("r", "Rename"), ("x", "Kill"), ("n", "New"), ("Q", "Save+Quit"), ("?", "Help")]
     } else {
-        vec![("n", "New-defaults"), ("N", "New-wizard"), ("f/Enter", "Focus"), ("r", "Rename"), ("x", "Kill"), ("i", "Info"), ("Q", "Save+Quit"), ("?", "Help")]
+        vec![("n", "New-defaults"), ("N", "New-wizard"), ("f/Enter", "Focus"), ("1-9", "Focus-N"), ("r", "Rename"), ("x", "Kill"), ("i", "Info"), ("Q", "Save+Quit"), ("?", "Help")]
     }
 }
 
@@ -1041,6 +1041,7 @@ pub fn render_help_overlay(rows: usize, cols: usize) {
     push_box_line(&mut lines, &format!("  {}j / Down{}   Move selection down", KEY_COLOR, RESET), box_width);
     push_box_line(&mut lines, &format!("  {}k / Up{}     Move selection up", KEY_COLOR, RESET), box_width);
     push_box_line(&mut lines, &format!("  {}1-9{}        Select & focus agent #", KEY_COLOR, RESET), box_width);
+    push_box_line(&mut lines, &format!("  {}Alt+1-9{}    Global: switch to agent #", KEY_COLOR, RESET), box_width);
     push_box_line(&mut lines, &format!("  {}[ ]{}        Cycle focused agent", KEY_COLOR, RESET), box_width);
     push_box_line(&mut lines, "", box_width);
 

--- a/lince-dashboard/plugin/src/main.rs
+++ b/lince-dashboard/plugin/src/main.rs
@@ -15,6 +15,7 @@ use crate::sandbox_backend::DetectedBackends;
 const PIPE_CLAUDE_STATUS: &str = "claude-status";
 const PIPE_LINCE_STATUS: &str = "lince-status";
 const PIPE_VOXCODE_TEXT: &str = "voxcode-text";
+const PIPE_FOCUS_AGENT: &str = "focus-agent";
 const CMD_GET_CWD: &str = "get_cwd";
 const CMD_LOAD_CONFIG: &str = "load_config";
 
@@ -493,6 +494,17 @@ impl ZellijPlugin for State {
         cli_pipe_output(&pipe_message.name, "");
 
         match pipe_message.name.as_str() {
+            PIPE_FOCUS_AGENT => {
+                if let Some(payload) = &pipe_message.payload {
+                    if let Ok(idx) = payload.parse::<usize>() {
+                        if idx > 0 && idx <= self.agents.len() {
+                            self.focus_agent_by_index(idx - 1);
+                            return true;
+                        }
+                    }
+                }
+                false
+            }
             PIPE_CLAUDE_STATUS | PIPE_LINCE_STATUS => {
                 if let Some(payload) = pipe_message.payload {
                     self.handle_status_message(&payload);
@@ -728,8 +740,7 @@ impl State {
             BareKey::Char(c @ '1'..='9') => {
                 let idx = (*c as u8 - b'1') as usize;
                 if idx < self.agents.len() {
-                    self.selected_index = idx;
-                    self.focus_selected();
+                    self.focus_agent_by_index(idx);
                     true
                 } else {
                     false
@@ -1190,6 +1201,19 @@ impl State {
                 self.status_message = Some(format!("Focused {}", agent.name));
             }
         }
+    }
+
+    /// Focus agent by 0-based index, unfocusing the current one first.
+    /// Used by both the 1-9 key handler (dashboard focus) and the Alt+1-9
+    /// pipe message (global keybinding via Zellij config.kdl MessagePlugin).
+    fn focus_agent_by_index(&mut self, idx: usize) {
+        if idx >= self.agents.len() {
+            return;
+        }
+        // Unfocus current agent if any.
+        self.unfocus_current();
+        self.selected_index = idx;
+        self.focus_selected();
     }
 
     /// Hide all agent floating panes (used after spawn to prevent unwanted pane visibility).

--- a/lince-dashboard/zellij-config/config.kdl
+++ b/lince-dashboard/zellij-config/config.kdl
@@ -144,6 +144,65 @@ keybinds clear-defaults=true {
         bind "Alt [" { PreviousSwapLayout; }
         bind "Alt ]" { NextSwapLayout; }
         bind "Alt f" { ToggleFloatingPanes; }
+        // Alt+1-9: broadcast focus-agent pipe to all running plugins.
+        // No plugin path specified to avoid launching a duplicate dashboard
+        // instance (the layout-loaded plugin has config_path which differs
+        // from a bare MessagePlugin target, causing a second spawn on first
+        // call). Broadcasting is safe: only lince-dashboard handles this pipe.
+        bind "Alt 1" {
+            MessagePlugin {
+                name "focus-agent"
+                payload "1"
+            }
+        }
+        bind "Alt 2" {
+            MessagePlugin {
+                name "focus-agent"
+                payload "2"
+            }
+        }
+        bind "Alt 3" {
+            MessagePlugin {
+                name "focus-agent"
+                payload "3"
+            }
+        }
+        bind "Alt 4" {
+            MessagePlugin {
+                name "focus-agent"
+                payload "4"
+            }
+        }
+        bind "Alt 5" {
+            MessagePlugin {
+                name "focus-agent"
+                payload "5"
+            }
+        }
+        bind "Alt 6" {
+            MessagePlugin {
+                name "focus-agent"
+                payload "6"
+            }
+        }
+        bind "Alt 7" {
+            MessagePlugin {
+                name "focus-agent"
+                payload "7"
+            }
+        }
+        bind "Alt 8" {
+            MessagePlugin {
+                name "focus-agent"
+                payload "8"
+            }
+        }
+        bind "Alt 9" {
+            MessagePlugin {
+                name "focus-agent"
+                payload "9"
+            }
+        }
         bind "Ctrl l" { SwitchToMode "locked"; }
         bind "Alt h" { MoveFocusOrTab "left"; }
         bind "Alt i" { MoveTab "left"; }


### PR DESCRIPTION
## Summary

Two discoverability and workflow improvements for the agent dashboard.

### gh#109 — Close-pane keybinding hint in agent pane title
Appends ` │ Alt+f to close` to every agent pane title via a centralized `CLOSE_PANE_HINT` constant in `agent.rs`. Users can now see how to dismiss the floating pane directly in the Zellij tab bar, even when the dashboard status bar is not visible.

**Before:**
- `🟢 [paranoid] agent-1`
- `[NON-SANDBOXED] claude`

**After:**
- `🟢 [paranoid] agent-1 │ Alt+f to close`
- `[NON-SANDBOXED] claude │ Alt+f to close`

### gh#110 — Alt+1..9 global keybindings for direct agent switching
When an agent pane has focus, pressing **Alt+1** through **Alt+9** now directly switches to the corresponding agent pane — no need to Alt+f first, then press a number.

**Architecture:**
- `config.kdl`: Alt+1..Alt+9 bound via `MessagePlugin` action, which pipes a `focus-agent` message to the dashboard plugin
- `main.rs`: Plugin `pipe()` handler receives the message, calls `focus_agent_by_index()` which unfocuses the current agent and focuses the target — single keystroke
- `dashboard.rs`: Status bar and help overlay show `Alt+1-9` hints
- Dashboard-level `1`-`9` keys still work when the dashboard has focus (unfocuses current agent first, then focuses target)

## Files changed
| File | Change |
|------|--------|
| `plugin/src/agent.rs` | `CLOSE_PANE_HINT` const + append to all 3 `pane_title()` return paths |
| `plugin/src/main.rs` | `PIPE_FOCUS_AGENT` pipe handler + `focus_agent_by_index()` method |
| `plugin/src/dashboard.rs` | `Alt+1-9` hint in status bar (focused context) and help overlay |
| `zellij-config/config.kdl` | Alt+1..Alt+9 `MessagePlugin` keybindings |

## Testing
```bash
cd lince-dashboard/plugin && cargo build --target wasm32-wasip1  # ✅ compiles
```

Closes #109, Closes #110