### PR TITLE
fix(wizard): validate project_dir on Enter, surface error in box

### DIFF
--- a/lince-dashboard/plugin/src/dashboard.rs
+++ b/lince-dashboard/plugin/src/dashboard.rs
@@ -964,6 +964,17 @@ pub fn render_wizard(
                 push_box_line(&mut lines, "  (default: current directory)", box_width);
                 push_box_line(&mut lines, "  [Tab] autocomplete path", box_width);
             }
+            // Validation error line (set by the ProjectDir Enter handler when
+            // the path is empty/relative/tilde-prefixed). Bold red, cleared as
+            // soon as the user edits the field.
+            if let Some(ref err) = wizard.project_dir_error {
+                push_box_line(&mut lines, "", box_width);
+                push_box_line(
+                    &mut lines,
+                    &format!("  \x1b[1;31m✗ {}\x1b[0m", err),
+                    box_width,
+                );
+            }
             push_box_line(&mut lines, "", box_width);
             push_box_line(&mut lines, "  [Enter] Next  [Esc] Cancel", box_width);
         }

--- a/lince-dashboard/plugin/src/main.rs
+++ b/lince-dashboard/plugin/src/main.rs
@@ -732,6 +732,7 @@ impl State {
                     project_dir: default_dir,
                     completions: Vec::new(),
                     completion_index: None,
+                    project_dir_error: None,
                 };
                 state.step = state.active_steps().into_iter().next().unwrap_or(WizardStep::Name);
                 self.wizard = Some(state);
@@ -1113,8 +1114,50 @@ impl State {
                             wizard.project_dir = selected;
                         }
                         wizard.clear_completions();
-                    } else if let Some(next) = wizard.next_step() {
-                        wizard.step = next;
+                        wizard.project_dir_error = None;
+                    } else {
+                        // Validate BEFORE advancing. Sandbox backends (nono on
+                        // macOS, agent-sandbox/bwrap on Linux) require absolute
+                        // paths — catch typos here so the user sees the cause
+                        // and can correct without spawning a doomed agent.
+                        // The error is rendered as a red line below the input
+                        // by `render_wizard` (status_message is invisible while
+                        // the wizard overlay is active, hence this dedicated
+                        // field on WizardState).
+                        //
+                        // Tilde handling: the path completer collapses absolute
+                        // matches back to `~/...` for readability (handler
+                        // CMD_PATH_COMPLETE applies `collapse_tilde`). Expand
+                        // it transparently here so the wizard accepts `~/...`
+                        // input — the backend gets the absolute form.
+                        let trimmed_owned = wizard.project_dir.trim().to_string();
+                        if trimmed_owned.starts_with('~') {
+                            let expanded = config::expand_tilde(&trimmed_owned);
+                            if expanded.starts_with('/') {
+                                wizard.project_dir = expanded;
+                            }
+                        }
+                        let trimmed = wizard.project_dir.trim();
+                        let err = if trimmed.is_empty() {
+                            Some("Project dir is required.")
+                        } else if trimmed.starts_with('~') {
+                            // Tilde survived expansion → $HOME unavailable in
+                            // this plugin process. Ask for the full path.
+                            Some("Project dir does not expand `~`. Use the full /Users/... path (Tab to autocomplete).")
+                        } else if !trimmed.starts_with('/') {
+                            Some("Project dir must be an absolute path (Tab to autocomplete).")
+                        } else {
+                            None
+                        };
+                        if let Some(msg) = err {
+                            wizard.project_dir_error = Some(msg.to_string());
+                            // Stay on ProjectDir — Backspace to edit, Tab to autocomplete.
+                            return true;
+                        }
+                        wizard.project_dir_error = None;
+                        if let Some(next) = wizard.next_step() {
+                            wizard.step = next;
+                        }
                     }
                 }
                 BareKey::Tab => {
@@ -1138,11 +1181,13 @@ impl State {
                     } else {
                         wizard.project_dir.pop();
                         wizard.clear_completions();
+                        wizard.project_dir_error = None;
                     }
                 }
                 BareKey::Char(c) => {
                     wizard.project_dir.push(c);
                     wizard.clear_completions();
+                    wizard.project_dir_error = None;
                 }
                 _ => {}
             },

--- a/lince-dashboard/plugin/src/types.rs
+++ b/lince-dashboard/plugin/src/types.rs
@@ -159,6 +159,12 @@ pub struct WizardState {
     pub completions: Vec<String>,
     /// Currently highlighted completion index (if any).
     pub completion_index: Option<usize>,
+    /// Validation error for the Project dir step. Set when Enter is
+    /// pressed on ProjectDir with an invalid value (empty, tilde-prefixed,
+    /// or not absolute); rendered as a red line below the input by
+    /// `render_wizard`. Cleared as soon as the user edits the field or
+    /// the value becomes valid.
+    pub project_dir_error: Option<String>,
 }
 
 impl WizardState {


### PR DESCRIPTION
Closes #126.

## Problem

The wizard's `ProjectDir` step accepts any input when Enter is pressed, even
malformed paths (relative, missing `~/...` expansion, non-existent dirs).
The failure mode is a cryptic backend error after spawn — the user has no
hint that the input was invalid until the sandbox refuses to start.

## Fix

Validate `project_dir` on Enter at the step itself, before advancing:

- Expand `~` and trim.
- Require an absolute path (`/...`). If the user typed `~/foo` and `~` did
  not expand (no `$HOME`, exotic shell), the message is explicit about
  needing the full `/Users/...` path.
- Reject paths that fail expansion with a dedicated message.
- On failure: stay on the `ProjectDir` step, render the validation error
  inline in the input box, and let the user fix with Backspace / Tab.

No state mutation on bad input — the wizard cannot leave `ProjectDir`
holding an invalid value.

## Files

- `lince-dashboard/plugin/src/main.rs` — Enter handler validation + error
  surfacing on the `ProjectDir` step.
- `lince-dashboard/plugin/src/types.rs` — `project_dir_error: Option<String>`
  on the wizard state.
- `lince-dashboard/plugin/src/dashboard.rs` — render the error line inside
  the input box.

## Test plan

- [ ] Type a relative path (`foo`) + Enter → error shown, step doesn't advance.
- [ ] Type `~/some/path` in a shell where `~` was already expanded → continues.
- [ ] Type `/non/existent/abs/path` + Enter → continues (existence is the backend's job; only shape is validated here, matching the issue scope).
- [ ] Tab still autocompletes from the same step.