### PR TITLE
fix(install): resolve cargo/rustc via rustup on macOS Homebrew setups

### DIFF
--- a/lince-dashboard/install.sh
+++ b/lince-dashboard/install.sh
@@ -134,8 +134,19 @@ if [ "$(uname -s)" = "Darwin" ]; then
     fi
     if [ -n "$BREW_CARGO" ] && ! command -v rustup >/dev/null 2>&1; then
         MISSING+=("rustup (Homebrew Rust detected at $BREW_CARGO but rustup is missing)")
-    elif [ -n "$BREW_CARGO" ] && ! rustup which cargo >/dev/null 2>&1; then
-        MISSING+=("rustup toolchain (run: rustup default stable)")
+    elif [ -n "$BREW_CARGO" ]; then
+        # rustup exists — verify the resolved cargo is actually rustup-managed,
+        # not Homebrew's standalone one.  `rustup which cargo` may succeed even
+        # when bare `cargo` still resolves to Homebrew's binary.
+        RUSTUP_CARGO="$(rustup which cargo 2>/dev/null || true)"
+        ACTIVE_CARGO="$(command -v cargo 2>/dev/null || true)"
+        if [ -z "$RUSTUP_CARGO" ]; then
+            MISSING+=("rustup toolchain (run: rustup default stable)")
+        elif [ "$RUSTUP_CARGO" != "$ACTIVE_CARGO" ] && [ ! -x "$HOME/.cargo/bin/cargo" ]; then
+            # rustup has a toolchain but the proxy in ~/.cargo/bin/ is missing —
+            # bare `cargo` will hit Homebrew's, and the build will fail.
+            MISSING+=("rustup cargo proxy (run: source ~/.cargo/env or restart your shell)")
+        fi
     fi
 fi
 

--- a/lince-dashboard/install.sh
+++ b/lince-dashboard/install.sh
@@ -134,19 +134,8 @@ if [ "$(uname -s)" = "Darwin" ]; then
     fi
     if [ -n "$BREW_CARGO" ] && ! command -v rustup >/dev/null 2>&1; then
         MISSING+=("rustup (Homebrew Rust detected at $BREW_CARGO but rustup is missing)")
-    elif [ -n "$BREW_CARGO" ]; then
-        # rustup exists — verify the resolved cargo is actually rustup-managed,
-        # not Homebrew's standalone one.  `rustup which cargo` may succeed even
-        # when bare `cargo` still resolves to Homebrew's binary.
-        RUSTUP_CARGO="$(rustup which cargo 2>/dev/null || true)"
-        ACTIVE_CARGO="$(command -v cargo 2>/dev/null || true)"
-        if [ -z "$RUSTUP_CARGO" ]; then
-            MISSING+=("rustup toolchain (run: rustup default stable)")
-        elif [ "$RUSTUP_CARGO" != "$ACTIVE_CARGO" ] && [ ! -x "$HOME/.cargo/bin/cargo" ]; then
-            # rustup has a toolchain but the proxy in ~/.cargo/bin/ is missing —
-            # bare `cargo` will hit Homebrew's, and the build will fail.
-            MISSING+=("rustup cargo proxy (run: source ~/.cargo/env or restart your shell)")
-        fi
+    elif [ -n "$BREW_CARGO" ] && ! rustup which rustc >/dev/null 2>&1; then
+        MISSING+=("rustup toolchain (run: rustup default stable)")
     fi
 fi
 

--- a/lince-dashboard/plugin/build.sh
+++ b/lince-dashboard/plugin/build.sh
@@ -26,20 +26,22 @@ if [ -z "$CARGO_BIN" ]; then
     exit 1
 fi
 
-# Verify the resolved cargo is rustup-managed (has the wasm32-wasip1 sysroot).
+# Verify the resolved cargo is rustup-managed by checking its path.
 if [ "$(uname -s)" = "Darwin" ]; then
-    SYSROOT="$("$CARGO_BIN" rustc -- --print sysroot 2>/dev/null || true)"
-    if [ -n "$SYSROOT" ] && ! echo "$SYSROOT" | grep -q "rustup"; then
-        echo "ERROR: resolved cargo ($CARGO_BIN) is not rustup-managed." >&2
-        echo "  Homebrew's standalone cargo cannot build wasm32-wasip1 targets." >&2
-        echo "" >&2
-        echo "  Fix: ensure the rustup toolchain is active:" >&2
-        echo "    rustup default stable" >&2
-        echo "    source ~/.cargo/env" >&2
-        echo "" >&2
-        echo "  Then verify: rustup which cargo" >&2
-        exit 1
-    fi
+    case "$CARGO_BIN" in
+        */.rustup/*|*/rustup/*) ;;  # rustup-managed, OK
+        *)
+            echo "ERROR: resolved cargo ($CARGO_BIN) is not rustup-managed." >&2
+            echo "  Homebrew's standalone cargo cannot build wasm32-wasip1 targets." >&2
+            echo "" >&2
+            echo "  Fix: ensure the rustup toolchain is active:" >&2
+            echo "    rustup default stable" >&2
+            echo "    source ~/.cargo/env" >&2
+            echo "" >&2
+            echo "  Then verify: rustup which cargo" >&2
+            exit 1
+            ;;
+    esac
 fi
 
 # Check target

--- a/lince-dashboard/plugin/build.sh
+++ b/lince-dashboard/plugin/build.sh
@@ -20,7 +20,24 @@ if command -v rustup >/dev/null 2>&1; then
     CARGO_BIN="$(rustup which cargo 2>/dev/null || true)"
     RUSTC_BIN="$(rustup which rustc 2>/dev/null || true)"
 fi
+
+# On macOS, Homebrew provides standalone rustc/cargo that cannot see
+# rustup-installed targets.  If rustup didn't resolve cargo, refuse to
+# fall back to a potentially-Homebrew binary — fail with remediation
+# steps instead of producing a cryptic "can't find crate for `core`".
 if [ -z "$CARGO_BIN" ] || [ ! -x "$CARGO_BIN" ]; then
+    if [ "$(uname -s)" = "Darwin" ]; then
+        echo "ERROR: could not resolve a rustup-managed cargo." >&2
+        echo "  Homebrew's standalone cargo cannot build wasm32-wasip1 targets." >&2
+        echo "" >&2
+        echo "  Fix: ensure the rustup toolchain is active:" >&2
+        echo "    rustup default stable" >&2
+        echo "    source ~/.cargo/env" >&2
+        echo "" >&2
+        echo "  Then verify: rustup which cargo" >&2
+        exit 1
+    fi
+    # Linux: safe to fall back to PATH resolution (no Homebrew conflict)
     CARGO_BIN="$(command -v cargo 2>/dev/null || true)"
 fi
 if [ -z "$CARGO_BIN" ]; then

--- a/lince-dashboard/plugin/build.sh
+++ b/lince-dashboard/plugin/build.sh
@@ -10,38 +10,26 @@ export PATH="$HOME/.cargo/bin:$PATH"
 TARGET="wasm32-wasip1"
 OUTPUT="$SCRIPT_DIR/lince-dashboard.wasm"
 
-# Resolve the actual cargo binary via rustup — on macOS, bare `cargo` may
-# resolve to Homebrew's standalone cargo which cannot see rustup-installed
-# targets.  Using the explicit path guarantees the rustup-managed toolchain.
+# Resolve the actual cargo and rustc binaries via rustup — on macOS, bare
+# `cargo`/`rustc` may resolve to Homebrew's standalone binaries which cannot
+# see rustup-installed targets.  Using explicit paths + RUSTC env var
+# guarantees the rustup-managed toolchain is used for both.
 CARGO_BIN=""
+RUSTC_BIN=""
 if command -v rustup >/dev/null 2>&1; then
     CARGO_BIN="$(rustup which cargo 2>/dev/null || true)"
+    RUSTC_BIN="$(rustup which rustc 2>/dev/null || true)"
 fi
 if [ -z "$CARGO_BIN" ] || [ ! -x "$CARGO_BIN" ]; then
-    # Fallback: try PATH resolution
     CARGO_BIN="$(command -v cargo 2>/dev/null || true)"
 fi
 if [ -z "$CARGO_BIN" ]; then
     echo "ERROR: cargo not found." >&2
     exit 1
 fi
-
-# Verify the resolved cargo is rustup-managed by checking its path.
-if [ "$(uname -s)" = "Darwin" ]; then
-    case "$CARGO_BIN" in
-        */.rustup/*|*/rustup/*) ;;  # rustup-managed, OK
-        *)
-            echo "ERROR: resolved cargo ($CARGO_BIN) is not rustup-managed." >&2
-            echo "  Homebrew's standalone cargo cannot build wasm32-wasip1 targets." >&2
-            echo "" >&2
-            echo "  Fix: ensure the rustup toolchain is active:" >&2
-            echo "    rustup default stable" >&2
-            echo "    source ~/.cargo/env" >&2
-            echo "" >&2
-            echo "  Then verify: rustup which cargo" >&2
-            exit 1
-            ;;
-    esac
+# Force cargo to use the rustup-managed rustc, not whatever is in PATH.
+if [ -n "$RUSTC_BIN" ] && [ -x "$RUSTC_BIN" ]; then
+    export RUSTC="$RUSTC_BIN"
 fi
 
 # Check target
@@ -56,6 +44,7 @@ fi
 
 echo "Building lince-dashboard plugin..."
 echo "  Using cargo: $CARGO_BIN"
+echo "  Using rustc: ${RUSTC:-$(command -v rustc)}"
 "$CARGO_BIN" build --release --target "$TARGET"
 
 # Binary target: output uses hyphens (lince-dashboard), not underscores

--- a/lince-dashboard/plugin/build.sh
+++ b/lince-dashboard/plugin/build.sh
@@ -10,18 +10,34 @@ export PATH="$HOME/.cargo/bin:$PATH"
 TARGET="wasm32-wasip1"
 OUTPUT="$SCRIPT_DIR/lince-dashboard.wasm"
 
-# On macOS, verify cargo is rustup-managed — Homebrew's standalone cargo
-# cannot see rustup-installed targets (dual Rust installation conflict).
+# Resolve the actual cargo binary via rustup — on macOS, bare `cargo` may
+# resolve to Homebrew's standalone cargo which cannot see rustup-installed
+# targets.  Using the explicit path guarantees the rustup-managed toolchain.
+CARGO_BIN=""
+if command -v rustup >/dev/null 2>&1; then
+    CARGO_BIN="$(rustup which cargo 2>/dev/null || true)"
+fi
+if [ -z "$CARGO_BIN" ] || [ ! -x "$CARGO_BIN" ]; then
+    # Fallback: try PATH resolution
+    CARGO_BIN="$(command -v cargo 2>/dev/null || true)"
+fi
+if [ -z "$CARGO_BIN" ]; then
+    echo "ERROR: cargo not found." >&2
+    exit 1
+fi
+
+# Verify the resolved cargo is rustup-managed (has the wasm32-wasip1 sysroot).
 if [ "$(uname -s)" = "Darwin" ]; then
-    if ! rustup which cargo >/dev/null 2>&1; then
-        echo "ERROR: active cargo is not managed by rustup." >&2
+    SYSROOT="$("$CARGO_BIN" rustc -- --print sysroot 2>/dev/null || true)"
+    if [ -n "$SYSROOT" ] && ! echo "$SYSROOT" | grep -q "rustup"; then
+        echo "ERROR: resolved cargo ($CARGO_BIN) is not rustup-managed." >&2
         echo "  Homebrew's standalone cargo cannot build wasm32-wasip1 targets." >&2
         echo "" >&2
-        echo "  Fix: ensure the rustup toolchain is set up:" >&2
+        echo "  Fix: ensure the rustup toolchain is active:" >&2
         echo "    rustup default stable" >&2
         echo "    source ~/.cargo/env" >&2
         echo "" >&2
-        echo "  Then verify: rustup which cargo  (should print ~/.cargo/bin/cargo)" >&2
+        echo "  Then verify: rustup which cargo" >&2
         exit 1
     fi
 fi
@@ -37,7 +53,8 @@ if ! rustup target list --installed 2>/dev/null | grep -q "$TARGET"; then
 fi
 
 echo "Building lince-dashboard plugin..."
-cargo build --release --target "$TARGET"
+echo "  Using cargo: $CARGO_BIN"
+"$CARGO_BIN" build --release --target "$TARGET"
 
 # Binary target: output uses hyphens (lince-dashboard), not underscores
 ARTIFACT="$SCRIPT_DIR/target/$TARGET/release/lince-dashboard.wasm"


### PR DESCRIPTION
## Summary
- Fix WASM build failure on macOS when both Homebrew Rust and rustup are installed
- Resolve `cargo` and `rustc` via `rustup which` instead of relying on PATH resolution
- Set `RUSTC` env var explicitly so cargo uses the rustup-managed compiler

## Problem
On macOS with Homebrew Rust + rustup, bare `cargo` resolves to Homebrew's binary which cannot see rustup-installed targets like `wasm32-wasip1`. Even after fixing cargo resolution, cargo internally invoked Homebrew's `rustc` (no `~/.cargo/bin/rustc` proxy existed), producing the same "can't find crate for `core`" error.

Follow-up to #134, closes #133.

## Test plan
- [x] Build succeeds on Fedora (Linux)
- [x] Build succeeds on macOS with Homebrew Rust + rustup
- [ ] Full install.sh run on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)