### PR TITLE
feat(dashboard): per-instance pane icons + dir-based naming + ProjectDir prefill (#166 #167 #168)

### DIFF
--- a/lince-dashboard/plugin/src/agent.rs
+++ b/lince-dashboard/plugin/src/agent.rs
@@ -57,23 +57,77 @@ pub fn sandbox_level_glyph(level: &str) -> &'static str {
 ///   The level is taken from `sandbox_level_override` (runtime wizard selection) first,
 ///   then falls back to the TOML-pinned `sandbox_level` for the agent type.
 /// - Sandboxed with no level anywhere (legacy static command): `<name>` (unchanged).
+///
+/// The per-instance `icon` (#166, a distinctive emoji) is prepended when
+/// non-empty — it renders inside the title regardless of the (theme-driven,
+/// green) pane frame, which a plugin cannot recolor. An empty `icon` is a no-op.
 pub fn pane_title(
     name: &str,
     agent_type: &str,
     agent_types: &HashMap<String, AgentTypeConfig>,
     sandbox_level_override: Option<&str>,
+    icon: &str,
 ) -> String {
+    let pre = if icon.is_empty() {
+        String::new()
+    } else {
+        format!("{} ", icon)
+    };
     let cfg = agent_types.get(agent_type);
     let sandboxed = cfg.map_or(true, |c| c.sandboxed);
     if !sandboxed {
-        return format!("[NON-SANDBOXED] {}{}", name, CLOSE_PANE_HINT);
+        return format!("{}[NON-SANDBOXED] {}{}", pre, name, CLOSE_PANE_HINT);
     }
     let level = sandbox_level_override
         .or_else(|| cfg.and_then(|c| c.sandbox_level.as_deref()));
     match level {
-        Some(level) => format!("{} [{}] {}{}", sandbox_level_glyph(level), level, name, CLOSE_PANE_HINT),
-        None => format!("{}{}", name, CLOSE_PANE_HINT),
+        Some(level) => format!("{}{} [{}] {}{}", pre, sandbox_level_glyph(level), level, name, CLOSE_PANE_HINT),
+        None => format!("{}{}{}", pre, name, CLOSE_PANE_HINT),
     }
+}
+
+/// Pick the per-instance marker slot for a freshly spawned agent (#166).
+///
+/// Returns the first slot whose marker isn't currently used by a live agent —
+/// guaranteeing distinct markers for all concurrently-open agents up to the
+/// pool size. When every slot is taken, wraps deterministically by `next_id`.
+/// `None` when the marker pool is empty (instance markers disabled).
+pub fn pick_instance_slot(icons: &[String], agents: &[AgentInfo], next_id: u32) -> Option<usize> {
+    if icons.is_empty() {
+        return None;
+    }
+    let free = (0..icons.len()).find(|&i| !agents.iter().any(|a| a.icon == icons[i]));
+    Some(free.unwrap_or((next_id as usize) % icons.len()))
+}
+
+/// Suggest a default agent name derived from the working-directory basename (#167).
+///
+/// - Basename = last path component of `project_dir` (a leading `~` and trailing
+///   `/` are stripped first), so `~/myPrj/` → `myPrj`.
+/// - When the basename is empty / `.` / `..`, falls back to the legacy
+///   `<fallback_base>-<next_id + 1>` scheme.
+/// - Otherwise returns `<basename>-<n>` where `n` is one past the highest `N`
+///   among existing agents named `<basename>-<N>` (starts at 1).
+pub fn suggest_agent_name(
+    project_dir: &str,
+    agents: &[AgentInfo],
+    next_id: u32,
+    fallback_base: &str,
+) -> String {
+    let trimmed = project_dir.trim();
+    let without_tilde = trimmed.strip_prefix('~').unwrap_or(trimmed);
+    let basename = without_tilde.trim_end_matches('/').rsplit('/').next().unwrap_or("");
+    if basename.is_empty() || basename == "." || basename == ".." {
+        return format!("{}-{}", fallback_base, next_id + 1);
+    }
+    let prefix = format!("{}-", basename);
+    let max_existing = agents
+        .iter()
+        .filter_map(|a| a.name.strip_prefix(&prefix))
+        .filter_map(|suffix| suffix.parse::<u32>().ok())
+        .max()
+        .unwrap_or(0);
+    format!("{}-{}", basename, max_existing + 1)
 }
 
 /// Default floating pane coordinates for agent panes (80% x 85%, centered).
@@ -530,6 +584,12 @@ fn spawn_inner(
     let resolved_sandbox_backend = sandbox_backend_override
         .or_else(|| config.agent_types.get(agent_type).map(|c| c.sandbox_backend.clone()));
 
+    // #166: claim a per-instance marker not already in use by a live agent.
+    let slot = pick_instance_slot(&config.instance_icons, agents, *next_id);
+    let icon = slot
+        .and_then(|i| config.instance_icons.get(i).cloned())
+        .unwrap_or_default();
+
     Ok(AgentInfo {
         id,
         name,
@@ -550,6 +610,7 @@ fn spawn_inner(
         sandbox_level: resolved_sandbox_level,
         sandbox_backend: resolved_sandbox_backend,
         transcript_path: None,
+        icon,
     })
 }
 
@@ -683,7 +744,7 @@ pub fn reconcile_panes(
                     // (hook events for native-hooks agents; permanently
                     // `Unknown` for non-hook agents — the dashboard is
                     // honest about not knowing the state).
-                    let title = pane_title(&agent.name, &agent.agent_type, agent_types, agent.sandbox_level.as_deref());
+                    let title = pane_title(&agent.name, &agent.agent_type, agent_types, agent.sandbox_level.as_deref(), &agent.icon);
                     rename_pane_with_id(PaneId::Terminal(pane.id), &title);
                     if expect_floating {
                         hide_pane_with_id(PaneId::Terminal(pane.id));
@@ -750,5 +811,86 @@ mod tests {
         assert!(!is_env_passthrough_self_ref("FOO", "${FOO"));
         assert!(!is_env_passthrough_self_ref("FOO", "$FOO_EXTRA"));
         assert!(!is_env_passthrough_self_ref("FOO", ""));
+    }
+
+    /// Minimal AgentInfo for naming/marker tests (only `name` and `icon` matter).
+    fn agent_with(name: &str, icon: &str) -> AgentInfo {
+        AgentInfo {
+            id: name.to_string(),
+            name: name.to_string(),
+            agent_type: "claude".to_string(),
+            provider: None,
+            project_dir: String::new(),
+            status: AgentStatus::Unknown,
+            pane_id: None,
+            started_at: None,
+            last_error: None,
+            exit_code: None,
+            group: None,
+            last_polled_event: None,
+            sandbox_level: None,
+            sandbox_backend: None,
+            transcript_path: None,
+            icon: icon.to_string(),
+        }
+    }
+
+    #[test]
+    fn suggest_name_from_basename_no_existing() {
+        assert_eq!(
+            suggest_agent_name("/home/user/myProj", &[], 5, "claude"),
+            "myProj-1"
+        );
+    }
+
+    #[test]
+    fn suggest_name_increments_past_existing() {
+        let agents = [agent_with("myProj-1", "")];
+        assert_eq!(
+            suggest_agent_name("/home/user/myProj", &agents, 5, "claude"),
+            "myProj-2"
+        );
+    }
+
+    #[test]
+    fn suggest_name_uses_max_existing_not_count() {
+        // Gaps must not lower the suggestion below the highest existing index.
+        let agents = [agent_with("myProj-1", ""), agent_with("myProj-4", "")];
+        assert_eq!(
+            suggest_agent_name("/home/user/myProj", &agents, 0, "claude"),
+            "myProj-5"
+        );
+    }
+
+    #[test]
+    fn suggest_name_strips_tilde_and_trailing_slash() {
+        assert_eq!(suggest_agent_name("~/src/lince/", &[], 0, "claude"), "lince-1");
+    }
+
+    #[test]
+    fn suggest_name_falls_back_on_dot_or_empty() {
+        assert_eq!(suggest_agent_name("/tmp/.", &[], 2, "claude"), "claude-3");
+        assert_eq!(suggest_agent_name("", &[], 2, "codex"), "codex-3");
+    }
+
+    #[test]
+    fn pick_slot_returns_first_free() {
+        let pool: Vec<String> = ["A", "B", "C"].iter().map(|s| s.to_string()).collect();
+        let agents = [agent_with("a", "A")];
+        // Slot 0 ("A") is taken → first free is slot 1 ("B").
+        assert_eq!(pick_instance_slot(&pool, &agents, 1), Some(1));
+    }
+
+    #[test]
+    fn pick_slot_wraps_when_pool_exhausted() {
+        let pool: Vec<String> = ["A", "B"].iter().map(|s| s.to_string()).collect();
+        let agents = [agent_with("a", "A"), agent_with("b", "B")];
+        // All taken → wrap by next_id: 2 % 2 == 0 → slot 0.
+        assert_eq!(pick_instance_slot(&pool, &agents, 2), Some(0));
+    }
+
+    #[test]
+    fn pick_slot_empty_pool_yields_none() {
+        assert_eq!(pick_instance_slot(&[], &[], 0), None);
     }
 }

--- a/lince-dashboard/plugin/src/config.rs
+++ b/lince-dashboard/plugin/src/config.rs
@@ -211,6 +211,29 @@ fn default_project_search_max_depth() -> usize {
     3
 }
 
+/// Default pool of distinct per-instance marker glyphs (#166).
+///
+/// Each spawned agent claims the first marker not already in use by a live
+/// agent, giving instant visual disambiguation between panes — two `claude`
+/// instances open at once get different markers. The SAME glyph is shown in the
+/// pane title and in the dashboard list, so the list entry and the pane share
+/// one identity.
+///
+/// Distinctive, easy-to-tell-apart emoji (a plugin cannot recolor a pane's
+/// border/title — that color is theme-driven and global — so varied glyphs beat
+/// near-identical colored squares for at-a-glance recognition). Avoids the
+/// sandbox-level circles (🟢🔵🟡). Overridable via `[dashboard] instance_icons`;
+/// an empty list disables instance markers.
+fn default_instance_icons() -> Vec<String> {
+    [
+        "⭐", "⚡", "🔥", "🌙", "🍀", "🎯", "🌸", "🐢", "🦊", "🐙", "🌵", "🍁", "🎲", "🦋", "🌊",
+        "🍄",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect()
+}
+
 
 fn default_status_file_dir() -> String {
     "/tmp/lince-dashboard".to_string()
@@ -299,6 +322,13 @@ pub struct DashboardConfig {
     /// nesting (e.g. `Projects/Personal/<proj>`, `Projects/Work/<client>/<repo>`).
     #[serde(default = "default_project_search_max_depth")]
     pub project_search_max_depth: usize,
+    /// Pool of distinct per-instance marker glyphs (first-free) for visual pane
+    /// identification (#166). Each live agent claims one (a distinctive emoji by
+    /// default); it appears in the pane title and as the matching marker in the
+    /// dashboard list. Overridable via `[dashboard] instance_icons`; empty
+    /// disables instance markers.
+    #[serde(default = "default_instance_icons")]
+    pub instance_icons: Vec<String>,
     /// Custom sandbox levels discovered from the filesystem, keyed by
     /// `<backend>:<base>` (e.g. `"nono:claude"` or `"agent-sandbox:claude"`).
     /// Populated asynchronously by `discover_sandbox_levels_async()` reading
@@ -329,6 +359,7 @@ impl Default for DashboardConfig {
             sandbox_colors: SandboxColors::default(),
             project_search_roots: Vec::new(),
             project_search_max_depth: default_project_search_max_depth(),
+            instance_icons: default_instance_icons(),
             discovered_sandbox_levels: HashMap::new(),
         }
     }

--- a/lince-dashboard/plugin/src/dashboard.rs
+++ b/lince-dashboard/plugin/src/dashboard.rs
@@ -495,6 +495,21 @@ fn render_agent_table(
                     String::new()
                 };
 
+                // #166: per-instance marker (distinctive emoji) prefix on the
+                // name column — the same glyph shown in the pane title, so the
+                // list entry and the pane share one identity. Reclaim 2 columns
+                // from the name pad for the marker + separating space.
+                let icon_pre = if agent.icon.is_empty() {
+                    String::new()
+                } else {
+                    format!("{} ", agent.icon)
+                };
+                let name_col = if agent.icon.is_empty() {
+                    col_name
+                } else {
+                    col_name.saturating_sub(2)
+                };
+
                 if is_selected {
                     // Trailing without color attrs — preserves the REVERSE that
                     // wraps the whole row. The trailing space-separators match
@@ -510,9 +525,9 @@ fn render_agent_table(
                     }
 
                     let main_part = format!(
-                        "{}{}{} {}",
+                        "{}{}{} {}{}",
                         prefix, pad_left(&idx_str, col_idx), type_col,
-                        pad_left(&agent.name, col_name),
+                        icon_pre, pad_left(&agent.name, name_col),
                     );
                     let status_str = pad_left(&status_label, col_status);
                     let main_visible = strip_ansi_len(&main_part);
@@ -539,14 +554,14 @@ fn render_agent_table(
                 } else {
                     // For non-selected rows, use display_name (with group suffix) in the name column
                     let name_field = if agent.group.is_some() {
-                        let base = pad_left(&agent.name, col_name.saturating_sub(agent.group.as_ref().map_or(0, |g| g.len() + 3)));
+                        let base = pad_left(&agent.name, name_col.saturating_sub(agent.group.as_ref().map_or(0, |g| g.len() + 3)));
                         if let Some(ref group) = agent.group {
-                            format!("{} {}[{}]{}", base, DIM, group, RESET)
+                            format!("{}{} {}[{}]{}", icon_pre, base, DIM, group, RESET)
                         } else {
-                            base
+                            format!("{}{}", icon_pre, base)
                         }
                     } else {
-                        pad_left(&agent.name, col_name)
+                        format!("{}{}", icon_pre, pad_left(&agent.name, name_col))
                     };
 
                     // Wrap the plain sandbox content with its color attribute
@@ -1006,6 +1021,10 @@ pub fn render_wizard(
                         box_width,
                     );
                 }
+            } else if wizard.project_dir_suggested {
+                // #168: the field is pre-filled from the selected agent's dir.
+                push_box_line(&mut lines, "  (from selected agent — Backspace to clear)", box_width);
+                push_box_line(&mut lines, "  [Tab] autocomplete path", box_width);
             } else {
                 push_box_line(&mut lines, "  (default: current directory)", box_width);
                 push_box_line(&mut lines, "  [Tab] autocomplete path", box_width);

--- a/lince-dashboard/plugin/src/main.rs
+++ b/lince-dashboard/plugin/src/main.rs
@@ -702,7 +702,20 @@ impl State {
                     _ => self.effective_default_agent_type().to_string(),
                 };
                 let base = agent::agent_type_base_name(&effective_type);
-                let default_name = format!("{}-{}", base, self.next_agent_id + 1);
+                // #167: derive the default name from the working-directory
+                // basename. Mirror the spawn's own dir resolution so the name
+                // matches where the agent actually starts: session default dir →
+                // config default → dashboard launch dir → ".".
+                let default_dir = self
+                    .session_defaults
+                    .as_ref()
+                    .map(|sd| sd.project_dir.clone())
+                    .filter(|d| !d.is_empty())
+                    .or_else(|| self.config.default_project_dir.clone().filter(|d| !d.is_empty()))
+                    .or_else(|| self.launch_dir.clone().filter(|d| !d.is_empty()))
+                    .unwrap_or_else(|| String::from("."));
+                let default_name =
+                    agent::suggest_agent_name(&default_dir, &self.agents, self.next_agent_id, base);
                 self.name_prompt = Some(NamePromptState {
                     input: String::new(),
                     default_name,
@@ -730,8 +743,17 @@ impl State {
                 true
             }
             BareKey::Char('N') => {
-                let default_dir = self.config.default_project_dir.clone()
+                // #168: pre-fill the project dir from the selected agent when
+                // there is one; otherwise fall back to the config default.
+                let mut default_dir = self.config.default_project_dir.clone()
                     .unwrap_or_default();
+                let mut project_dir_suggested = false;
+                if let Some(sel) = self.agents.get(self.selected_index) {
+                    if !sel.project_dir.is_empty() {
+                        default_dir = sel.project_dir.clone();
+                        project_dir_suggested = true;
+                    }
+                }
                 // Step 1 list: deduplicated base agents (e.g. "claude", not "claude-unsandboxed").
                 let agent_type_list = self.config.base_agents();
                 // Prefer the configured default_agent_type's base (gh#62) when it
@@ -783,7 +805,15 @@ impl State {
                 let discover_bases: Vec<String> = self.config.base_agents()
                     .into_iter().map(|(b, _)| b).collect();
                 config::discover_sandbox_levels_async(&discover_bases);
-                let default_name = format!("{}-{}", default_base, self.next_agent_id + 1);
+                // #167: seed the default name from the (possibly pre-filled)
+                // project dir basename. Recomputed when the user changes the
+                // ProjectDir field (which now precedes the Name step).
+                let default_name = agent::suggest_agent_name(
+                    &default_dir,
+                    &self.agents,
+                    self.next_agent_id,
+                    default_base,
+                );
                 // Build state, then derive the first step from active_steps() so the
                 // skip rules don't drift between init and key handlers.
                 let mut state = WizardState {
@@ -802,6 +832,7 @@ impl State {
                     completions: Vec::new(),
                     completion_index: None,
                     project_dir_error: None,
+                    project_dir_suggested,
                 };
                 state.step = state.active_steps().into_iter().next().unwrap_or(WizardStep::Name);
                 self.wizard = Some(state);
@@ -902,7 +933,7 @@ impl State {
                     if let Some(agent) = self.agents.iter_mut().find(|a| a.id == agent_id) {
                         agent.name = name.clone();
                         if let Some(pid) = agent.pane_id {
-                            let title = agent::pane_title(&name, &agent.agent_type, &self.config.agent_types, agent.sandbox_level.as_deref());
+                            let title = agent::pane_title(&name, &agent.agent_type, &self.config.agent_types, agent.sandbox_level.as_deref(), &agent.icon);
                             rename_pane_with_id(PaneId::Terminal(pid), &title);
                         }
                         self.status_message = Some(format!("Renamed to {}", name));
@@ -1027,8 +1058,18 @@ impl State {
                     wizard.provider_index = self.config.default_provider.as_ref()
                         .and_then(|dp| wizard.available_providers.iter().position(|p| p == dp))
                         .unwrap_or(0);
-                    // Update default name to reflect the new base.
-                    wizard.default_name = format!("{}-{}", base, self.next_agent_id + 1);
+                    // #167: keep the default name dir-derived (the basename
+                    // doesn't depend on agent type). `base` only matters as the
+                    // fallback when project_dir has no usable basename. Skipped
+                    // if the user already typed a custom name.
+                    if wizard.name.is_empty() {
+                        wizard.default_name = agent::suggest_agent_name(
+                            &wizard.project_dir,
+                            &self.agents,
+                            self.next_agent_id,
+                            &base,
+                        );
+                    }
                     if let Some(next) = wizard.next_step() {
                         wizard.step = next;
                     }
@@ -1184,6 +1225,7 @@ impl State {
                         }
                         wizard.clear_completions();
                         wizard.project_dir_error = None;
+                        wizard.project_dir_suggested = false;
                     } else {
                         // Validate BEFORE advancing. Sandbox backends (nono on
                         // macOS, agent-sandbox/bwrap on Linux) require absolute
@@ -1224,12 +1266,25 @@ impl State {
                             return true;
                         }
                         wizard.project_dir_error = None;
+                        // #167: now that the project dir is finalized, refresh the
+                        // dir-derived default name shown on the Name step — unless
+                        // the user already typed a custom name.
+                        if wizard.name.is_empty() {
+                            let base = wizard.selected_base_agent().to_string();
+                            wizard.default_name = agent::suggest_agent_name(
+                                &wizard.project_dir,
+                                &self.agents,
+                                self.next_agent_id,
+                                &base,
+                            );
+                        }
                         if let Some(next) = wizard.next_step() {
                             wizard.step = next;
                         }
                     }
                 }
                 BareKey::Tab => {
+                    wizard.project_dir_suggested = false;
                     if wizard.completions.is_empty() {
                         // First Tab press: request completions from the shell.
                         config::complete_path_async(
@@ -1247,7 +1302,16 @@ impl State {
                     }
                 }
                 BareKey::Backspace => {
-                    if wizard.project_dir.is_empty() {
+                    if wizard.project_dir_suggested && !wizard.project_dir.is_empty() {
+                        // #168: first Backspace on a pristine pre-fill clears the
+                        // whole field (ready for a fresh path) instead of deleting
+                        // one char or navigating back. Subsequent Backspaces follow
+                        // the normal empty-field behavior.
+                        wizard.project_dir = String::new();
+                        wizard.project_dir_suggested = false;
+                        wizard.clear_completions();
+                        wizard.project_dir_error = None;
+                    } else if wizard.project_dir.is_empty() {
                         if let Some(prev) = wizard.prev_step() {
                             wizard.step = prev;
                         }
@@ -1258,6 +1322,7 @@ impl State {
                     }
                 }
                 BareKey::Char(c) => {
+                    wizard.project_dir_suggested = false;
                     wizard.project_dir.push(c);
                     wizard.clear_completions();
                     wizard.project_dir_error = None;
@@ -1267,7 +1332,15 @@ impl State {
             WizardStep::Confirm => match bare {
                 BareKey::Enter | BareKey::Char('!') => {
                     // Clone values out before dropping the borrow.
-                    let name = wizard.name.clone();
+                    // #167: an empty Name field uses the dir-derived default the
+                    // wizard advertised (e.g. `myPrj-1`), NOT the legacy
+                    // `<type>-<id>` — spawn_agent_custom only falls back to the
+                    // latter when this string is also empty.
+                    let name = if wizard.name.is_empty() {
+                        wizard.default_name.clone()
+                    } else {
+                        wizard.name.clone()
+                    };
                     let agent_type = wizard.effective_agent_type();
                     let provider = wizard.selected_provider().map(|s| s.to_string());
                     let project_dir = wizard.project_dir.clone();

--- a/lince-dashboard/plugin/src/types.rs
+++ b/lince-dashboard/plugin/src/types.rs
@@ -149,10 +149,12 @@ pub enum WizardStep {
     AgentType,
     SandboxBackend,
     SandboxLevel,
+    /// Selected before `Name` (#167) so the directory basename can seed the
+    /// default agent name (e.g. `myPrj-1`).
+    ProjectDir,
     Name,
     /// Pick the provider env-var bundle (was `Profile` pre-#81).
     Provider,
-    ProjectDir,
     Confirm,
 }
 
@@ -198,6 +200,10 @@ pub struct WizardState {
     /// `render_wizard`. Cleared as soon as the user edits the field or
     /// the value becomes valid.
     pub project_dir_error: Option<String>,
+    /// True while `project_dir` holds an un-edited pre-fill from the selected
+    /// agent (#168). The first Backspace clears the field instead of navigating
+    /// to the previous step; any keystroke or completion clears the flag.
+    pub project_dir_suggested: bool,
 }
 
 impl WizardState {
@@ -267,11 +273,13 @@ impl WizardState {
         if self.has_sandbox_levels() && !self.is_unsandboxed_choice() {
             steps.push(WizardStep::SandboxLevel);
         }
+        // #167: ProjectDir precedes Name so the directory basename can seed the
+        // default name shown on the Name step.
+        steps.push(WizardStep::ProjectDir);
         steps.push(WizardStep::Name);
         if self.has_providers() {
             steps.push(WizardStep::Provider);
         }
-        steps.push(WizardStep::ProjectDir);
         steps.push(WizardStep::Confirm);
         steps
     }
@@ -344,6 +352,12 @@ pub struct AgentInfo {
     /// None means use the agent type's TOML-pinned `sandbox_backend`.
     pub sandbox_backend: Option<crate::sandbox_backend::SandboxBackend>,
     pub transcript_path: Option<String>,
+    /// Per-instance marker glyph (#166), claimed first-free from
+    /// `[dashboard].instance_icons` at spawn (a distinctive emoji by default).
+    /// Shown in the pane title and the dashboard list. Empty when the pool is
+    /// empty. Runtime-only — not persisted to the state file (the spawn path
+    /// re-derives it on restore).
+    pub icon: String,
 }
 
 impl AgentInfo {
@@ -594,6 +608,7 @@ mod tests {
             sandbox_level: None,
             sandbox_backend: None,
             transcript_path: None,
+            icon: String::new(),
         }
     }
 
@@ -653,6 +668,7 @@ mod tests {
             sandbox_level: Some("paranoid".to_string()),
             sandbox_backend: Some(crate::sandbox_backend::SandboxBackend::Nono),
             transcript_path: None,
+            icon: String::new(), // not persisted
         };
 
         let saved: SavedAgentInfo = (&agent).into();


### PR DESCRIPTION
## Summary

Three complementary spawn / identification enhancements for the lince-dashboard Zellij plugin, delivered together because #167 and #168 both rewrite the wizard step flow and the `ProjectDir` key handler.

New wizard flow: `AgentType → SandboxBackend → SandboxLevel → ProjectDir (prefilled) → Name (dir-derived) → Provider → Confirm`

### #166 — Per-instance pane icons
Each spawned agent claims a **distinct glyph** (first-free from a configurable pool) so two simultaneous panes of the same agent type are instantly distinguishable for fast context-switching — addressing the reporter's clarified intent (per-instance, not per-agent-type).
- Icon prepended to the pane title (before the sandbox-level glyph) and to the table name column.
- New `[dashboard].instance_icons` pool (ships with 16 default glyphs, avoids the level circles 🟢🔵🟡⚪); overridable in user config.
- `AgentInfo.icon` is runtime-only and re-derived on restore via the spawn path, so **`SavedAgentInfo` / state-file schema is unchanged**.
- Assignment is *first-free among live agents*, guaranteeing no collision up to the pool size.

### #167 — Directory-derived default name
- New `suggest_agent_name()` proposes `<dir-basename>-<n>` (`myPrj-1`, `myPrj-2`) instead of `<type>-<id>`.
- Wizard now visits **ProjectDir before Name** so the chosen directory seeds the default; recomputed when the directory changes; never overrides a manually-typed name.
- Falls back to `<type>-<id>` for empty / `.` / `..` directories.
- Applied to both quick-spawn `n` and wizard `N`.

### #168 — ProjectDir prefill from selected agent
- Wizard pre-fills `ProjectDir` from the selected agent's working directory.
- A single Backspace clears the **pristine** pre-fill (instead of navigating to the previous step); any keystroke / Tab / completion clears the suggestion flag, after which normal behavior resumes.
- Falls back to config default / empty when no agent is selected.

## Testing
- Added unit tests for `suggest_agent_name` and `pick_instance_icon` (pure functions).
- `cargo build --target wasm32-wasip1` ✅ and `cargo test --no-run --target wasm32-wasip1` ✅ (canonical WASM build + test-binary compilation). Tests can't execute in CI-less env here (no wasm runtime; host link blocked by zellij host-fn imports).

## Manual verification checklist
- [ ] Two `claude` panes show different leading glyphs (title + table); no collision after killing/respawning.
- [ ] `n`/`N` in `myPrj/` propose `myPrj-1`, then `myPrj-2`; custom name not overwritten; ProjectDir precedes Name.
- [ ] `N` with a selected agent pre-fills its dir; one Backspace clears, second goes back a step.

Closes #166
Closes #167
Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)