### PR TITLE
fix(dashboard): poll status .state files via run_command, not std::fs

### DIFF
--- a/lince-dashboard/plugin/src/config.rs
+++ b/lince-dashboard/plugin/src/config.rs
@@ -410,6 +410,29 @@ pub fn run_typed_command_with(args: &[&str], cmd_type: &str, extra: &[(&str, &st
 /// Command type for async path tab-completion via `run_command`.
 pub const CMD_PATH_COMPLETE: &str = "path_complete";
 
+/// Command type for async polling of per-agent `.state` status files.
+pub const CMD_POLL_STATUS: &str = "poll_status";
+
+/// Kick off async polling of the per-agent `.state` files.
+///
+/// WASI plugins have a virtualized filesystem — `std::fs` cannot see the
+/// host's `/tmp`, so the old `poll_status_files()` using `std::fs::read_to_string`
+/// silently read nothing. Read the files through a host `cat` via
+/// `run_command`, the same channel every other host-filesystem access in
+/// this plugin uses. Output is one `<basename>\t<event>` line per `.state`
+/// file (basename without the `.state` suffix); results arrive in
+/// `Event::RunCommandResult` with context `type=poll_status`.
+pub fn poll_status_files_async(status_dir: &str) {
+    let dir = shell_escape(status_dir);
+    let script = format!(
+        "for f in '{}'/*.state; do [ -f \"$f\" ] || continue; \
+         printf '%s\\t%s\\n' \"$(basename \"$f\" .state)\" \
+         \"$(tr -d '\\n' < \"$f\" 2>/dev/null)\"; done",
+        dir
+    );
+    run_typed_command(&["sh", "-c", &script], CMD_POLL_STATUS);
+}
+
 /// Command type for async discovery of custom sandbox-level profiles.
 /// Output format: lines of `<backend>:<base>:<level>` (or `<backend>:<base>:` for the
 /// suffix-less "normal" profile). See `discover_sandbox_levels_async()`.

--- a/lince-dashboard/plugin/src/main.rs
+++ b/lince-dashboard/plugin/src/main.rs
@@ -225,11 +225,12 @@ impl ZellijPlugin for State {
                     }
                 }
 
-                // File-based status polling fallback
+                // File-based status polling: kick off an async `cat` of the
+                // .state files. `std::fs` can't reach the host filesystem from
+                // the WASI plugin sandbox, so the read goes through a host
+                // shell command; results land in the CMD_POLL_STATUS handler.
                 if self.config.status_method == StatusMethod::File {
-                    if self.poll_status_files() {
-                        needs_render = true;
-                    }
+                    config::poll_status_files_async(&self.config.status_file_dir);
                 }
 
                 // Clear transient status messages after timeout
@@ -439,6 +440,51 @@ impl ZellijPlugin for State {
                             // If no matches, leave state unchanged.
                         }
                         true
+                    }
+                    Some(config::CMD_POLL_STATUS) if exit_code == Some(0) => {
+                        // Output: one `<basename>\t<event>` line per .state file.
+                        // The claude hook writes `claude-{id}.state` (basename
+                        // `claude-{id}`); the agent wrapper writes `{id}.state`
+                        // (basename `{id}`). Match both per agent.
+                        let output = String::from_utf8_lossy(&stdout);
+                        let mut file_events: std::collections::HashMap<&str, &str> =
+                            std::collections::HashMap::new();
+                        for line in output.lines() {
+                            if let Some((name, event)) = line.split_once('\t') {
+                                let event = event.trim();
+                                if !event.is_empty() {
+                                    file_events.insert(name, event);
+                                }
+                            }
+                        }
+                        let mut changed = false;
+                        for agent in self.agents.iter_mut() {
+                            let claude_key = format!("claude-{}", agent.id);
+                            let event = file_events
+                                .get(claude_key.as_str())
+                                .or_else(|| file_events.get(agent.id.as_str()))
+                                .copied();
+                            if let Some(event) = event {
+                                if agent.last_polled_event.as_deref() == Some(event) {
+                                    continue;
+                                }
+                                agent.last_polled_event = Some(event.to_string());
+                                let msg = StatusMessage {
+                                    agent_id: agent.id.clone(),
+                                    event: event.to_string(),
+                                    timestamp: None,
+                                    error: None,
+                                };
+                                let new_status = msg.to_agent_status(
+                                    self.config.event_map_for(&agent.agent_type),
+                                );
+                                if agent.status != new_status {
+                                    agent.status = new_status;
+                                    changed = true;
+                                }
+                            }
+                        }
+                        changed
                     }
                     _ => false,
                 }
@@ -1300,41 +1346,11 @@ impl State {
 
     /// Poll status files for all agents (file-based fallback, LINCE-42).
     /// Returns true if any agent state changed.
-    fn poll_status_files(&mut self) -> bool {
-        let mut changed = false;
-        let status_dir = &self.config.status_file_dir;
-        for agent in self.agents.iter_mut() {
-            // Check both file naming conventions:
-            // Claude hook writes "claude-{id}.state", wrapper writes "{id}.state"
-            let path_claude = format!("{}/claude-{}.state", status_dir, agent.id);
-            let path_wrapper = format!("{}/{}.state", status_dir, agent.id);
-            let content_opt = std::fs::read_to_string(&path_claude)
-                .or_else(|_| std::fs::read_to_string(&path_wrapper))
-                .ok();
-            if let Some(content) = content_opt {
-                let event = content.trim().to_string();
-                if !event.is_empty() {
-                    // Skip if the event hasn't changed since last poll
-                    if agent.last_polled_event.as_ref() == Some(&event) {
-                        continue;
-                    }
-                    agent.last_polled_event = Some(event.clone());
-                    let msg = StatusMessage {
-                        agent_id: agent.id.clone(),
-                        event,
-                        timestamp: None,
-                        error: None,
-                    };
-                    let new_status = msg.to_agent_status(self.config.event_map_for(&agent.agent_type));
-                    if agent.status != new_status {
-                        agent.status = new_status;
-                        changed = true;
-                    }
-                }
-            }
-        }
-        changed
-    }
+    // Status-file polling is now async — see `config::poll_status_files_async`
+    // (kicked off from the Timer handler) and the `CMD_POLL_STATUS` arm in
+    // `update()`. The previous synchronous `poll_status_files()` used
+    // `std::fs::read_to_string`, which silently reads nothing from a WASI
+    // plugin sandbox: the host `/tmp` is not on the plugin's virtual fs.
 
     /// Save current agent state and quit Zellij.
     /// The actual quit happens in the RunCommandResult handler after


### PR DESCRIPTION
## Problem

With `status_method = "file"` the dashboard never updates the Status column. `poll_status_files()` runs every timer tick but reads nothing.

## Root Cause

`poll_status_files()` reads the `.state` files with `std::fs::read_to_string`. Zellij plugins run in a WASI sandbox with a virtualized filesystem — the host `/tmp` is not on the plugin's view, so every read returns `Err`. It's the same reason the rest of the plugin reaches the host filesystem only through `run_command` (`pwd`, config-load `cat`, detect_backend, complete_path).

## Fix

Read the `.state` files through a host `cat` via `run_command`:

- `config::poll_status_files_async()` runs a shell loop over `<status_dir>/*.state`, emitting `<basename>\t<event>` lines.
- A new `CMD_POLL_STATUS` arm in `update()` parses them, maps each event through the agent's `event_map`, updates `AgentInfo.status`.

## Why it matters

`status_method` defaults to `pipe`, so most users don't hit this. But `file` is the only working channel for a sandboxed agent whose runtime can't reach the zellij IPC socket — e.g. the `nono` backend on macOS, where the socket lives under `$TMPDIR` outside the sandbox's filesystem grants. There the pipe is unreachable and the documented `file` fallback is silently broken.

Closes #143.