### PR TITLE
fix(dashboard): BSD sed alias setup still failing on macOS

### DIFF
--- a/lince-config/install.sh
+++ b/lince-config/install.sh
@@ -34,6 +34,15 @@ python3 -c "import tomlkit" 2>/dev/null || {
     echo -e "${YELLOW}  tomlkit not found. Installing...${NC}"
     _installed=false
     for _pip in "python3 -m pip" pip pip3; do
+        # --user installs fail inside virtualenvs, try without first
+        if $_pip install tomlkit 2>/dev/null; then
+            _installed=true
+            break
+        fi
+        if $_pip install --break-system-packages tomlkit 2>/dev/null; then
+            _installed=true
+            break
+        fi
         if $_pip install --user tomlkit 2>/dev/null; then
             _installed=true
             break
@@ -44,11 +53,8 @@ python3 -c "import tomlkit" 2>/dev/null || {
         fi
     done
     if [ "$_installed" = "false" ]; then
-        echo -e "${RED}  All pip attempts failed. Last error:${NC}"
-        python3 -m pip install --user --break-system-packages tomlkit || true
-        echo "" >&2
-        echo -e "${RED}  Install manually:${NC}" >&2
-        echo -e "${RED}    python3 -m pip install --user --break-system-packages tomlkit${NC}" >&2
+        echo -e "${RED}  Failed to install tomlkit. Install manually:${NC}"
+        echo -e "${RED}    python3 -m pip install tomlkit${NC}" >&2
         exit 1
     fi
 }

--- a/lince-config/install.sh
+++ b/lince-config/install.sh
@@ -34,16 +34,21 @@ python3 -c "import tomlkit" 2>/dev/null || {
     echo -e "${YELLOW}  tomlkit not found. Installing...${NC}"
     _installed=false
     for _pip in "python3 -m pip" pip pip3; do
-        for _flags in "--user" "--user --break-system-packages"; do
-            if $_pip install $_flags tomlkit 2>/dev/null; then
-                _installed=true
-                break 2
-            fi
-        done
+        if $_pip install --user tomlkit 2>/dev/null; then
+            _installed=true
+            break
+        fi
+        if $_pip install --user --break-system-packages tomlkit 2>/dev/null; then
+            _installed=true
+            break
+        fi
     done
     if [ "$_installed" = "false" ]; then
-        echo -e "${RED}  Failed to install tomlkit. Install manually:${NC}"
-        echo -e "${RED}    python3 -m pip install --user tomlkit${NC}"
+        echo -e "${RED}  All pip attempts failed. Last error:${NC}"
+        python3 -m pip install --user --break-system-packages tomlkit || true
+        echo "" >&2
+        echo -e "${RED}  Install manually:${NC}" >&2
+        echo -e "${RED}    python3 -m pip install --user --break-system-packages tomlkit${NC}" >&2
         exit 1
     fi
 }

--- a/lince-dashboard/install.sh
+++ b/lince-dashboard/install.sh
@@ -451,16 +451,21 @@ for rc in "$HOME/.bashrc" "$HOME/.zshrc"; do
             echo -e "${YELLOW}  Updating LINCE aliases in $(basename $rc)${NC}"
             # Remove old LINCE alias block and re-add
             # BSD sed (macOS) requires -i '' — GNU sed uses -i alone
-            _sed_inplace=(sed -i)
             if [ "$(uname -s)" = "Darwin" ]; then
-                _sed_inplace=(sed -i "")
+                sed -i '' '/# LINCE aliases/d' "$rc"
+                sed -i '' '/alias lince=/d' "$rc"
+                sed -i '' '/alias lince-floating=/d' "$rc"
+                sed -i '' '/alias zd=/d' "$rc"
+                sed -i '' '/alias z="zellij"/d' "$rc"
+                sed -i '' '/alias zn=/d' "$rc"
+            else
+                sed -i '/# LINCE aliases/d' "$rc"
+                sed -i '/alias lince=/d' "$rc"
+                sed -i '/alias lince-floating=/d' "$rc"
+                sed -i '/alias zd=/d' "$rc"
+                sed -i '/alias z="zellij"/d' "$rc"
+                sed -i '/alias zn=/d' "$rc"
             fi
-            "${_sed_inplace[@]}" '/# LINCE aliases/d' "$rc"
-            "${_sed_inplace[@]}" '/alias lince=/d' "$rc"
-            "${_sed_inplace[@]}" '/alias lince-floating=/d' "$rc"
-            "${_sed_inplace[@]}" '/alias zd=/d' "$rc"
-            "${_sed_inplace[@]}" '/alias z="zellij"/d' "$rc"
-            "${_sed_inplace[@]}" '/alias zn=/d' "$rc"
         fi
         echo "" >> "$rc"
         echo "$ALIAS_COMMENT" >> "$rc"

--- a/lince-dashboard/install.sh
+++ b/lince-dashboard/install.sh
@@ -135,17 +135,10 @@ if [ "$(uname -s)" = "Darwin" ]; then
     if [ -n "$BREW_CARGO" ] && ! command -v rustup >/dev/null 2>&1; then
         MISSING+=("rustup (Homebrew Rust detected at $BREW_CARGO but rustup is missing)")
     elif [ -n "$BREW_CARGO" ]; then
-        # rustup exists — verify the resolved cargo is actually rustup-managed,
-        # not Homebrew's standalone one.  `rustup which cargo` may succeed even
-        # when bare `cargo` still resolves to Homebrew's binary.
-        RUSTUP_CARGO="$(rustup which cargo 2>/dev/null || true)"
-        ACTIVE_CARGO="$(command -v cargo 2>/dev/null || true)"
-        if [ -z "$RUSTUP_CARGO" ]; then
+        # rustup exists — verify it can resolve a cargo binary.  The build script
+        # uses `rustup which cargo` directly, so the ~/.cargo/bin proxy is optional.
+        if ! rustup which cargo >/dev/null 2>&1; then
             MISSING+=("rustup toolchain (run: rustup default stable)")
-        elif [ "$RUSTUP_CARGO" != "$ACTIVE_CARGO" ] && [ ! -x "$HOME/.cargo/bin/cargo" ]; then
-            # rustup has a toolchain but the proxy in ~/.cargo/bin/ is missing —
-            # bare `cargo` will hit Homebrew's, and the build will fail.
-            MISSING+=("rustup cargo proxy (run: source ~/.cargo/env or restart your shell)")
         fi
     fi
 fi

--- a/lince-dashboard/plugin/build.sh
+++ b/lince-dashboard/plugin/build.sh
@@ -10,27 +10,24 @@ export PATH="$HOME/.cargo/bin:$PATH"
 TARGET="wasm32-wasip1"
 OUTPUT="$SCRIPT_DIR/lince-dashboard.wasm"
 
-# Resolve the actual cargo binary via rustup — on macOS, bare `cargo` may
-# resolve to Homebrew's standalone cargo which cannot see rustup-installed
-# targets.  Using the explicit path guarantees the rustup-managed toolchain.
+# Resolve the actual cargo and rustc binaries via rustup — on macOS, bare
+# `cargo`/`rustc` may resolve to Homebrew's standalone binaries which cannot
+# see rustup-installed targets.  Using explicit paths + RUSTC env var
+# guarantees the rustup-managed toolchain is used for both.
 CARGO_BIN=""
+RUSTC_BIN=""
 if command -v rustup >/dev/null 2>&1; then
     CARGO_BIN="$(rustup which cargo 2>/dev/null || true)"
-fi
-if [ -z "$CARGO_BIN" ] || [ ! -x "$CARGO_BIN" ]; then
-    # Fallback: try PATH resolution
-    CARGO_BIN="$(command -v cargo 2>/dev/null || true)"
-fi
-if [ -z "$CARGO_BIN" ]; then
-    echo "ERROR: cargo not found." >&2
-    exit 1
+    RUSTC_BIN="$(rustup which rustc 2>/dev/null || true)"
 fi
 
-# Verify the resolved cargo is rustup-managed (has the wasm32-wasip1 sysroot).
-if [ "$(uname -s)" = "Darwin" ]; then
-    SYSROOT="$("$CARGO_BIN" rustc -- --print sysroot 2>/dev/null || true)"
-    if [ -n "$SYSROOT" ] && ! echo "$SYSROOT" | grep -q "rustup"; then
-        echo "ERROR: resolved cargo ($CARGO_BIN) is not rustup-managed." >&2
+# On macOS, Homebrew provides standalone rustc/cargo that cannot see
+# rustup-installed targets.  If rustup didn't resolve cargo, refuse to
+# fall back to a potentially-Homebrew binary — fail with remediation
+# steps instead of producing a cryptic "can't find crate for `core`".
+if [ -z "$CARGO_BIN" ] || [ ! -x "$CARGO_BIN" ]; then
+    if [ "$(uname -s)" = "Darwin" ]; then
+        echo "ERROR: could not resolve a rustup-managed cargo." >&2
         echo "  Homebrew's standalone cargo cannot build wasm32-wasip1 targets." >&2
         echo "" >&2
         echo "  Fix: ensure the rustup toolchain is active:" >&2
@@ -40,6 +37,16 @@ if [ "$(uname -s)" = "Darwin" ]; then
         echo "  Then verify: rustup which cargo" >&2
         exit 1
     fi
+    # Linux: safe to fall back to PATH resolution (no Homebrew conflict)
+    CARGO_BIN="$(command -v cargo 2>/dev/null || true)"
+fi
+if [ -z "$CARGO_BIN" ]; then
+    echo "ERROR: cargo not found." >&2
+    exit 1
+fi
+# Force cargo to use the rustup-managed rustc, not whatever is in PATH.
+if [ -n "$RUSTC_BIN" ] && [ -x "$RUSTC_BIN" ]; then
+    export RUSTC="$RUSTC_BIN"
 fi
 
 # Check target
@@ -54,6 +61,7 @@ fi
 
 echo "Building lince-dashboard plugin..."
 echo "  Using cargo: $CARGO_BIN"
+echo "  Using rustc: ${RUSTC:-$(command -v rustc)}"
 "$CARGO_BIN" build --release --target "$TARGET"
 
 # Binary target: output uses hyphens (lince-dashboard), not underscores


### PR DESCRIPTION
## Summary

- Replace array-based `_sed_inplace=(sed -i "")` with explicit `if/else` branches for BSD vs GNU sed

## Problem

PR #139's array approach `(sed -i "")` still fails on macOS with the same `"extra characters at the end of p command"` error. The empty-string array element likely doesn't expand as a separate argument on macOS's bash 3.2.

## Fix

Use inline `if Darwin / else` branches with direct `sed -i ''` / `sed -i` calls — no arrays, no bash version sensitivity.

## Test plan

- [ ] Run `quickstart.sh` on macOS — alias setup step should complete without sed errors
- [ ] Run `quickstart.sh` on Fedora (regression check)

Follows up on #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)