### PR TITLE
feat(dashboard): per-workdir colored swimlane headers (closes #161)

### DIFF
--- a/lince-dashboard/plugin/src/dashboard.rs
+++ b/lince-dashboard/plugin/src/dashboard.rs
@@ -46,6 +46,21 @@ const CYAN: &str = "\x1b[36m";
 const KEY_COLOR: &str = "\x1b[1;36m"; // bold cyan for key hints
 const BLUE_BOLD: &str = "\x1b[1;34m"; // blue bold for swimlane headers
 
+/// Hard-coded color palette cycled across unique workdir swimlane headers,
+/// in order of first appearance, so multi-project sessions are easy to tell
+/// apart at a glance. The first entry is `BLUE_BOLD`, so single-workdir setups
+/// keep their legacy appearance exactly. Intentionally not configurable —
+/// grouping by color helps everyone and another config knob would just add
+/// noise (see issue #161).
+const WORKDIR_HEADER_PALETTE: [&str; 6] = [
+    BLUE_BOLD,       // blue   (legacy)
+    "\x1b[1;35m",    // magenta
+    "\x1b[1;36m",    // cyan
+    "\x1b[1;32m",    // green
+    "\x1b[1;33m",    // yellow
+    "\x1b[1;31m",    // red
+];
+
 /// Truncate a string to fit within `max_width` *visible* characters, appending
 /// "..." if truncated. ANSI CSI sequences (e.g. `\x1b[1;31m`) are copied verbatim
 /// and never count toward width — without this, a cut landing inside a CSI
@@ -396,6 +411,19 @@ fn render_agent_table(
         header_dirs.push(String::new());
     }
 
+    // Assign each unique workdir a stable cycle index (order of first
+    // appearance) so its header color is independent of scroll position and
+    // survives a `Q` + restart (which preserves agent order via
+    // `restore_agents` → `sort_agents_by_dir`).
+    let mut dir_color_idx: HashMap<&str, usize> = HashMap::new();
+    for (i, slot) in virtual_rows.iter().enumerate() {
+        if slot.is_none() {
+            let d = header_dirs[i].as_str();
+            let next_idx = dir_color_idx.len();
+            dir_color_idx.entry(d).or_insert(next_idx);
+        }
+    }
+
     // Find the virtual row index of the selected agent
     let selected_vrow = virtual_rows.iter().position(|v| *v == Some(selected)).unwrap_or(0);
 
@@ -424,13 +452,16 @@ fn render_agent_table(
 
         match virtual_rows[vrow] {
             None => {
-                // Swimlane header row
+                // Swimlane header row — color cycles per workdir in order of
+                // first appearance (palette wraps modulo its length).
                 let dir = &header_dirs[vrow];
+                let idx = dir_color_idx.get(dir.as_str()).copied().unwrap_or(0);
+                let header_color = WORKDIR_HEADER_PALETTE[idx % WORKDIR_HEADER_PALETTE.len()];
                 let short = collapse_tilde(dir);
                 let fill_len = cols.saturating_sub(short.len() + 5);
                 println!(
                     " {}\u{250c} {} {}{}",
-                    BLUE_BOLD, short, repeat_char('\u{2500}', fill_len), RESET,
+                    header_color, short, repeat_char('\u{2500}', fill_len), RESET,
                 );
                 rendered_rows += 1;
             }


### PR DESCRIPTION
## Problem

The agent table groups agents by `project_dir` under bold-blue headers. With more than a couple of workdirs open (multi-project sessions, monorepo + side experiments), every group header is the same color and it's hard to tell groups apart at a glance.

## Fix

Cycle a hard-coded palette of bold ANSI colors across **unique** workdirs, in order of first appearance:

```
blue (legacy) → magenta → cyan → green → yellow → red → (wraps)
```

- Color assignment is **stable across scroll position** and survives `Q` + restart (agent order preserved by `restore_agents` → `sort_agents_by_dir`), via a small `HashMap<&str, usize>` built up-front.
- The first palette entry is the legacy bold blue, so **single-workdir setups look exactly as before**.

## Per your feedback on #161

> Just don't make it configurable, hard code the colors used. Too many configs for small details are just confusing.

Done — the palette is a `const` in `dashboard.rs`, **not configurable**. The change is confined to `dashboard.rs` (no config surface, no new struct).

## Scope

Single file, `dashboard.rs`. No behavior change other than header color.

Closes #161