### PR TITLE
fix(update): preserve user config.toml and agents-defaults.toml

### DIFF
--- a/lince-dashboard/update.sh
+++ b/lince-dashboard/update.sh
@@ -52,13 +52,12 @@ CONFIG_DIR="$HOME/.config/lince-dashboard"
 CONFIG_DST="$CONFIG_DIR/config.toml"
 mkdir -p "$CONFIG_DIR"
 
-if [ -f "$CONFIG_DST" ]; then
-    BACKUP="${CONFIG_DST}.bak.$(date +%Y%m%d_%H%M%S)"
-    cp "$CONFIG_DST" "$BACKUP"
-    echo -e "${YELLOW}  Existing config backed up → $(basename "$BACKUP")${NC}"
+if [ ! -f "$CONFIG_DST" ]; then
+    cp "$SCRIPT_DIR/config.toml" "$CONFIG_DST"
+    echo -e "${GREEN}  ✓ Config installed${NC}"
+else
+    echo -e "${GREEN}  ✓ Existing config preserved (delete it manually to receive new defaults)${NC}"
 fi
-cp "$SCRIPT_DIR/config.toml" "$CONFIG_DST"
-echo -e "${GREEN}  ✓ Config updated${NC}"
 echo ""
 
 # ── Hooks ──────────────────────────────────────────────────────────────
@@ -80,9 +79,11 @@ echo -e "${GREEN}[7/8] Updating agent defaults...${NC}"
 AGENTS_DEFAULTS_SRC="$SCRIPT_DIR/agents-defaults.toml"
 AGENTS_DEFAULTS_DST="$CONFIG_DIR/agents-defaults.toml"
 
-if [ -f "$AGENTS_DEFAULTS_SRC" ]; then
+if [ -f "$AGENTS_DEFAULTS_SRC" ] && [ ! -f "$AGENTS_DEFAULTS_DST" ]; then
     cp "$AGENTS_DEFAULTS_SRC" "$AGENTS_DEFAULTS_DST"
-    echo -e "${GREEN}  ✓ Agent defaults updated${NC}"
+    echo -e "${GREEN}  ✓ Agent defaults installed${NC}"
+elif [ -f "$AGENTS_DEFAULTS_DST" ]; then
+    echo -e "${GREEN}  ✓ Existing agent defaults preserved (delete it manually to receive new upstream defaults)${NC}"
 fi
 echo ""
 

--- a/lince-dashboard/update.sh
+++ b/lince-dashboard/update.sh
@@ -56,8 +56,13 @@ if [ ! -f "$CONFIG_DST" ]; then
     cp "$SCRIPT_DIR/config.toml" "$CONFIG_DST"
     echo -e "${GREEN}  ✓ Config installed${NC}"
 else
-    echo -e "${GREEN}  ✓ Existing config preserved (delete it manually to receive new defaults)${NC}"
+    echo -e "${GREEN}  ✓ Existing config preserved${NC}"
 fi
+# Always refresh the shipped-defaults sidecar so users can diff against new
+# upstream keys without losing their customizations:
+#   diff -u "$CONFIG_DST.dist" "$CONFIG_DST"
+cp "$SCRIPT_DIR/config.toml" "$CONFIG_DST.dist"
+echo -e "${GREEN}  ✓ Upstream defaults available at config.toml.dist${NC}"
 echo ""
 
 # ── Hooks ──────────────────────────────────────────────────────────────
@@ -83,9 +88,20 @@ if [ -f "$AGENTS_DEFAULTS_SRC" ] && [ ! -f "$AGENTS_DEFAULTS_DST" ]; then
     cp "$AGENTS_DEFAULTS_SRC" "$AGENTS_DEFAULTS_DST"
     echo -e "${GREEN}  ✓ Agent defaults installed${NC}"
 elif [ -f "$AGENTS_DEFAULTS_DST" ]; then
-    echo -e "${GREEN}  ✓ Existing agent defaults preserved (delete it manually to receive new upstream defaults)${NC}"
+    echo -e "${GREEN}  ✓ Existing agent defaults preserved${NC}"
+fi
+# Always refresh the shipped-defaults sidecar (mirrors the config.toml.dist
+# pattern above) so new upstream agent defaults stay discoverable:
+#   diff -u "$AGENTS_DEFAULTS_DST.dist" "$AGENTS_DEFAULTS_DST"
+if [ -f "$AGENTS_DEFAULTS_SRC" ]; then
+    cp "$AGENTS_DEFAULTS_SRC" "$AGENTS_DEFAULTS_DST.dist"
+    echo -e "${GREEN}  ✓ Upstream defaults available at agents-defaults.toml.dist${NC}"
 fi
 echo ""
+
+# NOTE: new upstream keys are not auto-merged into preserved user files — by
+# design, to avoid clobbering customizations. The .dist sidecars surface the
+# diff. A tomlkit-based key-merge utility is tracked as follow-up in #108.
 
 # ── Lince-add-supported-agent skill ──────────────────────────────────
 echo -e "${GREEN}[8/8] Updating lince-add-supported-agent skill...${NC}"


### PR DESCRIPTION
## Problem

`lince-dashboard/update.sh` destroyed user customizations on every run:

- **`config.toml`**: backed up with a timestamp, then **always overwritten** from the shipped template — silently discarding API keys, security levels, agent tweaks, etc.
- **`agents-defaults.toml`**: **always copied** over the user's file, with no backup at all.

A user who ran `update.sh` after any release lost their local configuration.

## Fix

Preserve existing user files, and ship the upstream defaults as a `.dist` sidecar so new keys stay discoverable without clobbering customizations:

- `config.toml` / `agents-defaults.toml`: written **only** when the destination does not already exist (first install behaves exactly as before).
- On every run, the shipped defaults are (re)written to a sibling **`*.dist`** file:
  - `~/.config/lince-dashboard/config.toml.dist`
  - `~/.config/lince-dashboard/agents-defaults.toml.dist`
- Users can review new upstream keys with:
  ```bash
  diff -u ~/.config/lince-dashboard/config.toml.dist ~/.config/lince-dashboard/config.toml
  ```

Non-config assets (plugin WASM, layouts, hooks, wrappers, skills) keep being replaced on every update — correct distinction between user-owned and repo-owned files.

## Why the `.dist` sidecar (addressing review feedback)

@maeste rightly flagged that a pure "skip if exists" guard introduces the opposite problem: a user with an existing `config.toml` would **never** receive new default keys from future releases, and "delete it manually" is a destructive workaround.

The `.dist` sidecar is the low-effort option from that discussion: it surfaces every new upstream key via a plain `diff`, with zero risk to user data and no extra tooling. Automatic key-merging (tomlkit-based) is intentionally **out of scope** here and tracked as follow-up in #108.

## Test plan

- [x] Existing `config.toml` is preserved (not overwritten, not backed up away)
- [x] Existing `agents-defaults.toml` is preserved
- [x] `config.toml.dist` and `agents-defaults.toml.dist` are written with current upstream defaults on every run
- [x] First-time install (no existing files) still receives the shipped defaults
- [x] `bash -n update.sh` passes; verified end-to-end by running `update.sh` against a populated config dir