### PR TITLE
feat: relay messaging + nono sandbox fixes

### DIFF
--- a/lince-dashboard/MULTI-AGENT-GUIDE.md
+++ b/lince-dashboard/MULTI-AGENT-GUIDE.md
@@ -298,6 +298,46 @@ The dashboard now listens on two pipe names:
 
 Both pipes are active simultaneously. No configuration needed.
 
+## Message Relay
+
+The dashboard can relay conversation messages from one agent to another, letting you share context, cross-review output, or challenge one agent's work with another.
+
+### How it works
+
+The dashboard reads Claude Code's JSONL transcript files to extract structured conversation messages (user prompts and assistant responses). These are formatted and injected as typed text into the target agent's pane.
+
+### UX flow
+
+1. Navigate to the **source agent** (the one whose messages you want to relay)
+2. Press `s` to relay the **last message**, or `S` to be prompted for a count (1--9)
+3. The dashboard extracts the messages from the source agent's transcript
+4. A **target selection** overlay appears — pick the destination agent with `f`/`Enter` or its number key (`1`--`9`)
+5. The relayed text is typed into the target pane, delivered as if you pasted it
+
+### Use cases
+
+- **Cross-review**: Have one agent review another agent's output by relaying the conversation
+- **Challenge mode**: Relay one agent's solution to another agent and ask it to find flaws or improvements
+- **Context sharing**: Bring a second agent up to speed by relaying relevant conversation history
+- **Handoff**: Transfer partial work context when switching tasks between agents
+
+### Format
+
+Relayed text is wrapped with header and footer markers so the receiving agent can distinguish relayed content from direct input:
+
+```
+--- Relay from fullstack (2 messages) ---
+[User]: Implement a binary search tree with insert and delete
+[Assistant]: Here's the BST implementation with insert and delete operations...
+--- End relay ---
+```
+
+Messages are prefixed with `[User]:` or `[Assistant]:` to preserve the conversation structure.
+
+### Limitations
+
+Currently works with **Claude Code agents only**. The relay feature requires `transcript_path` from Claude Code's hooks to locate the JSONL conversation log. Agents without native hooks that don't report `transcript_path` will show "Transcript not available" when you attempt to relay from them. Support for other agent transcript formats may be added in the future.
+
 ## File Changes Summary
 
 | File | Change |

--- a/lince-dashboard/README.md
+++ b/lince-dashboard/README.md
@@ -20,6 +20,8 @@ Multi-agent TUI dashboard for managing AI coding agents in [Zellij](https://zell
 
 Sandboxed agents run inside [agent-sandbox](../sandbox/) (bubblewrap, Linux) or [nono](https://github.com/always-further/nono) (Landlock/Seatbelt, Linux + macOS) — the dashboard manages pane lifecycle and status, not isolation. The sandbox backend is auto-detected or configurable per-agent.
 
+**Message relay**: Send conversation messages between agents (`s` to relay last message, `S` for N messages).
+
 ## Prerequisites
 
 - **Zellij** >= 0.40 (0.43.x recommended)
@@ -69,6 +71,8 @@ Press `n` to spawn an agent (quick name prompt), or `N` for the full wizard (typ
 | `h` / `Esc` | Hide agent pane |
 | `j` / `k` | Navigate agent list |
 | `i` | Toggle detail panel |
+| `s` | Relay last message to another agent |
+| `S` | Relay N messages (prompt for count) |
 | `x` | Kill agent |
 | `Q` | Save state & quit |
 | `?` | Help overlay |

--- a/lince-dashboard/agents-template.toml
+++ b/lince-dashboard/agents-template.toml
@@ -35,7 +35,7 @@ color = "green"
 sandboxed = true
 has_native_hooks = true
 home_ro_dirs = ["~/.claude/"]
-profiles = ["__discover__"]
+providers = ["__discover__"]
 sandbox_level = "paranoid"
 
 [agents.claude-permissive]
@@ -48,7 +48,7 @@ color = "yellow"
 sandboxed = true
 has_native_hooks = true
 home_ro_dirs = ["~/.claude/"]
-profiles = ["__discover__"]
+providers = ["__discover__"]
 sandbox_level = "permissive"
 
 # ── Codex ───────────────────────────────────────────────────────────
@@ -61,12 +61,11 @@ display_name = "OpenAI Codex (paranoid)"
 short_label = "CDP"
 color = "green"
 sandboxed = true
-has_native_hooks = false
-ignore_wrapper_start = true
+has_native_hooks = true
 bwrap_conflict = true
 disable_inner_sandbox_args = ["--sandbox", "danger-full-access"]
 home_ro_dirs = ["~/.codex/"]
-profiles = ["__discover__"]
+providers = ["__discover__"]
 sandbox_level = "paranoid"
 
 [agents.codex-paranoid.env_vars]
@@ -80,12 +79,11 @@ display_name = "OpenAI Codex (permissive)"
 short_label = "CD+"
 color = "yellow"
 sandboxed = true
-has_native_hooks = false
-ignore_wrapper_start = true
+has_native_hooks = true
 bwrap_conflict = true
 disable_inner_sandbox_args = ["--sandbox", "danger-full-access"]
 home_ro_dirs = ["~/.codex/"]
-profiles = ["__discover__"]
+providers = ["__discover__"]
 sandbox_level = "permissive"
 
 [agents.codex-permissive.env_vars]
@@ -105,7 +103,7 @@ has_native_hooks = false
 bwrap_conflict = false
 disable_inner_sandbox_args = []
 home_ro_dirs = ["~/.gemini/"]
-profiles = ["__discover__"]
+providers = ["__discover__"]
 sandbox_level = "paranoid"
 
 [agents.gemini-paranoid.env_vars]
@@ -123,7 +121,7 @@ has_native_hooks = false
 bwrap_conflict = false
 disable_inner_sandbox_args = []
 home_ro_dirs = ["~/.gemini/"]
-profiles = ["__discover__"]
+providers = ["__discover__"]
 sandbox_level = "permissive"
 
 [agents.gemini-permissive.env_vars]
@@ -143,7 +141,7 @@ has_native_hooks = false
 bwrap_conflict = false
 disable_inner_sandbox_args = []
 home_ro_dirs = ["~/.config/opencode/"]
-profiles = ["__discover__"]
+providers = ["__discover__"]
 sandbox_level = "paranoid"
 
 [agents.opencode-permissive]
@@ -158,7 +156,7 @@ has_native_hooks = false
 bwrap_conflict = false
 disable_inner_sandbox_args = []
 home_ro_dirs = ["~/.config/opencode/"]
-profiles = ["__discover__"]
+providers = ["__discover__"]
 sandbox_level = "permissive"
 
 # ── Pi ──────────────────────────────────────────────────────────────
@@ -175,7 +173,7 @@ has_native_hooks = true
 bwrap_conflict = false
 disable_inner_sandbox_args = []
 home_ro_dirs = ["~/.pi/"]
-profiles = ["__discover__"]
+providers = ["__discover__"]
 sandbox_level = "paranoid"
 
 # Pi paranoid covers anthropic, openai, gemini (the providers nono and
@@ -202,7 +200,7 @@ has_native_hooks = true
 bwrap_conflict = false
 disable_inner_sandbox_args = []
 home_ro_dirs = ["~/.pi/"]
-profiles = ["__discover__"]
+providers = ["__discover__"]
 sandbox_level = "permissive"
 
 [agents.pi-permissive.env_vars]

--- a/lince-dashboard/hooks/claude-status-hook.sh
+++ b/lince-dashboard/hooks/claude-status-hook.sh
@@ -63,7 +63,28 @@ if [ "$HOOK_EVENT" = "Notification" ]; then
     fi
 fi
 
-PAYLOAD="{\"agent_id\":\"${AGENT_ID}\",\"event\":\"${NATIVE_EVENT}\"}"
+SESSION_ID=$(extract_json_field "session_id")
+TRANSCRIPT_PATH=$(extract_json_field "transcript_path")
+
+# Build JSON payload with optional session_id and transcript_path.
+# Use jq when available for safe escaping of special characters.
+if $HAS_JQ; then
+    PAYLOAD=$(jq -n --arg aid "$AGENT_ID" --arg evt "$NATIVE_EVENT" \
+        --arg sid "${SESSION_ID:-}" --arg tp "${TRANSCRIPT_PATH:-}" \
+        '{agent_id: $aid, event: $evt} +
+         (if $sid != "" then {session_id: $sid} else {} end) +
+         (if $tp  != "" then {transcript_path: $tp} else {} end)')
+else
+    # Fallback: manual string concatenation (no escaping — safe for known values only)
+    PAYLOAD="{\"agent_id\":\"${AGENT_ID}\",\"event\":\"${NATIVE_EVENT}\""
+    if [ -n "$SESSION_ID" ]; then
+        PAYLOAD="${PAYLOAD},\"session_id\":\"${SESSION_ID}\""
+    fi
+    if [ -n "$TRANSCRIPT_PATH" ]; then
+        PAYLOAD="${PAYLOAD},\"transcript_path\":\"${TRANSCRIPT_PATH}\""
+    fi
+    PAYLOAD="${PAYLOAD}}"
+fi
 
 echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ${AGENT_ID} ${NATIVE_EVENT}" >> "$LOG_FILE" 2>/dev/null || true
 

--- a/lince-dashboard/nono-profiles/lince-bash.json
+++ b/lince-dashboard/nono-profiles/lince-bash.json
@@ -20,7 +20,7 @@
     ]
   },
   "environment": {
-    "passthrough": [
+    "allow_vars": [
       "TERM",
       "COLORTERM",
       "TERM_PROGRAM",

--- a/lince-dashboard/nono-profiles/lince-claude-paranoid.json
+++ b/lince-dashboard/nono-profiles/lince-claude-paranoid.json
@@ -5,7 +5,7 @@
     "description": "Claude Code, paranoid sandbox: only Anthropic API reachable via nono credential proxy; ~/.claude isolated to a per-agent scratch dir (rsync'd at spawn, deleted on stop)."
   },
   "filesystem": {
-    "allow": ["$WORKDIR", "$HOME"],
+    "allow": ["$WORKDIR"],
     "read": []
   },
   "network": {

--- a/lince-dashboard/nono-profiles/lince-claude-paranoid.json
+++ b/lince-dashboard/nono-profiles/lince-claude-paranoid.json
@@ -9,6 +9,8 @@
     "read": []
   },
   "network": {
-    "credentials": ["anthropic"]
+    "block": true,
+    "credentials": ["anthropic"],
+    "allow_domain": ["api.anthropic.com"]
   }
 }

--- a/lince-dashboard/nono-profiles/lince-codex-paranoid.json
+++ b/lince-dashboard/nono-profiles/lince-codex-paranoid.json
@@ -9,6 +9,8 @@
     "read": []
   },
   "network": {
-    "credentials": ["openai"]
+    "block": true,
+    "credentials": ["openai"],
+    "allow_domain": ["api.openai.com"]
   }
 }

--- a/lince-dashboard/nono-profiles/lince-codex-paranoid.json
+++ b/lince-dashboard/nono-profiles/lince-codex-paranoid.json
@@ -5,7 +5,7 @@
     "description": "Codex paranoid: only api.openai.com via nono credential proxy; ~/.codex on a per-agent scratch HOME."
   },
   "filesystem": {
-    "allow": ["$WORKDIR", "$HOME"],
+    "allow": ["$WORKDIR"],
     "read": []
   },
   "network": {

--- a/lince-dashboard/nono-profiles/lince-fish.json
+++ b/lince-dashboard/nono-profiles/lince-fish.json
@@ -19,7 +19,7 @@
     ]
   },
   "environment": {
-    "passthrough": [
+    "allow_vars": [
       "TERM",
       "COLORTERM",
       "TERM_PROGRAM",

--- a/lince-dashboard/nono-profiles/lince-gemini-paranoid.json
+++ b/lince-dashboard/nono-profiles/lince-gemini-paranoid.json
@@ -9,6 +9,8 @@
     "read": []
   },
   "network": {
-    "credentials": ["gemini"]
+    "block": true,
+    "credentials": ["gemini"],
+    "allow_domain": ["generativelanguage.googleapis.com"]
   }
 }

--- a/lince-dashboard/nono-profiles/lince-gemini-paranoid.json
+++ b/lince-dashboard/nono-profiles/lince-gemini-paranoid.json
@@ -5,7 +5,7 @@
     "description": "Gemini paranoid: only generativelanguage.googleapis.com via nono credential proxy; ~/.gemini isolated to a per-agent scratch HOME (rsync'd at spawn, deleted on stop). API-key auth only — OAuth users should use normal/permissive (paranoid does NOT allow accounts.google.com / oauth2.googleapis.com to keep the surface minimal)."
   },
   "filesystem": {
-    "allow": ["$WORKDIR", "$HOME"],
+    "allow": ["$WORKDIR"],
     "read": []
   },
   "network": {

--- a/lince-dashboard/nono-profiles/lince-opencode-paranoid.json
+++ b/lince-dashboard/nono-profiles/lince-opencode-paranoid.json
@@ -9,6 +9,8 @@
     "read": []
   },
   "network": {
-    "credentials": ["anthropic", "openai", "gemini"]
+    "block": true,
+    "credentials": ["anthropic", "openai", "gemini"],
+    "allow_domain": ["api.anthropic.com", "api.openai.com", "generativelanguage.googleapis.com"]
   }
 }

--- a/lince-dashboard/nono-profiles/lince-opencode-paranoid.json
+++ b/lince-dashboard/nono-profiles/lince-opencode-paranoid.json
@@ -5,7 +5,7 @@
     "description": "OpenCode paranoid: only the LLM providers known to nono's credential proxy (anthropic, openai, gemini) are reachable; ~/.config/opencode is isolated to a per-agent scratch HOME. The Bun/Landlock workaround (exec'ing the native .opencode binary) is preserved at the dashboard plugin level. For other providers (groq, mistral, deepseek, ...) ship a custom level — `network.credentials` here covers only the common subset."
   },
   "filesystem": {
-    "allow": ["$WORKDIR", "$HOME"],
+    "allow": ["$WORKDIR"],
     "read": []
   },
   "network": {

--- a/lince-dashboard/nono-profiles/lince-pi-paranoid.json
+++ b/lince-dashboard/nono-profiles/lince-pi-paranoid.json
@@ -5,7 +5,7 @@
     "description": "Pi paranoid: only LLM providers known to nono's credential proxy (anthropic, openai, gemini) are reachable; ~/.pi is isolated to a per-agent scratch HOME. Pi supports 18+ providers but only the three above ship with credential injection — for the others (mistral, groq, deepseek, cerebras, openrouter, AWS Bedrock, ...) ship a custom level fragment that extends `network.allow_domain`. environment.passthrough below is intentionally narrow: only the providers covered by credential injection cross into the sandbox."
   },
   "filesystem": {
-    "allow": ["$WORKDIR", "$HOME"],
+    "allow": ["$WORKDIR"],
     "read": []
   },
   "network": {

--- a/lince-dashboard/nono-profiles/lince-pi-paranoid.json
+++ b/lince-dashboard/nono-profiles/lince-pi-paranoid.json
@@ -12,7 +12,7 @@
     "credentials": ["anthropic", "openai", "gemini"]
   },
   "environment": {
-    "passthrough": [
+    "allow_vars": [
       "TERM",
       "COLORTERM",
       "TERM_PROGRAM",

--- a/lince-dashboard/nono-profiles/lince-pi-paranoid.json
+++ b/lince-dashboard/nono-profiles/lince-pi-paranoid.json
@@ -9,7 +9,9 @@
     "read": []
   },
   "network": {
-    "credentials": ["anthropic", "openai", "gemini"]
+    "block": true,
+    "credentials": ["anthropic", "openai", "gemini"],
+    "allow_domain": ["api.anthropic.com", "api.openai.com", "generativelanguage.googleapis.com"]
   },
   "environment": {
     "allow_vars": [

--- a/lince-dashboard/nono-profiles/lince-pi.json
+++ b/lince-dashboard/nono-profiles/lince-pi.json
@@ -11,7 +11,7 @@
     ]
   },
   "environment": {
-    "passthrough": [
+    "allow_vars": [
       "TERM",
       "COLORTERM",
       "TERM_PROGRAM",

--- a/lince-dashboard/nono-profiles/lince-zsh.json
+++ b/lince-dashboard/nono-profiles/lince-zsh.json
@@ -22,7 +22,7 @@
     ]
   },
   "environment": {
-    "passthrough": [
+    "allow_vars": [
       "TERM",
       "COLORTERM",
       "TERM_PROGRAM",

--- a/lince-dashboard/plugin/src/agent.rs
+++ b/lince-dashboard/plugin/src/agent.rs
@@ -549,6 +549,7 @@ fn spawn_inner(
         last_polled_event: None,
         sandbox_level: resolved_sandbox_level,
         sandbox_backend: resolved_sandbox_backend,
+        transcript_path: None,
     })
 }
 

--- a/lince-dashboard/plugin/src/config.rs
+++ b/lince-dashboard/plugin/src/config.rs
@@ -445,6 +445,55 @@ pub fn poll_status_files_async(status_dir: &str) {
 /// suffix-less "normal" profile). See `discover_sandbox_levels_async()`.
 pub const CMD_DISCOVER_SANDBOX_LEVELS: &str = "discover_sandbox_levels";
 
+/// Command type for async transcript extraction for the relay feature.
+pub const CMD_EXTRACT_TRANSCRIPT: &str = "extract_transcript";
+
+/// Kick off async extraction of the last N conversation messages from a
+/// Claude Code JSONL transcript file. Results arrive in
+/// `Event::RunCommandResult` with context `type=extract_transcript`.
+///
+/// Uses python3 (guaranteed present — Claude Code requires it) because
+/// JSONL with nested content arrays is awkward in jq but trivial in Python.
+pub fn extract_transcript_async(
+    source_agent_id: &str,
+    transcript_path: &str,
+    message_count: usize,
+) {
+    let path = shell_escape(transcript_path);
+    let count = message_count;
+    let script = format!(
+        r#"python3 -c "
+import json, sys
+msgs = []
+for line in open('{path}'):
+    line = line.strip()
+    if not line: continue
+    try: d = json.loads(line)
+    except: continue
+    t = d.get('type','')
+    if t not in ('user','assistant'): continue
+    content = d.get('message',{{}}).get('content',[])
+    texts = [c['text'].strip() for c in content if isinstance(c,dict) and c.get('type')=='text' and c.get('text','').strip()]
+    if texts:
+        role = 'User' if t == 'user' else 'Assistant'
+        msgs.append('[' + role + ']: ' + ' '.join(texts))
+for m in msgs[-{count}:]:
+    print(m)
+    print()
+" 2>/dev/null || echo '[error] python3 extraction failed'"#,
+        path = path,
+        count = count,
+    );
+    run_typed_command_with(
+        &["sh", "-c", &script],
+        CMD_EXTRACT_TRANSCRIPT,
+        &[
+            ("source_agent_id", source_agent_id),
+            ("message_count", &message_count.to_string()),
+        ],
+    );
+}
+
 /// Extract provider details from a TOML table (the value side of a
 /// `[*.providers.<name>]` / `[*.profiles.<name>]` entry).
 fn parse_provider_details(table: &toml::Table) -> ProviderDetails {

--- a/lince-dashboard/plugin/src/dashboard.rs
+++ b/lince-dashboard/plugin/src/dashboard.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::config::{AgentTypeConfig, SandboxColors};
 use crate::types::{
-    AgentInfo, AgentStatus, NamePromptState, WizardState, WizardStep,
+    AgentInfo, AgentStatus, NamePromptState, RelayPhase, WizardState, WizardStep,
 };
 
 /// Map a color name from config to an ANSI escape code.
@@ -230,6 +230,7 @@ pub fn render_dashboard(
     cols: usize,
     status_message: Option<&str>,
     name_prompt: Option<&NamePromptState>,
+    relay_phase: Option<&RelayPhase>,
     agent_types: &HashMap<String, AgentTypeConfig>,
     sandbox_colors: &SandboxColors,
 ) {
@@ -252,8 +253,12 @@ pub fn render_dashboard(
             if let Some(prompt) = name_prompt {
                 render_name_prompt_bar(prompt, cols);
                 print_status_pad_line(cols);
+            } else if let Some(RelayPhase::MessagePrompt { input }) = relay_phase {
+                render_relay_message_prompt(input, cols);
+                print_status_pad_line(cols);
             } else {
-                render_status_bar(cols, status_message, agents, focused, detail);
+                let rp = matches!(relay_phase, Some(RelayPhase::DeliveryPending { .. }));
+                render_status_bar(cols, status_message, agents, focused, detail, rp);
             }
         } else if status_lines == 1 {
             if let Some(prompt) = name_prompt {
@@ -295,8 +300,12 @@ pub fn render_dashboard(
     if let Some(prompt) = name_prompt {
         render_name_prompt_bar(prompt, cols);
         print_status_pad_line(cols);
+    } else if let Some(RelayPhase::MessagePrompt { input }) = relay_phase {
+        render_relay_message_prompt(input, cols);
+        print_status_pad_line(cols);
     } else {
-        render_status_bar(cols, status_message, agents, focused, detail);
+        let rp = matches!(relay_phase, Some(RelayPhase::DeliveryPending { .. }));
+        render_status_bar(cols, status_message, agents, focused, detail, rp);
     }
 }
 
@@ -675,6 +684,28 @@ fn render_name_prompt_bar(prompt: &NamePromptState, cols: usize) {
     println!();
 }
 
+/// Render the relay message-count prompt bar (blue background).
+/// Pattern matches render_name_prompt_bar: cursor block, dim default, hints.
+fn render_relay_message_prompt(input: &str, cols: usize) {
+    let cursor = "\u{2588}"; // solid block cursor
+    let input_part = if input.is_empty() {
+        format!("{}1{}{}", DIM, RESET, cursor) // default "1" in dim
+    } else {
+        format!("{}{}", input, cursor)
+    };
+
+    let text = format!(
+        " {}Relay:{} Messages (1-9): {}  {}[Enter]{} OK  {}[Esc]{} Cancel",
+        CYAN, RESET, input_part,
+        KEY_COLOR, RESET, KEY_COLOR, RESET,
+    );
+
+    let visible_len = strip_ansi_len(&text);
+    let padding = cols.saturating_sub(visible_len + 1);
+    print!("\x1b[44m {}{:>pad$}{}", text, "", RESET, pad = padding);
+    println!();
+}
+
 /// A key hint entry: (key label, description).
 type KeyHint = (&'static str, &'static str);
 
@@ -694,6 +725,11 @@ fn format_key_hints_short(hints: &[KeyHint]) -> String {
         .map(|(key, label)| format!("{}:{}", key, label))
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+/// Key hints shown during the relay DeliveryPending phase.
+fn relay_pending_hints() -> Vec<KeyHint> {
+    vec![("s", "Relay"), ("f/Enter", "Deliver"), ("j/k", "Nav"), ("1-9", "Quick"), ("Esc", "Cancel")]
 }
 
 /// Return the context-appropriate key hints.
@@ -718,7 +754,15 @@ fn render_status_bar(
     agents: &[AgentInfo],
     focused: Option<&str>,
     detail: Option<&str>,
+    relay_pending: bool,
 ) {
+    if relay_pending {
+        let hints = relay_pending_hints();
+        let text = format_key_hints(&hints);
+        print_status_line(&text, &hints, cols);
+        return;
+    }
+
     let is_empty = agents.is_empty();
     let is_focused = focused.is_some();
     let is_detail = detail.is_some();
@@ -1022,6 +1066,11 @@ pub fn render_help_overlay(rows: usize, cols: usize) {
     push_box_line(&mut lines, &format!("  {}Create{}", BOLD, RESET), box_width);
     push_box_line(&mut lines, &format!("  {}n{}          New agent (name prompt)", KEY_COLOR, RESET), box_width);
     push_box_line(&mut lines, &format!("  {}N{}          New agent wizard", KEY_COLOR, RESET), box_width);
+    push_box_line(&mut lines, "", box_width);
+
+    push_box_line(&mut lines, &format!("  {}Relay{}", BOLD, RESET), box_width);
+    push_box_line(&mut lines, &format!("  {}s{}          Relay last message to agent", KEY_COLOR, RESET), box_width);
+    push_box_line(&mut lines, &format!("  {}S{}          Relay N messages (prompt)", KEY_COLOR, RESET), box_width);
     push_box_line(&mut lines, "", box_width);
 
     push_box_line(&mut lines, &format!("  {}Other{}", BOLD, RESET), box_width);

--- a/lince-dashboard/plugin/src/main.rs
+++ b/lince-dashboard/plugin/src/main.rs
@@ -567,6 +567,7 @@ impl ZellijPlugin for State {
             cols,
             effective_status,
             self.name_prompt.as_ref(),
+            self.relay_state.as_ref().map(|r| &r.phase),
             &self.config.agent_types,
             &self.config.sandbox_colors,
         );

--- a/lince-dashboard/plugin/src/main.rs
+++ b/lince-dashboard/plugin/src/main.rs
@@ -21,8 +21,8 @@ const CMD_GET_CWD: &str = "get_cwd";
 const CMD_LOAD_CONFIG: &str = "load_config";
 
 use crate::types::{
-    AgentInfo, AgentStatus, NamePromptState, SavedAgentInfo, SessionDefaults,
-    StatusMessage, WizardState, WizardStep,
+    AgentInfo, AgentStatus, NamePromptState, RelayPhase, RelayState, SavedAgentInfo,
+    SessionDefaults, StatusMessage, WizardState, WizardStep,
 };
 
 struct State {
@@ -41,6 +41,8 @@ struct State {
     name_prompt: Option<NamePromptState>,
     /// When set, the name_prompt acts as a rename prompt for this agent id.
     rename_target: Option<String>,
+    /// Active relay state machine (None = idle). LINCE-87/88/89 relay feature.
+    relay_state: Option<RelayState>,
     launch_dir: Option<String>,
     /// Buffered saved state awaiting agent type defaults before restore.
     /// Set when load_state completes before load_agent_defaults.
@@ -79,6 +81,7 @@ impl Default for State {
             wizard: None,
             name_prompt: None,
             rename_target: None,
+            relay_state: None,
             launch_dir: None,
             pending_restore: None,
             agent_types_loaded: false,
@@ -488,6 +491,38 @@ impl ZellijPlugin for State {
                         }
                         changed
                     }
+                    Some(cmd_type) if cmd_type == config::CMD_EXTRACT_TRANSCRIPT => {
+                        // Only process if relay is still in Extracting phase
+                        let Some(ref rs) = self.relay_state else { return false };
+                        let RelayPhase::Extracting { source_agent_id, source_agent_name, message_count } = &rs.phase else { return false };
+
+                        let output = String::from_utf8_lossy(&stdout);
+                        let source_name = source_agent_name.clone();
+                        let source_id = source_agent_id.clone();
+                        let count = *message_count;
+                        let src_idx = rs.source_index;
+
+                        if exit_code != Some(0) || output.contains("[error]") || output.trim().is_empty() {
+                            self.relay_state = None;
+                            self.status_message = Some("Transcript extraction failed".to_string());
+                            set_timeout(3.0);
+                            return true;
+                        }
+
+                        self.relay_state = Some(RelayState {
+                            phase: RelayPhase::DeliveryPending {
+                                source_agent_name: source_name,
+                                captured_text: output.trim_end().to_string(),
+                                message_count: count,
+                            },
+                            source_index: src_idx,
+                        });
+                        self.status_message = Some(format!(
+                            "Extracted {} messages from {}. Select target (f/Enter/1-9), Esc cancel",
+                            count, source_id
+                        ));
+                        true
+                    }
                     _ => false,
                 }
             }
@@ -625,6 +660,11 @@ impl State {
             return self.handle_name_prompt_key(key);
         }
 
+        // If relay is active, route all keys there
+        if self.relay_state.is_some() {
+            return self.handle_relay_key(key);
+        }
+
         let bare = &key.bare_key;
         let no_mods = key.key_modifiers.is_empty();
 
@@ -660,6 +700,14 @@ impl State {
                         label: "Rename",
                     });
                 }
+                true
+            }
+            BareKey::Char('s') => {
+                self.start_relay(1);
+                true
+            }
+            BareKey::Char('S') => {
+                self.start_relay_with_prompt();
                 true
             }
             BareKey::Char('N') => {
@@ -1353,6 +1401,291 @@ impl State {
             self.focused_agent = Some(self.agents[idx].id.clone());
             self.selected_index = idx;
         }
+    }
+
+    /// Start relay: extract last `count` messages from selected agent's transcript.
+    /// LINCE-87/88/89 inter-agent message relay.
+    fn start_relay(&mut self, count: usize) {
+        let agent = match self.agents.get(self.selected_index) {
+            Some(a) => a,
+            None => {
+                self.status_message = Some("No agent selected".to_string());
+                set_timeout(3.0);
+                return;
+            }
+        };
+
+        let tp = match &agent.transcript_path {
+            Some(p) if !p.is_empty() => p.clone(),
+            _ => {
+                self.status_message = Some(format!(
+                    "Transcript not available for {}",
+                    agent.name
+                ));
+                set_timeout(3.0);
+                return;
+            }
+        };
+
+        if self.agents.len() < 2 {
+            self.status_message = Some("Need 2+ agents to relay".to_string());
+            set_timeout(3.0);
+            return;
+        }
+
+        let source_id = agent.id.clone();
+        let source_name = agent.name.clone();
+        let source_index = self.selected_index;
+
+        config::extract_transcript_async(&source_id, &tp, count);
+
+        self.relay_state = Some(RelayState {
+            phase: RelayPhase::Extracting {
+                source_agent_id: source_id,
+                source_agent_name: source_name,
+                message_count: count,
+            },
+            source_index,
+        });
+        self.status_message = Some("Extracting...".to_string());
+    }
+
+    /// Enter relay MessagePrompt phase so user can pick count 1-9.
+    fn start_relay_with_prompt(&mut self) {
+        let agent = match self.agents.get(self.selected_index) {
+            Some(a) => a,
+            None => {
+                self.status_message = Some("No agent selected".to_string());
+                set_timeout(3.0);
+                return;
+            }
+        };
+
+        if agent.transcript_path.as_deref().unwrap_or("").is_empty() {
+            self.status_message = Some(format!(
+                "Transcript not available for {}",
+                agent.name
+            ));
+            set_timeout(3.0);
+            return;
+        }
+
+        if self.agents.len() < 2 {
+            self.status_message = Some("Need 2+ agents to relay".to_string());
+            set_timeout(3.0);
+            return;
+        }
+
+        let source_index = self.selected_index;
+        self.relay_state = Some(RelayState {
+            phase: RelayPhase::MessagePrompt { input: String::new() },
+            source_index,
+        });
+    }
+
+    /// Handle keyboard input while relay state machine is active.
+    fn handle_relay_key(&mut self, key: KeyWithModifier) -> bool {
+        let bare = key.bare_key;
+        let no_mods = key.key_modifiers.is_empty();
+
+        if !no_mods {
+            return false;
+        }
+
+        // Take ownership of the current relay state for processing.
+        let rs = match self.relay_state.take() {
+            Some(rs) => rs,
+            None => return false,
+        };
+
+        match &rs.phase {
+            RelayPhase::MessagePrompt { .. } => {
+                match bare {
+                    BareKey::Char(c @ '1'..='9') => {
+                        let digit = c.to_string();
+                        self.relay_state = Some(RelayState {
+                            phase: RelayPhase::MessagePrompt { input: digit },
+                            source_index: rs.source_index,
+                        });
+                    }
+                    BareKey::Enter => {
+                        let input = match &rs.phase {
+                            RelayPhase::MessagePrompt { input } => input.clone(),
+                            _ => String::new(),
+                        };
+                        let count = if input.is_empty() { 1 } else { input.parse::<usize>().unwrap_or(1) };
+                        // Restore relay_state so start_relay can validate the agent.
+                        self.relay_state = Some(rs);
+                        self.start_relay(count);
+                    }
+                    BareKey::Esc => {
+                        // Clear relay_state (already taken).
+                    }
+                    _ => {
+                        // Unrecognized key: put state back.
+                        self.relay_state = Some(rs);
+                    }
+                }
+            }
+            RelayPhase::Extracting { .. } => {
+                match bare {
+                    BareKey::Esc => {
+                        // Clear relay_state (already taken).
+                    }
+                    _ => {
+                        // Ignore all other keys during extraction.
+                        self.relay_state = Some(rs);
+                    }
+                }
+            }
+            RelayPhase::DeliveryPending { .. } => {
+                let max_idx = self.agents.len().saturating_sub(1);
+                match bare {
+                    BareKey::Char('f') | BareKey::Enter => {
+                        // Restore state for deliver_relay_to_selected.
+                        self.relay_state = Some(rs);
+                        self.deliver_relay_to_selected();
+                    }
+                    BareKey::Char('j') => {
+                        let new_idx = rs.source_index.saturating_sub(1);
+                        self.relay_state = Some(RelayState {
+                            phase: rs.phase,
+                            source_index: new_idx,
+                        });
+                    }
+                    BareKey::Char('k') => {
+                        let new_idx = if rs.source_index < max_idx {
+                            rs.source_index + 1
+                        } else {
+                            max_idx
+                        };
+                        self.relay_state = Some(RelayState {
+                            phase: rs.phase,
+                            source_index: new_idx,
+                        });
+                    }
+                    BareKey::Char(c @ '1'..='9') => {
+                        let target_idx = (c as u8 - b'1') as usize;
+                        self.relay_state = Some(RelayState {
+                            phase: rs.phase,
+                            source_index: target_idx.min(max_idx),
+                        });
+                        self.deliver_relay_to_selected();
+                    }
+                    BareKey::Esc => {
+                        // Clear relay_state (already taken).
+                    }
+                    _ => {
+                        self.relay_state = Some(rs);
+                    }
+                }
+            }
+        }
+        true
+    }
+
+    /// Deliver relayed text to the target agent pane.
+    fn deliver_relay_to_selected(&mut self) {
+        let rs = match self.relay_state.take() {
+            Some(rs) => rs,
+            None => return,
+        };
+
+        let (source_name, captured_text, message_count) = match &rs.phase {
+            RelayPhase::DeliveryPending { source_agent_name, captured_text, message_count } => {
+                (source_agent_name.clone(), captured_text.clone(), *message_count)
+            }
+            _ => {
+                // Should not happen — put state back.
+                self.relay_state = Some(rs);
+                return;
+            }
+        };
+
+        // Validate target index.
+        let target_idx = rs.source_index;
+        if target_idx >= self.agents.len() {
+            self.relay_state = Some(RelayState {
+                phase: RelayPhase::DeliveryPending {
+                    source_agent_name: source_name,
+                    captured_text,
+                    message_count,
+                },
+                source_index: target_idx,
+            });
+            self.status_message = Some("Invalid target index".to_string());
+            set_timeout(3.0);
+            return;
+        }
+
+        let target = &self.agents[target_idx];
+
+        // Prevent self-relay.
+        let source_agent = self.agents.iter().find(|a| a.name == source_name);
+        if let Some(src) = source_agent {
+            if src.id == target.id {
+                self.relay_state = Some(RelayState {
+                    phase: RelayPhase::DeliveryPending {
+                        source_agent_name: source_name,
+                        captured_text,
+                        message_count,
+                    },
+                    source_index: target_idx,
+                });
+                self.status_message = Some("Cannot relay to self — select another agent".to_string());
+                set_timeout(3.0);
+                return;
+            }
+        }
+
+        // Validate target has a pane.
+        let target_pid = match target.pane_id {
+            Some(pid) => pid,
+            None => {
+                self.relay_state = Some(RelayState {
+                    phase: RelayPhase::DeliveryPending {
+                        source_agent_name: source_name,
+                        captured_text,
+                        message_count,
+                    },
+                    source_index: target_idx,
+                });
+                self.status_message = Some(format!("{} has no pane", target.name));
+                set_timeout(3.0);
+                return;
+            }
+        };
+
+        let target_name = target.name.clone();
+        let target_id = target.id.clone();
+
+        // Wrap text with header/footer.
+        let wrapped = format!(
+            "--- Relay from {} ({} messages) ---\n{}\n--- End relay ---\n",
+            source_name, message_count, captured_text
+        );
+
+        write_chars_to_pane_id(&wrapped, PaneId::Terminal(target_pid));
+
+        // Focus target agent pane.
+        if let Some(target_agent) = self.agents.get(target_idx) {
+            if pane_manager::focus_agent(
+                target_agent,
+                &self.agents,
+                &self.config.focus_mode,
+                &self.config.agent_layout,
+            ) {
+                self.focused_agent = Some(target_id);
+                self.selected_index = target_idx;
+            }
+        }
+
+        self.relay_state = None;
+        self.status_message = Some(format!(
+            "Relayed {} messages from {} to {}",
+            message_count, source_name, target_name
+        ));
+        set_timeout(3.0);
     }
 
     /// Poll status files for all agents (file-based fallback, LINCE-42).

--- a/lince-dashboard/plugin/src/main.rs
+++ b/lince-dashboard/plugin/src/main.rs
@@ -474,6 +474,8 @@ impl ZellijPlugin for State {
                                     event: event.to_string(),
                                     timestamp: None,
                                     error: None,
+                                    session_id: None,
+                                    transcript_path: None,
                                 };
                                 let new_status = msg.to_agent_status(
                                     self.config.event_map_for(&agent.agent_type),
@@ -1306,6 +1308,15 @@ impl State {
 
         if let Some(e) = msg.error {
             agent.last_error = Some(e);
+        }
+
+        // Forward transcript_path from hook events to agent state.
+        // Updated on every hook event (not just SessionStart) for robustness —
+        // the field is stable within a session so repeated writes are benign.
+        if let Some(tp) = msg.transcript_path {
+            if !tp.is_empty() {
+                agent.transcript_path = Some(tp);
+            }
         }
     }
 

--- a/lince-dashboard/plugin/src/types.rs
+++ b/lince-dashboard/plugin/src/types.rs
@@ -110,6 +110,34 @@ pub struct NamePromptState {
     pub label: &'static str,
 }
 
+/// Phases of the inter-agent message relay state machine.
+///
+/// Flow: MessagePrompt → Extracting → DeliveryPending → (deliver or cancel).
+/// Triggered by `s` (relay last message) or `S` (prompt for count).
+#[derive(Debug, Clone)]
+pub enum RelayPhase {
+    /// User pressed S, entering message count (1-9).
+    MessagePrompt { input: String },
+    /// Async extraction from transcript in progress.
+    Extracting {
+        source_agent_id: String,
+        source_agent_name: String,
+        message_count: usize,
+    },
+    /// Extracted messages ready for delivery to target.
+    DeliveryPending {
+        source_agent_name: String,
+        captured_text: String,
+        message_count: usize,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct RelayState {
+    pub phase: RelayPhase,
+    pub source_index: usize,
+}
+
 /// Which step the wizard is currently on.
 ///
 /// Note: `Provider` selects an env-var bundle (Anthropic vs Vertex vs Z.ai

--- a/lince-dashboard/plugin/src/types.rs
+++ b/lince-dashboard/plugin/src/types.rs
@@ -46,6 +46,11 @@ pub struct StatusMessage {
     pub timestamp: Option<String>,
     #[serde(default)]
     pub error: Option<String>,
+    #[serde(default)]
+    #[allow(dead_code)] // deserialized from hook JSON, reserved for future session tracking
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub transcript_path: Option<String>,
 }
 
 /// Map a canonical status string to AgentStatus.
@@ -304,6 +309,7 @@ pub struct AgentInfo {
     /// Runtime-selected sandbox backend (wizard choice or saved state).
     /// None means use the agent type's TOML-pinned `sandbox_backend`.
     pub sandbox_backend: Option<crate::sandbox_backend::SandboxBackend>,
+    pub transcript_path: Option<String>,
 }
 
 impl AgentInfo {
@@ -412,6 +418,8 @@ mod tests {
             event: event.to_string(),
             timestamp: None,
             error: None,
+            session_id: None,
+            transcript_path: None,
         }
     }
 
@@ -551,6 +559,7 @@ mod tests {
             last_polled_event: None,
             sandbox_level: None,
             sandbox_backend: None,
+            transcript_path: None,
         }
     }
 
@@ -609,6 +618,7 @@ mod tests {
             last_polled_event: None,
             sandbox_level: Some("paranoid".to_string()),
             sandbox_backend: Some(crate::sandbox_backend::SandboxBackend::Nono),
+            transcript_path: None,
         };
 
         let saved: SavedAgentInfo = (&agent).into();

--- a/lince-dashboard/zellij-config/config.kdl
+++ b/lince-dashboard/zellij-config/config.kdl
@@ -434,7 +434,7 @@ web_client {
 // copy_command "xclip -selection clipboard" // x11
 // copy_command "wl-copy"                    // wayland
 // copy_command "pbcopy"                     // osx
-// 
+//
 // copy_command "pbcopy"
  
 // Choose the destination for copied text

--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -1568,9 +1568,10 @@ def build_nono_cmd(
     agent_extra_args: list[str],
     safe_mode: bool = False,
     agent_id: str | None = None,
+    nono_profile: str | None = None,
 ) -> list[str]:
     """Build nono run command for the given agent."""
-    profile_name = f"lince-{agent_name}"
+    profile_name = nono_profile or f"lince-{agent_name}"
     cmd = ["nono", "run", "--profile", profile_name]
     cmd.extend(["--workdir", str(project_dir)])
     cmd.extend(["--allow-cwd"])
@@ -1671,10 +1672,13 @@ def generate_nono_profile(
         profile["filesystem"] = filesystem
 
     # --- Environment passthrough ---
+    # nono v0.33 used "passthrough"; v0.59+ renamed it to "allow_vars".
+    # Use the current canonical name.
     env_conf = config.get("env", {})
+    _nono_env_key = "allow_vars"
     passthrough = list(env_conf.get("passthrough", []))
     if passthrough:
-        profile["environment"] = {"passthrough": passthrough}
+        profile["environment"] = {_nono_env_key: passthrough}
 
     # --- Extra env vars ---
     # Collect env vars from agent config, profile env, and [env.extra]
@@ -1700,13 +1704,13 @@ def generate_nono_profile(
         all_env[var] = _expand_env_value(val)
 
     for var in sorted(all_env):
-        existing_pt = profile.get("environment", {}).get("passthrough", [])
+        existing_pt = profile.get("environment", {}).get(_nono_env_key, [])
         if var not in existing_pt:
             if "environment" not in profile:
-                profile["environment"] = {"passthrough": []}
-            if "passthrough" not in profile["environment"]:
-                profile["environment"]["passthrough"] = []
-            profile["environment"]["passthrough"].append(var)
+                profile["environment"] = {_nono_env_key: []}
+            if _nono_env_key not in profile["environment"]:
+                profile["environment"][_nono_env_key] = []
+            profile["environment"][_nono_env_key].append(var)
 
     # --- Security ---
     # allowed_commands was deprecated in nono v0.33.0 (startup-only,
@@ -2624,23 +2628,38 @@ def cmd_run(args, agent_extra: list[str]) -> None:
         for d in agent_cfg.get("home_rw_dirs", []):
             (Path.home() / d).mkdir(parents=True, exist_ok=True)
 
-        # Ensure nono profile exists
-        nono_profile_file = NONO_PROFILE_DIR / f"lince-{agent_name}.json"
+        # Resolve nono profile: level-specific if a level was requested,
+        # otherwise the base profile.  Mirrors the dashboard plugin's
+        # resolve_nono_profile() in agent.rs.
+        resolved_level = getattr(args, "sandbox_level", None)
+        if resolved_level and resolved_level != "normal":
+            nono_profile_name = f"lince-{agent_name}-{resolved_level}"
+        else:
+            nono_profile_name = f"lince-{agent_name}"
+
+        nono_profile_file = NONO_PROFILE_DIR / f"{nono_profile_name}.json"
         if not nono_profile_file.exists():
-            print(f"nono profile not found: {nono_profile_file}", file=sys.stderr)
-            print("Run 'agent-sandbox nono-sync' to generate profiles.", file=sys.stderr)
-            sys.exit(1)
+            # Fall back to base profile if level-specific one is missing
+            base_profile = NONO_PROFILE_DIR / f"lince-{agent_name}.json"
+            if base_profile.exists():
+                nono_profile_name = f"lince-{agent_name}"
+                nono_profile_file = base_profile
+            else:
+                print(f"nono profile not found: {nono_profile_file}", file=sys.stderr)
+                print("Run 'agent-sandbox nono-sync' to generate profiles.", file=sys.stderr)
+                sys.exit(1)
 
         cmd = build_nono_cmd(
             agent_name, project_dir, agent_cfg, agent_extra,
             safe_mode=args.safe, agent_id=args.id,
+            nono_profile=nono_profile_name,
         )
 
         if args.dry_run:
             print("# nono command that would be executed:\n")
             print(f"# config: {config_path}")
             print(f"# agent: {agent_name} ({agent_cfg['command']})")
-            print(f"# nono profile: lince-{agent_name}")
+            print(f"# nono profile: {nono_profile_name}")
             if provider:
                 print(f"# provider: {provider}")
             _pretty_print_cmd(cmd)
@@ -2651,7 +2670,7 @@ def cmd_run(args, agent_extra: list[str]) -> None:
         print(f"  config      {config_path}")
         print(f"  backend     nono ({shutil.which('nono')})")
         print(f"  agent       {agent_name} ({agent_cfg['command']})")
-        print(f"  nono prof   lince-{agent_name}")
+        print(f"  nono prof   {nono_profile_name}")
         if provider:
             desc = f" ({prof_desc})" if prof_desc else ""
             print(f"  provider    {provider}{desc}")

--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -234,6 +234,10 @@ NONO_BUILTIN_PROFILES: dict[str, str] = {
 }
 
 NONO_PROFILE_DIR = Path.home() / ".config" / "nono" / "profiles"
+NONO_PROFILE_PREFIX = "lince-"
+# nono v0.33 used "passthrough"; v0.59+ renamed it to "allow_vars".
+# This constant is the canonical key for the nono profile JSON schema.
+NONO_ENV_VARS_KEY = "allow_vars"
 
 # ---------------------------------------------------------------------------
 # Credential proxy rules — maps env vars to API domain/header pairs
@@ -1672,13 +1676,10 @@ def generate_nono_profile(
         profile["filesystem"] = filesystem
 
     # --- Environment passthrough ---
-    # nono v0.33 used "passthrough"; v0.59+ renamed it to "allow_vars".
-    # Use the current canonical name.
     env_conf = config.get("env", {})
-    _nono_env_key = "allow_vars"
     passthrough = list(env_conf.get("passthrough", []))
     if passthrough:
-        profile["environment"] = {_nono_env_key: passthrough}
+        profile["environment"] = {NONO_ENV_VARS_KEY: passthrough}
 
     # --- Extra env vars ---
     # Collect env vars from agent config, profile env, and [env.extra]
@@ -1703,14 +1704,11 @@ def generate_nono_profile(
     for var, val in agent_config.get("env", {}).items():
         all_env[var] = _expand_env_value(val)
 
+    env_block = profile.setdefault("environment", {})
+    vars_list = env_block.setdefault(NONO_ENV_VARS_KEY, [])
     for var in sorted(all_env):
-        existing_pt = profile.get("environment", {}).get(_nono_env_key, [])
-        if var not in existing_pt:
-            if "environment" not in profile:
-                profile["environment"] = {_nono_env_key: []}
-            if _nono_env_key not in profile["environment"]:
-                profile["environment"][_nono_env_key] = []
-            profile["environment"][_nono_env_key].append(var)
+        if var not in vars_list:
+            vars_list.append(var)
 
     # --- Security ---
     # allowed_commands was deprecated in nono v0.33.0 (startup-only,
@@ -2630,19 +2628,20 @@ def cmd_run(args, agent_extra: list[str]) -> None:
 
         # Resolve nono profile: level-specific if a level was requested,
         # otherwise the base profile.  Mirrors the dashboard plugin's
-        # resolve_nono_profile() in agent.rs.
-        resolved_level = getattr(args, "sandbox_level", None)
-        if resolved_level and resolved_level != "normal":
-            nono_profile_name = f"lince-{agent_name}-{resolved_level}"
+        # resolve_nono_profile() in agent.rs.  sandbox_level is already
+        # resolved from args at line ~2555 above.
+        if sandbox_level and sandbox_level != "normal":
+            nono_profile_name = f"{NONO_PROFILE_PREFIX}{agent_name}-{sandbox_level}"
         else:
-            nono_profile_name = f"lince-{agent_name}"
+            nono_profile_name = f"{NONO_PROFILE_PREFIX}{agent_name}"
 
         nono_profile_file = NONO_PROFILE_DIR / f"{nono_profile_name}.json"
         if not nono_profile_file.exists():
             # Fall back to base profile if level-specific one is missing
-            base_profile = NONO_PROFILE_DIR / f"lince-{agent_name}.json"
+            base_name = f"{NONO_PROFILE_PREFIX}{agent_name}"
+            base_profile = NONO_PROFILE_DIR / f"{base_name}.json"
             if base_profile.exists():
-                nono_profile_name = f"lince-{agent_name}"
+                nono_profile_name = base_name
                 nono_profile_file = base_profile
             else:
                 print(f"nono profile not found: {nono_profile_file}", file=sys.stderr)


### PR DESCRIPTION
## Summary

Two feature areas in this PR:

### Inter-agent message relay (LINCE-87 → LINCE-91)
- Forward `transcript_path` and `session_id` from Claude hooks to the dashboard
- Add `RelayState`/`RelayPhase` types and transcript extraction helper (Python3 JSONL parser)
- Implement relay state machine with key bindings (`s`/`S`) and message delivery
- Render relay UI: message prompt bar, status hints, help overlay updates
- Document relay feature in README and MULTI-AGENT-GUIDE

### Nono sandbox fixes (LINCE-99 verification + bug fixes)
- Fix `nono-sync` generating stale `"passthrough"` field → `"allow_vars"` (nono v0.59 schema)
- Fix `agent-sandbox` nono backend ignoring `--sandbox-level` flag (always used base profile)
- Fix `agents-template.toml`: `has_native_hooks=false` → `true` for codex (would break hooks via install.sh)
- Remove `$HOME` from all paranoid nono profiles (overlaps nono state root `~/.nono`)
- Add `network.block: true` + `allow_domain` to all paranoid profiles (previously inherited `block: false` from parent presets)
- Promote nono constants to module level (`NONO_ENV_VARS_KEY`, `NONO_PROFILE_PREFIX`)
- Simplify env-var loop in `generate_nono_profile()` with `setdefault` pattern
- Standardize `profiles` → `providers` in `agents-template.toml`

## Linked issues

Relay: LINCE-87, LINCE-88, LINCE-89, LINCE-90, LINCE-91
Sandbox: Closes #49 (three-level sandbox model for codex), umbrella #47, follows #48 (claude prototype)

## Test results (macOS, nono v0.59)

| Test | Result |
|------|--------|
| Paranoid blocks `attacker.com` | ✅ HTTP 000 |
| Permissive allows `api.github.com` | ✅ HTTP 200 |
| `docker`/`podman ps` fails in permissive | ✅ binary/socket blocked |
| `--sandbox-level paranoid` → `lince-codex-paranoid` | ✅ |
| `--sandbox-level normal` → `lince-codex` (base) | ✅ |
| `nono-sync` generates `allow_vars` | ✅ |
| Shipped profiles have no stale `passthrough` | ✅ |
| WASM build (`cargo build --target wasm32-wasip1`) | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)