### PR TITLE
fix(dashboard): make bwrap sandbox generic for any agent type

### DIFF
--- a/lince-dashboard/plugin/src/agent.rs
+++ b/lince-dashboard/plugin/src/agent.rs
@@ -171,10 +171,33 @@ fn synthesize_sandboxed_command(
     project_dir: &str,
 ) -> Option<Vec<String>> {
     let base = agent_type_base_name(agent_type);
-    // Per-agent dispatch: (inner argv, $HOME subdir for the paranoid scratch).
+
+    // AgentSandbox (bwrap) doesn't need per-agent inner-command knowledge —
+    // agent-sandbox resolves the inner binary and args itself via --agent.
+    // Handle it generically so any agent type (including future ones) gets
+    // --sandbox-level passed through correctly.
+    if matches!(backend, SandboxBackend::AgentSandbox) {
+        let mut cmd = vec![
+            "agent-sandbox".to_string(),
+            "run".to_string(),
+            "-p".to_string(),
+            project_dir.to_string(),
+            "--id".to_string(),
+            agent_id.to_string(),
+            "--agent".to_string(),
+            base.to_string(),
+        ];
+        if level != "normal" {
+            cmd.push("--sandbox-level".to_string());
+            cmd.push(level.to_string());
+        }
+        return Some(cmd);
+    }
+
+    // Remaining backends (Nono, None) need per-agent knowledge:
+    // (inner argv, $HOME subdir for the paranoid scratch).
     // codex's `--sandbox danger-full-access` disables its own filesystem
-    // sandbox so it doesn't fight ours; the bwrap path also reads
-    // disable_inner_sandbox_args from agents-defaults.toml.
+    // sandbox so it doesn't fight ours.
     let (inner_command, agent_home_subdir): (Vec<String>, &str) = match base {
         "claude" => (
             vec![
@@ -223,23 +246,6 @@ fn synthesize_sandboxed_command(
     let nono_profile = resolve_nono_profile(base, level);
 
     Some(match backend {
-        SandboxBackend::AgentSandbox => {
-            let mut cmd = vec![
-                "agent-sandbox".to_string(),
-                "run".to_string(),
-                "-p".to_string(),
-                project_dir.to_string(),
-                "--id".to_string(),
-                agent_id.to_string(),
-                "--agent".to_string(),
-                base.to_string(),
-            ];
-            if level != "normal" {
-                cmd.push("--sandbox-level".to_string());
-                cmd.push(level.to_string());
-            }
-            cmd
-        }
         SandboxBackend::Nono => {
             let inner_str = inner_command
                 .iter()
@@ -282,6 +288,8 @@ fn synthesize_sandboxed_command(
             }
         }
         SandboxBackend::None => inner_command,
+        // AgentSandbox handled by the early return above.
+        SandboxBackend::AgentSandbox => unreachable!(),
     })
 }
 


### PR DESCRIPTION
## Summary

- Restructure `synthesize_sandboxed_command()` so the `AgentSandbox` (bwrap) backend returns early before the agent-specific match, making `--sandbox-level` work for **any** agent type without patching the Rust match
- Expose full `~/.ssh` directory (not just `known_hosts`) in the permissive sandbox profile

## Problem

Agent types not listed in the hard-coded match (`claude`, `codex`, `gemini`, `opencode`, `pi`, `bash`, `zsh`, `fish`) fell through to `_ => None`, which caused the caller to use the static `command` template from `agents-defaults.toml`. That template lacks `--sandbox-level`, so the agent ran at the default `normal` level regardless of its configured `sandbox_level = "permissive"`. The permissive profile's `home_ro_dirs` (including `.ssh`) were never mounted.

This affects any custom agent type added to `agents-defaults.toml` without also patching the Rust match.

## Fix

The `SandboxBackend::AgentSandbox` branch doesn't use `inner_command` or `agent_home_subdir` from the match — those are only consumed by `Nono` and `None` backends. So the agent-specific match is unnecessary for bwrap. The early return builds `agent-sandbox run --agent <base> [--sandbox-level <level>]` from just the base agent name, which agent-sandbox resolves internally.

## Test plan

- [x] Build WASM: `cd lince-dashboard/plugin && PATH="$HOME/.cargo/bin:$PATH" $HOME/.cargo/bin/cargo build --target wasm32-wasip1`
- [x] Install: `cp target/wasm32-wasip1/debug/lince-dashboard.wasm ~/.config/zellij/plugins/`
- [x] Spawn claude agent with permissive level → verify regression-free (same synthesis path, now via early return)
- [x] `ps aux | grep agent-sandbox` confirms `--sandbox-level permissive` in the bwrap command
- [x] Spawn any agent not in the hard-coded match with a sandbox level → `--sandbox-level` is now correctly passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #132