### PR TITLE
fix(dashboard): detect_backend_async resolves binaries via absolute paths

### DIFF
--- a/lince-dashboard/plugin/src/sandbox_backend.rs
+++ b/lince-dashboard/plugin/src/sandbox_backend.rs
@@ -66,10 +66,26 @@ pub const CMD_DETECT_BACKEND: &str = "detect_backend";
 /// Checks for `agent-sandbox` and `nono` in PATH. Results arrive in
 /// `Event::RunCommandResult` with context `type=detect_backend`.
 pub fn detect_backend_async() {
+    // WASI plugins inherit a sandboxed / empty PATH and `export PATH=...`
+    // inside the script does NOT propagate the way one would expect under
+    // Zellij's host shell implementation. Bypass PATH entirely: probe
+    // well-known absolute install locations + use /usr/bin/uname directly.
+    // This covers macOS (Homebrew Apple Silicon /opt/homebrew, Intel
+    // /usr/local) and Linux (/usr/bin, /usr/local/bin, ~/.local/bin via
+    // $HOME) without depending on PATH at all.
     let script = concat!(
-        "echo -n 'agent-sandbox:'; command -v agent-sandbox >/dev/null 2>&1 && echo 'yes' || echo 'no'; ",
-        "echo -n 'nono:'; command -v nono >/dev/null 2>&1 && echo 'yes' || echo 'no'; ",
-        "echo -n 'os:'; uname -s 2>/dev/null || echo 'unknown'"
+        "as=no; ",
+        "for p in /usr/bin/agent-sandbox /usr/local/bin/agent-sandbox /opt/homebrew/bin/agent-sandbox \"$HOME/.local/bin/agent-sandbox\"; do ",
+        "  [ -x \"$p\" ] && { as=yes; break; }; ",
+        "done; ",
+        "echo \"agent-sandbox:$as\"; ",
+        "nn=no; ",
+        "for p in /opt/homebrew/bin/nono /usr/local/bin/nono /usr/bin/nono \"$HOME/.local/bin/nono\"; do ",
+        "  [ -x \"$p\" ] && { nn=yes; break; }; ",
+        "done; ",
+        "echo \"nono:$nn\"; ",
+        "os=$(/usr/bin/uname -s 2>/dev/null || /bin/uname -s 2>/dev/null); ",
+        "echo \"os:${os:-unknown}\""
     );
     crate::config::run_typed_command(&["sh", "-c", script], CMD_DETECT_BACKEND);
 }


### PR DESCRIPTION
Partial fix for #112.

## Problem

`detect_backend_async()` invokes `nono` / `agent-sandbox` via bare names
relying on the WASI plugin host's `\$PATH`. On macOS, Zellij plugins
inherit a minimal `\$PATH` that often does **not** include
`/opt/homebrew/bin` (where Homebrew installs `nono`). The detection
silently returns "not installed" → the wizard falls back to
`SandboxBackend::Default` (= `AgentSandbox`) → spawn tries to exec
`agent-sandbox`, which also isn't on the plugin's `\$PATH` → cryptic
backend error.

This is one of the failure paths covered by #112.

## Fix

`detect_backend_async()` now resolves each candidate via a list of
absolute paths (`/opt/homebrew/bin/<bin>`, `/usr/local/bin/<bin>`,
`/usr/bin/<bin>`, `\$HOME/.local/bin/<bin>`) before falling back to a
bare-name PATH lookup. The first existing executable wins. On Linux the
common system paths still work; on macOS the Homebrew paths now resolve
correctly without depending on the inherited `\$PATH`.

## Scope

This PR addresses **only** the binary-resolution failure mode of #112.
The broader concern in #112 — that `SandboxBackend::Default` is hardcoded
to `AgentSandbox` regardless of platform — is a separate change (the
wizard should default to `Nono` on macOS once detection confirms it). I'm
happy to follow up with that in a separate PR if the maintainers prefer.

## Files

- `lince-dashboard/plugin/src/sandbox_backend.rs` — `detect_backend_async`
  now tries absolute paths first, with a documented fallback chain.

## Test plan

- [ ] On macOS Homebrew: launch wizard with `nono` installed only via
      `brew install nono`. The dashboard's "available backends" reflects
      `nono` as available (was reporting "none" before).
- [ ] On Linux with `agent-sandbox` in `/usr/local/bin`: detection still works.
- [ ] On a host without either binary: detection still returns no backend
      (no false positives).