### PR TITLE
fix(hooks): fall back when `timeout` is missing (macOS)

### DIFF
--- a/lince-dashboard/hooks/claude-status-hook.sh
+++ b/lince-dashboard/hooks/claude-status-hook.sh
@@ -67,9 +67,21 @@ PAYLOAD="{\"agent_id\":\"${AGENT_ID}\",\"event\":\"${NATIVE_EVENT}\"}"
 
 echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ${AGENT_ID} ${NATIVE_EVENT}" >> "$LOG_FILE" 2>/dev/null || true
 
-# Primary: send via zellij pipe (if inside a Zellij session)
+# Primary: send via zellij pipe (if inside a Zellij session).
+# Use whatever `timeout` is available (GNU `timeout` on Linux, `gtimeout` on
+# macOS with `brew install coreutils`); fall back to running zellij directly
+# when neither exists — macOS ships without `timeout` by default.
+_lince_send_pipe() {
+    if command -v timeout >/dev/null 2>&1; then
+        timeout 2 zellij pipe --name "$1"
+    elif command -v gtimeout >/dev/null 2>&1; then
+        gtimeout 2 zellij pipe --name "$1"
+    else
+        zellij pipe --name "$1"
+    fi
+}
 if [ -n "${ZELLIJ:-}" ] && command -v zellij >/dev/null 2>&1; then
-    echo "$PAYLOAD" | timeout 2 zellij pipe --name "claude-status" >/dev/null 2>&1 || true
+    echo "$PAYLOAD" | _lince_send_pipe "claude-status" >/dev/null 2>&1 || true
 fi
 
 # Fallback: write status to file (always, as backup)

--- a/lince-dashboard/hooks/codex-status-hook.sh
+++ b/lince-dashboard/hooks/codex-status-hook.sh
@@ -57,8 +57,20 @@ PAYLOAD="{\"agent_id\":\"${AGENT_ID}\",\"event\":\"${NATIVE_EVENT}\"}"
 
 echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ${AGENT_ID} ${NATIVE_EVENT}" >> "$LOG_FILE" 2>/dev/null || true
 
+# Use whatever `timeout` is available (GNU `timeout` on Linux, `gtimeout` on
+# macOS with `brew install coreutils`); fall back to running zellij directly
+# when neither exists — macOS ships without `timeout` by default.
+_lince_send_pipe() {
+    if command -v timeout >/dev/null 2>&1; then
+        timeout 2 zellij pipe --name "$1"
+    elif command -v gtimeout >/dev/null 2>&1; then
+        gtimeout 2 zellij pipe --name "$1"
+    else
+        zellij pipe --name "$1"
+    fi
+}
 if [ -n "${ZELLIJ:-}" ] && command -v zellij >/dev/null 2>&1; then
-    printf '%s' "$PAYLOAD" | timeout 2 zellij pipe --name "lince-status" >/dev/null 2>&1 || true
+    printf '%s' "$PAYLOAD" | _lince_send_pipe "lince-status" >/dev/null 2>&1 || true
 fi
 
 mkdir -p "${STATUS_DIR}" 2>/dev/null || true


### PR DESCRIPTION
## Problem

`claude-status-hook.sh` and `codex-status-hook.sh` prefix the `zellij pipe` call with `timeout 2`. macOS doesn't ship `timeout` (it's GNU coreutils; Homebrew installs it as `gtimeout`). The pipe send fails silently with `timeout: command not found`, the dashboard never receives status events, and the Status column appears frozen.

`opencode-status-hook.js` was already fixed in PR #130 (dropped `timeout 2`); the two bash hooks still have it.

## Fix

Pick `timeout` if available, else `gtimeout`, else run `zellij pipe` unprotected. The pipe send is a fast IPC, so the missing wrapper is a non-issue on the happy path.

## Reproduction

```
command -v timeout            # empty on a stock macOS
ls ~/.local/bin/timeout 2>&1  # not installed
```

Then trigger Claude or Codex inside Lince. Without this fix the dashboard Status column stays at whatever value was last received (typically `INPUT` from a previous session) regardless of agent activity.

Closes #135.