### PR TITLE
feat(dashboard): `U` shortcut quick-spawns an unsandboxed agent

### DIFF
--- a/lince-dashboard/plugin/src/dashboard.rs
+++ b/lince-dashboard/plugin/src/dashboard.rs
@@ -699,13 +699,13 @@ fn format_key_hints_short(hints: &[KeyHint]) -> String {
 /// Return the context-appropriate key hints.
 fn status_bar_hints(empty: bool, focused: bool, detail: bool) -> Vec<KeyHint> {
     if empty {
-        vec![("n", "New-defaults"), ("N", "New-wizard"), ("Q", "Save+Quit"), ("?", "Help")]
+        vec![("n", "New-defaults"), ("N", "New-wizard"), ("U", "New-unsandboxed"), ("Q", "Save+Quit"), ("?", "Help")]
     } else if focused {
-        vec![("Alt-f", "Unfocus"), ("Alt+1-9", "Switch-agent"), ("Alt+PgDn/Up", "Cycle"), ("r", "Rename"), ("x", "Kill"), ("i", "Info"), ("n", "New"), ("Q", "Save+Quit"), ("?", "Help")]
+        vec![("Alt-f", "Unfocus"), ("Alt+1-9", "Switch-agent"), ("Alt+PgDn/Up", "Cycle"), ("r", "Rename"), ("x", "Kill"), ("i", "Info"), ("n", "New"), ("U", "New-unsandboxed"), ("Q", "Save+Quit"), ("?", "Help")]
     } else if detail {
-        vec![("i", "Hide info"), ("f/Enter", "Focus"), ("1-9", "Focus-N"), ("j/k", "Nav"), ("r", "Rename"), ("x", "Kill"), ("n", "New"), ("Q", "Save+Quit"), ("?", "Help")]
+        vec![("i", "Hide info"), ("f/Enter", "Focus"), ("1-9", "Focus-N"), ("j/k", "Nav"), ("r", "Rename"), ("x", "Kill"), ("n", "New"), ("U", "New-unsandboxed"), ("Q", "Save+Quit"), ("?", "Help")]
     } else {
-        vec![("n", "New-defaults"), ("N", "New-wizard"), ("f/Enter", "Focus"), ("1-9", "Focus-N"), ("r", "Rename"), ("x", "Kill"), ("i", "Info"), ("Q", "Save+Quit"), ("?", "Help")]
+        vec![("n", "New-defaults"), ("N", "New-wizard"), ("U", "New-unsandboxed"), ("f/Enter", "Focus"), ("1-9", "Focus-N"), ("r", "Rename"), ("x", "Kill"), ("i", "Info"), ("Q", "Save+Quit"), ("?", "Help")]
     }
 }
 
@@ -1022,6 +1022,7 @@ pub fn render_help_overlay(rows: usize, cols: usize) {
     push_box_line(&mut lines, &format!("  {}Create{}", BOLD, RESET), box_width);
     push_box_line(&mut lines, &format!("  {}n{}          New agent (name prompt)", KEY_COLOR, RESET), box_width);
     push_box_line(&mut lines, &format!("  {}N{}          New agent wizard", KEY_COLOR, RESET), box_width);
+    push_box_line(&mut lines, &format!("  {}U{}          Quick unsandboxed (skip wizard)", KEY_COLOR, RESET), box_width);
     push_box_line(&mut lines, "", box_width);
 
     push_box_line(&mut lines, &format!("  {}Other{}", BOLD, RESET), box_width);

--- a/lince-dashboard/plugin/src/main.rs
+++ b/lince-dashboard/plugin/src/main.rs
@@ -603,6 +603,36 @@ impl State {
                 });
                 true
             }
+            BareKey::Char('U') => {
+                // Quick-spawn an unsandboxed agent. Skips the wizard entirely,
+                // ignores `session_defaults` (which are tied to the sandboxed
+                // workflow), and never touches them — `n` keeps spawning what
+                // the user picked via `!` in the wizard. Useful as a one-shot
+                // escape hatch for greenfield bootstrap where the sandbox
+                // would otherwise block tool caches (~/.npm, ~/.cargo, ...).
+                let base = agent::agent_type_base_name(
+                    self.effective_default_agent_type()
+                ).to_string();
+                let unsandboxed_type = format!("{}-unsandboxed", base);
+                if !self.config.agent_types.contains_key(&unsandboxed_type) {
+                    self.status_message = Some(format!(
+                        "U: no [agents.{}] configured — add it to use this shortcut",
+                        unsandboxed_type
+                    ));
+                    return true;
+                }
+                let name = format!("{}-{}", base, self.next_agent_id + 1);
+                let project_dir = self.config.default_project_dir.clone().unwrap_or_default();
+                self.spawn_wizard_agent(
+                    name,
+                    &unsandboxed_type,
+                    self.config.default_provider.clone(),
+                    project_dir,
+                    None,
+                    Some(sandbox_backend::SandboxBackend::None),
+                );
+                true
+            }
             BareKey::Char('r') => {
                 if let Some(agent) = self.agents.get(self.selected_index) {
                     self.rename_target = Some(agent.id.clone());


### PR DESCRIPTION
## Problem

The wizard's path to unsandboxed (`Shift+N` → Sandbox Backend → `none`) works, but it's hidden behind a default-tab that lands on `nono`. New users don't discover that backend `none` exists; even seasoned users hitting a greenfield bootstrap that needs `~/.npm`, `~/.cargo`, etc. have to walk the full wizard to get there.

## Fix

Add a top-level `U` keybinding that spawns the `<base>-unsandboxed` companion of the current default agent type, skipping the wizard. One-shot — does not touch `session_defaults`, so `n` keeps spawning the sandboxed configuration the user set up via `!`.

Surfaces in the help overlay and status-bar hints as `U  New-unsandboxed`. If the `<base>-unsandboxed` entry isn't configured for the current default agent, a status message explains why nothing happened.

## Why not expose `-unsandboxed` in wizard Step 1

That would revert the 2-axes design from #53 (`agent type × sandbox backend × level`, settled because the combined Cartesian product scales noisily). `U` keeps the architecture intact while offering a more discoverable path.

## Related

Surfaced while answering a user's question about why `Claude Code (unsandboxed)` doesn't appear in Step 1; same discussion produced PR #140 (doc fix for the now-obsolete mockup in `MULTI-AGENT-GUIDE.md`).