### PR TITLE
fix(wizard): normalize trailing-slash on completer matches + swimlane key

### DIFF
--- a/lince-dashboard/plugin/src/dashboard.rs
+++ b/lince-dashboard/plugin/src/dashboard.rs
@@ -376,10 +376,12 @@ fn render_agent_table(
     let mut header_dirs: Vec<String> = Vec::new();
     let mut last_dir: Option<&str> = None;
     for (i, agent) in agents.iter().enumerate() {
-        if last_dir != Some(&agent.project_dir) {
+        // Compare/display normalized so legacy `path/` and new `path` group together.
+        let key = agent.project_dir.trim_end_matches('/');
+        if last_dir != Some(key) {
             virtual_rows.push(None);
-            header_dirs.push(agent.project_dir.clone());
-            last_dir = Some(&agent.project_dir);
+            header_dirs.push(key.to_string());
+            last_dir = Some(key);
         }
         virtual_rows.push(Some(i));
         header_dirs.push(String::new());

--- a/lince-dashboard/plugin/src/main.rs
+++ b/lince-dashboard/plugin/src/main.rs
@@ -420,9 +420,18 @@ impl ZellijPlugin for State {
                             let mut matches: Vec<String> = output
                                 .lines()
                                 .filter(|l| !l.is_empty())
-                                .map(|l| config::collapse_tilde(l))
+                                // Normalize the trailing-slash inconsistency
+                                // between the legacy glob path completer (which
+                                // returns `path/`) and the multi-root `find`
+                                // (which returns `path`). Otherwise two agents
+                                // pointed at the same project but spawned from
+                                // different code paths end up in distinct
+                                // swimlanes — see also `sort_agents_by_dir`.
+                                .map(|l| l.trim_end_matches('/').to_string())
+                                .map(|l| config::collapse_tilde(&l))
                                 .collect();
                             matches.sort();
+                            matches.dedup();
 
                             if matches.len() == 1 {
                                 // Single match: auto-fill directly.
@@ -595,6 +604,14 @@ impl ZellijPlugin for State {
     }
 }
 
+/// Group/sort key for agent workdirs. Strips a trailing `/` so paths that
+/// differ only by that (e.g. `synoptic/` from the legacy glob completer vs
+/// `synoptic` from the multi-root `find`) land in the same swimlane in the
+/// dashboard. Doesn't mutate `agent.project_dir` — only the comparison.
+fn workdir_key(s: &str) -> &str {
+    s.trim_end_matches('/')
+}
+
 impl State {
     /// Sort agents by project_dir, then by name within each group.
     /// Preserves the selected agent across the sort.
@@ -602,7 +619,8 @@ impl State {
         let selected_id = self.agents.get(self.selected_index).map(|a| a.id.clone());
 
         self.agents.sort_by(|a, b| {
-            a.project_dir.cmp(&b.project_dir).then(a.name.cmp(&b.name))
+            workdir_key(&a.project_dir).cmp(workdir_key(&b.project_dir))
+                .then(a.name.cmp(&b.name))
         });
 
         if let Some(id) = selected_id {


### PR DESCRIPTION
Related to #125.

## Problem

The wizard's path completer historically returns directories with a trailing
`/` (the legacy `for d in <prefix>*/; do echo "\$d"; done` shell glob). When
the multi-root recursive `find` was introduced (RFC #127), it returns paths
without trailing slash. Two agents pointed at the same project but spawned
through different code paths end up with `project_dir` values like
`/Users/me/proj/synoptic/` vs `/Users/me/proj/synoptic` — and the dashboard
groups agents by `project_dir` string, so they fall into distinct swimlanes.

Issue #125 also tracks the broader relative-path bug; this PR addresses
the trailing-slash discrepancy that surfaces alongside it (sandbox spawn
also gets unhappy with a path that ends in `/`).

## Fix

- Normalize completer output: strip trailing `/` before storing in
  `wizard.project_dir`.
- Normalize the swimlane group key in `sort_agents_by_dir` (function
  `workdir_key`) so an agent with `…/proj` and one with `…/proj/` land
  in the same lane regardless of where the value originated.

The swimlane normalization is a comparison-only helper — it does NOT
mutate the stored `agent.project_dir`, so the value the user typed is
preserved for display.

## Files

- `lince-dashboard/plugin/src/main.rs` — strip trailing slash on completer
  result; `workdir_key` helper for swimlane grouping.
- `lince-dashboard/plugin/src/dashboard.rs` — use `workdir_key` when
  computing the swimlane group.

## Test plan

- [ ] Spawn agent A with `~/Projects/foo` (no slash). Spawn agent B with
      `~/Projects/foo/` (trailing slash). They appear in the **same** swimlane.
- [ ] Use Tab autocomplete on a partial → completed value has no trailing slash.
- [ ] Backend spawn does not receive `…/foo/` paths.