### PR TITLE
feat(dashboard): smart project picker for the wizard ProjectDir step (closes #127)

### DIFF
--- a/lince-dashboard/plugin/src/dashboard.rs
+++ b/lince-dashboard/plugin/src/dashboard.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::config::{AgentTypeConfig, SandboxColors};
 use crate::types::{
-    AgentInfo, AgentStatus, NamePromptState, RelayPhase, WizardState, WizardStep,
+    AgentInfo, AgentStatus, NamePromptState, ProjectDirMode, RelayPhase, WizardState, WizardStep,
 };
 
 /// Map a color name from config to an ANSI escape code.
@@ -121,6 +121,20 @@ fn truncate(s: &str, max_width: usize) -> String {
         out.push_str("...");
     }
     out
+}
+
+/// Truncate `s` from the LEFT to at most `max_len` visible chars, prefixing an
+/// ellipsis (`…`) so the distinguishing tail of a path stays visible. Returns
+/// `s` unchanged when it already fits or `max_len <= 1`. Char-based, so it
+/// never splits a multi-byte UTF-8 sequence.
+fn truncate_left(s: &str, max_len: usize) -> String {
+    if s.chars().count() > max_len && max_len > 1 {
+        let skip = s.chars().count() - max_len + 1;
+        let tail: String = s.chars().skip(skip).collect();
+        format!("\u{2026}{}", tail)
+    } else {
+        s.to_string()
+    }
 }
 
 /// Pad or truncate a string to exactly `width` characters, left-aligned.
@@ -1011,68 +1025,107 @@ pub fn render_wizard(
             );
             push_box_line(&mut lines, "  [j/k] Select  [Enter] Next  [Esc] Cancel", box_width);
         }
-        WizardStep::ProjectDir => {
-            // Horizontal scroll: show the tail of the input when it overflows.
-            let input_prefix = "  > ";
-            let input_suffix = "_";
-            let max_visible = box_width.saturating_sub(4 + input_prefix.len() + input_suffix.len());
-            let dir_display = if wizard.project_dir.chars().count() > max_visible && max_visible > 1 {
-                let skip = wizard.project_dir.chars().count() - max_visible + 1;
-                let s: String = wizard.project_dir.chars().skip(skip).collect();
-                format!("\u{2026}{}", s) // …prefix
-            } else {
-                wizard.project_dir.clone()
-            };
-            push_box_line(&mut lines, &format!("{}{}{}", input_prefix, dir_display, input_suffix), box_width);
+        WizardStep::ProjectDir => match wizard.project_dir_mode {
+            // ── Recents picker (#127) ──────────────────────────────────
+            ProjectDirMode::List => {
+                push_box_line(
+                    &mut lines,
+                    &format!("  Filter: {}_", wizard.project_dir_filter),
+                    box_width,
+                );
+                push_box_line(&mut lines, "", box_width);
 
-            // Show completion suggestions (max 5 visible).
-            if !wizard.completions.is_empty() {
-                let max_show = 5.min(wizard.completions.len());
-                for (i, entry) in wizard.completions.iter().take(max_show).enumerate() {
-                    let marker = if wizard.completion_index == Some(i) { ">" } else { " " };
-                    // Truncate long paths to fit the box.
-                    let max_len = box_width.saturating_sub(6);
-                    let display: &str = if entry.len() > max_len {
-                        // Truncate from the left (show the distinguishing tail).
-                        // Advance past any mid-char byte to a valid UTF-8 boundary.
-                        let mut start = entry.len() - max_len;
-                        while !entry.is_char_boundary(start) && start < entry.len() {
-                            start += 1;
-                        }
-                        &entry[start..]
-                    } else {
-                        entry
-                    };
-                    push_box_line(&mut lines, &format!("  {} {}", marker, display), box_width);
-                }
-                if wizard.completions.len() > max_show {
+                let filtered = wizard.filtered_project_dirs();
+                if filtered.is_empty() {
                     push_box_line(
                         &mut lines,
-                        &format!("    (+{} more)", wizard.completions.len() - max_show),
+                        "  (no match — [Enter] types it as a new path)",
+                        box_width,
+                    );
+                } else {
+                    push_box_line(&mut lines, "  RECENTS", box_width);
+                    // Scrolling window of up to 6 rows around the selection.
+                    let max_show = 6;
+                    let total = filtered.len();
+                    let sel = wizard.project_dir_index.min(total.saturating_sub(1));
+                    let start = if sel >= max_show { sel + 1 - max_show } else { 0 };
+                    for (i, entry) in filtered.iter().enumerate().skip(start).take(max_show) {
+                        let marker = if i == sel { ">" } else { " " };
+                        let short = collapse_tilde(entry);
+                        // Truncate from the left to keep the distinguishing tail.
+                        let disp = truncate_left(&short, box_width.saturating_sub(6));
+                        push_box_line(&mut lines, &format!("  {} {}", marker, disp), box_width);
+                    }
+                    if total > start + max_show {
+                        push_box_line(
+                            &mut lines,
+                            &format!("    (+{} more)", total - (start + max_show)),
+                            box_width,
+                        );
+                    }
+                }
+                push_box_line(&mut lines, "", box_width);
+                // `[i] free text` only applies while the filter is empty (that's
+                // when `i` switches modes); once filtering, Backspace backs out.
+                let hint = if wizard.project_dir_filter.is_empty() {
+                    "  [type] filter  [\u{2191}/\u{2193}] move  [Enter] select  [i] free text"
+                } else {
+                    "  [type] filter  [\u{2191}/\u{2193}] move  [Enter] select  [\u{232b}] back"
+                };
+                push_box_line(&mut lines, hint, box_width);
+            }
+            // ── Free-text input (legacy escape hatch) ──────────────────
+            ProjectDirMode::Input => {
+                // Horizontal scroll: show the tail of the input when it overflows.
+                let input_prefix = "  > ";
+                let input_suffix = "_";
+                let max_visible = box_width.saturating_sub(4 + input_prefix.len() + input_suffix.len());
+                let dir_display = if wizard.project_dir.chars().count() > max_visible && max_visible > 1 {
+                    let skip = wizard.project_dir.chars().count() - max_visible + 1;
+                    let s: String = wizard.project_dir.chars().skip(skip).collect();
+                    format!("\u{2026}{}", s) // …prefix
+                } else {
+                    wizard.project_dir.clone()
+                };
+                push_box_line(&mut lines, &format!("{}{}{}", input_prefix, dir_display, input_suffix), box_width);
+
+                // Show completion suggestions (max 5 visible).
+                if !wizard.completions.is_empty() {
+                    let max_show = 5.min(wizard.completions.len());
+                    for (i, entry) in wizard.completions.iter().take(max_show).enumerate() {
+                        let marker = if wizard.completion_index == Some(i) { ">" } else { " " };
+                        let display = truncate_left(entry, box_width.saturating_sub(6));
+                        push_box_line(&mut lines, &format!("  {} {}", marker, display), box_width);
+                    }
+                    if wizard.completions.len() > max_show {
+                        push_box_line(
+                            &mut lines,
+                            &format!("    (+{} more)", wizard.completions.len() - max_show),
+                            box_width,
+                        );
+                    }
+                } else if wizard.project_dir_suggested {
+                    // #168: the field is pre-filled from the selected agent's dir.
+                    push_box_line(&mut lines, "  (from selected agent — Backspace to clear)", box_width);
+                    push_box_line(&mut lines, "  [Tab] autocomplete path", box_width);
+                } else {
+                    push_box_line(&mut lines, "  (default: current directory)", box_width);
+                    push_box_line(&mut lines, "  [Tab] autocomplete path", box_width);
+                }
+                // Validation error line (set by the ProjectDir Enter handler when
+                // the path is empty/relative/tilde-prefixed). Bold red, cleared as
+                // soon as the user edits the field.
+                if let Some(ref err) = wizard.project_dir_error {
+                    push_box_line(&mut lines, "", box_width);
+                    push_box_line(
+                        &mut lines,
+                        &format!("  \x1b[1;31m✗ {}\x1b[0m", err),
                         box_width,
                     );
                 }
-            } else if wizard.project_dir_suggested {
-                // #168: the field is pre-filled from the selected agent's dir.
-                push_box_line(&mut lines, "  (from selected agent — Backspace to clear)", box_width);
-                push_box_line(&mut lines, "  [Tab] autocomplete path", box_width);
-            } else {
-                push_box_line(&mut lines, "  (default: current directory)", box_width);
-                push_box_line(&mut lines, "  [Tab] autocomplete path", box_width);
-            }
-            // Validation error line (set by the ProjectDir Enter handler when
-            // the path is empty/relative/tilde-prefixed). Bold red, cleared as
-            // soon as the user edits the field.
-            if let Some(ref err) = wizard.project_dir_error {
                 push_box_line(&mut lines, "", box_width);
-                push_box_line(
-                    &mut lines,
-                    &format!("  \x1b[1;31m✗ {}\x1b[0m", err),
-                    box_width,
-                );
+                push_box_line(&mut lines, "  [Enter] Next  [Esc] Cancel", box_width);
             }
-            push_box_line(&mut lines, "", box_width);
-            push_box_line(&mut lines, "  [Enter] Next  [Esc] Cancel", box_width);
         }
         WizardStep::Name => {
             // Horizontal scroll for name input too.

--- a/lince-dashboard/plugin/src/main.rs
+++ b/lince-dashboard/plugin/src/main.rs
@@ -2,6 +2,7 @@ mod agent;
 mod config;
 mod dashboard;
 mod pane_manager;
+mod recents;
 mod sandbox_backend;
 mod state_file;
 mod types;
@@ -21,8 +22,8 @@ const CMD_GET_CWD: &str = "get_cwd";
 const CMD_LOAD_CONFIG: &str = "load_config";
 
 use crate::types::{
-    AgentInfo, AgentStatus, NamePromptState, RelayPhase, RelayState, SavedAgentInfo,
-    SessionDefaults, StatusMessage, WizardState, WizardStep,
+    AgentInfo, AgentStatus, NamePromptState, ProjectDirMode, RelayPhase, RelayState,
+    SavedAgentInfo, SessionDefaults, StatusMessage, WizardState, WizardStep,
 };
 
 struct State {
@@ -62,6 +63,10 @@ struct State {
     /// When `Some`, the `n` shortcut spawns with these values instead of
     /// resolving from `[dashboard].default_*` config fields.
     session_defaults: Option<SessionDefaults>,
+    /// Global most-recently-used project dirs, loaded from
+    /// `~/.config/lince-dashboard/recents.json` and offered by the wizard's
+    /// Project dir picker (#127).
+    recent_project_dirs: Vec<String>,
 }
 
 impl Default for State {
@@ -90,6 +95,7 @@ impl Default for State {
             cwd_retries: 0,
             cwd_retry_exhausted: false,
             session_defaults: None,
+            recent_project_dirs: Vec::new(),
         }
     }
 }
@@ -167,6 +173,9 @@ impl ZellijPlugin for State {
         // permissions for local file plugins, so run_command may already work.
         config::run_typed_command(&["pwd"], CMD_GET_CWD);
         sandbox_backend::detect_backend_async();
+        // Load the global recents list for the wizard's Project dir picker.
+        // Independent of launch_dir — the file lives under ~/.config.
+        recents::load_recents_async();
         // Load config async (std::fs fails in WASI sandbox)
         if let Some(ref path) = self.config_path {
             let script = format!("cat {} 2>/dev/null", config::shell_path_expr(path));
@@ -532,6 +541,16 @@ impl ZellijPlugin for State {
                         ));
                         true
                     }
+                    Some(recents::CMD_LOAD_RECENTS) => {
+                        self.recent_project_dirs = recents::parse_loaded_recents(&stdout);
+                        // No re-render needed: recents are only consumed when
+                        // the wizard opens, which seeds from this field.
+                        false
+                    }
+                    Some(recents::CMD_SAVE_RECENTS) => {
+                        // Fire-and-forget persistence; nothing to do on ack.
+                        false
+                    }
                     _ => false,
                 }
             }
@@ -653,6 +672,15 @@ fn workdir_key(s: &str) -> &str {
 impl State {
     /// Sort agents by project_dir, then by name within each group.
     /// Preserves the selected agent across the sort.
+    /// Record a freshly-spawned agent's project dir into the global recents
+    /// (MRU), then persist asynchronously. Only fires on user-initiated spawns
+    /// — never on session restore (#127).
+    fn record_recent_project_dir(&mut self, dir: &str) {
+        if recents::push_recent(&mut self.recent_project_dirs, dir) {
+            recents::save_recents_async(&self.recent_project_dirs);
+        }
+    }
+
     fn sort_agents_by_dir(&mut self) {
         let selected_id = self.agents.get(self.selected_index).map(|a| a.id.clone());
 
@@ -814,6 +842,26 @@ impl State {
                     self.next_agent_id,
                     default_base,
                 );
+                // Seed the project-dir picker from the global recents, then bias
+                // toward the focused/selected agent's workdir by moving it to the
+                // front so it's pre-highlighted (context default, cf. #168).
+                let mut seed_project_dirs = self.recent_project_dirs.clone();
+                if let Some(dir) = self
+                    .focused_agent
+                    .as_ref()
+                    .and_then(|name| self.agents.iter().find(|a| &a.name == name))
+                    .or_else(|| self.agents.get(self.selected_index))
+                    .map(|a| a.project_dir.clone())
+                {
+                    recents::push_recent(&mut seed_project_dirs, &dir);
+                }
+                // Show the recents list when we have any; otherwise drop straight
+                // to the legacy free-text input (no empty list to navigate).
+                let project_dir_mode = if seed_project_dirs.is_empty() {
+                    ProjectDirMode::Input
+                } else {
+                    ProjectDirMode::List
+                };
                 // Build state, then derive the first step from active_steps() so the
                 // skip rules don't drift between init and key handlers.
                 let mut state = WizardState {
@@ -833,6 +881,10 @@ impl State {
                     completion_index: None,
                     project_dir_error: None,
                     project_dir_suggested,
+                    available_project_dirs: seed_project_dirs,
+                    project_dir_index: 0,
+                    project_dir_filter: String::new(),
+                    project_dir_mode,
                 };
                 state.step = state.active_steps().into_iter().next().unwrap_or(WizardStep::Name);
                 self.wizard = Some(state);
@@ -975,6 +1027,7 @@ impl State {
                     ) {
                         Ok(info) => {
                             self.status_message = Some(format!("Spawned {}", info.name));
+                            self.record_recent_project_dir(&info.project_dir);
                             self.agents.push(info);
                             self.sort_agents_by_dir();
                             self.hide_all_agent_panes();
@@ -1216,118 +1269,195 @@ impl State {
                 }
                 _ => {}
             },
-            WizardStep::ProjectDir => match bare {
-                BareKey::Enter => {
-                    // If completions are showing and one is highlighted, accept it first.
-                    if let Some(idx) = wizard.completion_index {
-                        if let Some(selected) = wizard.completions.get(idx).cloned() {
-                            wizard.project_dir = selected;
+            // Dual-mode (#127): a navigable recents picker (List) with a
+            // free-text escape hatch (Input). When there are no recents the
+            // wizard opens straight in Input mode (legacy behavior intact).
+            WizardStep::ProjectDir => match wizard.project_dir_mode {
+                // ── Recents picker (#127) ──────────────────────────────
+                ProjectDirMode::List => match bare {
+                    BareKey::Down => {
+                        let len = wizard.filtered_project_dirs().len();
+                        if len > 0 {
+                            wizard.project_dir_index = (wizard.project_dir_index + 1) % len;
                         }
-                        wizard.clear_completions();
-                        wizard.project_dir_error = None;
-                        wizard.project_dir_suggested = false;
-                    } else {
-                        // Validate BEFORE advancing. Sandbox backends (nono on
-                        // macOS, agent-sandbox/bwrap on Linux) require absolute
-                        // paths — catch typos here so the user sees the cause
-                        // and can correct without spawning a doomed agent.
-                        // The error is rendered as a red line below the input
-                        // by `render_wizard` (status_message is invisible while
-                        // the wizard overlay is active, hence this dedicated
-                        // field on WizardState).
-                        //
-                        // Tilde handling: the path completer collapses absolute
-                        // matches back to `~/...` for readability (handler
-                        // CMD_PATH_COMPLETE applies `collapse_tilde`). Expand
-                        // it transparently here so the wizard accepts `~/...`
-                        // input — the backend gets the absolute form.
-                        let trimmed_owned = wizard.project_dir.trim().to_string();
-                        if trimmed_owned.starts_with('~') {
-                            let expanded = config::expand_tilde(&trimmed_owned);
-                            if expanded.starts_with('/') {
-                                wizard.project_dir = expanded;
+                    }
+                    BareKey::Up => {
+                        let len = wizard.filtered_project_dirs().len();
+                        if len > 0 {
+                            wizard.project_dir_index = (wizard.project_dir_index + len - 1) % len;
+                        }
+                    }
+                    BareKey::Enter => {
+                        let selected = wizard
+                            .filtered_project_dirs()
+                            .get(wizard.project_dir_index)
+                            .map(|s| s.to_string());
+                        if let Some(dir) = selected {
+                            wizard.project_dir = dir;
+                            wizard.project_dir_error = None;
+                            wizard.project_dir_suggested = false;
+                            // #167: refresh the dir-derived default name unless the
+                            // user already typed a custom one.
+                            if wizard.name.is_empty() {
+                                let base = wizard.selected_base_agent().to_string();
+                                wizard.default_name = agent::suggest_agent_name(
+                                    &wizard.project_dir,
+                                    &self.agents,
+                                    self.next_agent_id,
+                                    &base,
+                                );
+                            }
+                            if let Some(next) = wizard.next_step() {
+                                wizard.step = next;
+                            }
+                        } else {
+                            // Filter matched nothing → hand the typed text over to
+                            // free-text input so the user can finish a fresh path
+                            // instead of hitting a dead end.
+                            wizard.project_dir = wizard.project_dir_filter.trim().to_string();
+                            wizard.project_dir_filter.clear();
+                            wizard.project_dir_index = 0;
+                            wizard.project_dir_suggested = false;
+                            wizard.project_dir_mode = ProjectDirMode::Input;
+                        }
+                    }
+                    // `i` switches to free-text ONLY as the first keystroke (filter
+                    // still empty). Once filtering has begun, `i` is a normal filter
+                    // character — otherwise paths containing "i" (most of them)
+                    // couldn't be filtered.
+                    BareKey::Char('i') if wizard.project_dir_filter.is_empty() => {
+                        wizard.project_dir_mode = ProjectDirMode::Input;
+                    }
+                    BareKey::Char(c) => {
+                        wizard.project_dir_filter.push(c);
+                        wizard.project_dir_index = 0;
+                    }
+                    BareKey::Backspace => {
+                        if wizard.project_dir_filter.is_empty() {
+                            if let Some(prev) = wizard.prev_step() {
+                                wizard.step = prev;
+                            }
+                        } else {
+                            wizard.project_dir_filter.pop();
+                            wizard.project_dir_index = 0;
+                        }
+                    }
+                    _ => {}
+                },
+                // ── Free-text input (legacy escape hatch) ──────────────
+                ProjectDirMode::Input => match bare {
+                    BareKey::Enter => {
+                        // If completions are showing and one is highlighted, accept it first.
+                        if let Some(idx) = wizard.completion_index {
+                            if let Some(selected) = wizard.completions.get(idx).cloned() {
+                                wizard.project_dir = selected;
+                            }
+                            wizard.clear_completions();
+                            wizard.project_dir_error = None;
+                            wizard.project_dir_suggested = false;
+                        } else {
+                            // Validate BEFORE advancing. Sandbox backends (nono on
+                            // macOS, agent-sandbox/bwrap on Linux) require absolute
+                            // paths — catch typos here so the user sees the cause
+                            // and can correct without spawning a doomed agent.
+                            //
+                            // Tilde handling: the path completer collapses absolute
+                            // matches back to `~/...` for readability. Expand it
+                            // transparently here so the wizard accepts `~/...` input.
+                            let trimmed_owned = wizard.project_dir.trim().to_string();
+                            if trimmed_owned.starts_with('~') {
+                                let expanded = config::expand_tilde(&trimmed_owned);
+                                if expanded.starts_with('/') {
+                                    wizard.project_dir = expanded;
+                                }
+                            }
+                            let trimmed = wizard.project_dir.trim();
+                            let err = if trimmed.is_empty() {
+                                Some("Project dir is required.")
+                            } else if trimmed.starts_with('~') {
+                                // Tilde survived expansion → $HOME unavailable in
+                                // this plugin process. Ask for the full path.
+                                Some("Project dir does not expand `~`. Use the full /Users/... path (Tab to autocomplete).")
+                            } else if !trimmed.starts_with('/') {
+                                Some("Project dir must be an absolute path (Tab to autocomplete).")
+                            } else {
+                                None
+                            };
+                            if let Some(msg) = err {
+                                wizard.project_dir_error = Some(msg.to_string());
+                                // Stay on ProjectDir — Backspace to edit, Tab to autocomplete.
+                                return true;
+                            }
+                            wizard.project_dir_error = None;
+                            // #167: refresh the dir-derived default name unless the
+                            // user already typed a custom one.
+                            if wizard.name.is_empty() {
+                                let base = wizard.selected_base_agent().to_string();
+                                wizard.default_name = agent::suggest_agent_name(
+                                    &wizard.project_dir,
+                                    &self.agents,
+                                    self.next_agent_id,
+                                    &base,
+                                );
+                            }
+                            if let Some(next) = wizard.next_step() {
+                                wizard.step = next;
                             }
                         }
-                        let trimmed = wizard.project_dir.trim();
-                        let err = if trimmed.is_empty() {
-                            Some("Project dir is required.")
-                        } else if trimmed.starts_with('~') {
-                            // Tilde survived expansion → $HOME unavailable in
-                            // this plugin process. Ask for the full path.
-                            Some("Project dir does not expand `~`. Use the full /Users/... path (Tab to autocomplete).")
-                        } else if !trimmed.starts_with('/') {
-                            Some("Project dir must be an absolute path (Tab to autocomplete).")
-                        } else {
-                            None
-                        };
-                        if let Some(msg) = err {
-                            wizard.project_dir_error = Some(msg.to_string());
-                            // Stay on ProjectDir — Backspace to edit, Tab to autocomplete.
-                            return true;
-                        }
-                        wizard.project_dir_error = None;
-                        // #167: now that the project dir is finalized, refresh the
-                        // dir-derived default name shown on the Name step — unless
-                        // the user already typed a custom name.
-                        if wizard.name.is_empty() {
-                            let base = wizard.selected_base_agent().to_string();
-                            wizard.default_name = agent::suggest_agent_name(
-                                &wizard.project_dir,
-                                &self.agents,
-                                self.next_agent_id,
-                                &base,
-                            );
-                        }
-                        if let Some(next) = wizard.next_step() {
-                            wizard.step = next;
-                        }
                     }
-                }
-                BareKey::Tab => {
-                    wizard.project_dir_suggested = false;
-                    if wizard.completions.is_empty() {
-                        // First Tab press: request completions from the shell.
-                        config::complete_path_async(
-                            &wizard.project_dir,
-                            &self.config.project_search_roots,
-                            self.config.project_search_max_depth,
-                        );
-                    } else {
-                        // Subsequent Tab presses: cycle through suggestions.
-                        let len = wizard.completions.len();
-                        wizard.completion_index = Some(match wizard.completion_index {
-                            Some(i) => (i + 1) % len,
-                            None => 0,
-                        });
-                    }
-                }
-                BareKey::Backspace => {
-                    if wizard.project_dir_suggested && !wizard.project_dir.is_empty() {
-                        // #168: first Backspace on a pristine pre-fill clears the
-                        // whole field (ready for a fresh path) instead of deleting
-                        // one char or navigating back. Subsequent Backspaces follow
-                        // the normal empty-field behavior.
-                        wizard.project_dir = String::new();
+                    BareKey::Tab => {
                         wizard.project_dir_suggested = false;
-                        wizard.clear_completions();
-                        wizard.project_dir_error = None;
-                    } else if wizard.project_dir.is_empty() {
-                        if let Some(prev) = wizard.prev_step() {
-                            wizard.step = prev;
+                        if wizard.completions.is_empty() {
+                            // First Tab press: request completions from the shell.
+                            config::complete_path_async(
+                                &wizard.project_dir,
+                                &self.config.project_search_roots,
+                                self.config.project_search_max_depth,
+                            );
+                        } else {
+                            // Subsequent Tab presses: cycle through suggestions.
+                            let len = wizard.completions.len();
+                            wizard.completion_index = Some(match wizard.completion_index {
+                                Some(i) => (i + 1) % len,
+                                None => 0,
+                            });
                         }
-                    } else {
-                        wizard.project_dir.pop();
+                    }
+                    BareKey::Backspace => {
+                        if wizard.project_dir_suggested && !wizard.project_dir.is_empty() {
+                            // #168: first Backspace on a pristine pre-fill clears the
+                            // whole field (ready for a fresh path) instead of deleting
+                            // one char or navigating back.
+                            wizard.project_dir = String::new();
+                            wizard.project_dir_suggested = false;
+                            wizard.clear_completions();
+                            wizard.project_dir_error = None;
+                        } else if wizard.project_dir.is_empty() {
+                            // Back out to the recents list if we have any (#127),
+                            // else step backward through the wizard.
+                            if wizard.available_project_dirs.is_empty() {
+                                if let Some(prev) = wizard.prev_step() {
+                                    wizard.step = prev;
+                                }
+                            } else {
+                                wizard.project_dir_mode = ProjectDirMode::List;
+                                wizard.clear_completions();
+                                wizard.project_dir_error = None;
+                            }
+                        } else {
+                            wizard.project_dir.pop();
+                            wizard.clear_completions();
+                            wizard.project_dir_error = None;
+                        }
+                    }
+                    BareKey::Char(c) => {
+                        wizard.project_dir_suggested = false;
+                        wizard.project_dir.push(c);
                         wizard.clear_completions();
                         wizard.project_dir_error = None;
                     }
-                }
-                BareKey::Char(c) => {
-                    wizard.project_dir_suggested = false;
-                    wizard.project_dir.push(c);
-                    wizard.clear_completions();
-                    wizard.project_dir_error = None;
-                }
-                _ => {}
+                    _ => {}
+                },
             },
             WizardStep::Confirm => match bare {
                 BareKey::Enter | BareKey::Char('!') => {
@@ -1421,6 +1551,7 @@ impl State {
         ) {
             Ok(info) => {
                 self.status_message = Some(format!("Spawned {}", info.name));
+                self.record_recent_project_dir(&info.project_dir);
                 self.agents.push(info);
                 self.sort_agents_by_dir();
                 self.hide_all_agent_panes();

--- a/lince-dashboard/plugin/src/recents.rs
+++ b/lince-dashboard/plugin/src/recents.rs
@@ -1,0 +1,137 @@
+//! Global "recent project directories" store for the wizard's Project dir
+//! picker (#127).
+//!
+//! Unlike `.lince-dashboard` (per-launch-dir agent state), recents live in a
+//! single global file so they follow the user regardless of which directory
+//! the dashboard was launched from:
+//!
+//!   ~/.config/lince-dashboard/recents.json
+//!
+//! The file is a plain JSON array of absolute paths, most-recently-used first.
+//! We intentionally store *order only* (no timestamps): wall-clock time is
+//! unreliable in the WASI sandbox, and MRU order is all the picker needs.
+
+use crate::config::run_typed_command;
+
+pub const CMD_LOAD_RECENTS: &str = "load_recents";
+pub const CMD_SAVE_RECENTS: &str = "save_recents";
+
+/// Cap on how many recent dirs we keep / persist.
+pub const MAX_RECENTS: usize = 20;
+
+/// Shell expression for the recents file path. `$HOME` is expanded by the
+/// host shell (the plugin process itself can't reliably resolve `~`/`$HOME`
+/// under WASI).
+const RECENTS_PATH_EXPR: &str = "\"$HOME/.config/lince-dashboard/recents.json\"";
+
+/// Kick off an async load of the global recents file.
+/// Missing file → empty stdout → `parse_loaded_recents` yields an empty list.
+pub fn load_recents_async() {
+    let script = format!("cat {} 2>/dev/null", RECENTS_PATH_EXPR);
+    run_typed_command(&["sh", "-c", &script], CMD_LOAD_RECENTS);
+}
+
+/// Kick off an async save of the recents list, creating the parent dir if
+/// needed. Writes the whole list (already trimmed to `MAX_RECENTS`).
+pub fn save_recents_async(dirs: &[String]) {
+    let json = match serde_json::to_string_pretty(dirs) {
+        Ok(j) => j,
+        Err(_) => return,
+    };
+    // Heredoc write avoids shell-escaping the JSON payload.
+    let script = format!(
+        "mkdir -p \"$HOME/.config/lince-dashboard\" && cat > {} <<'__LINCE_EOF__'\n{}\n__LINCE_EOF__",
+        RECENTS_PATH_EXPR, json
+    );
+    run_typed_command(&["sh", "-c", &script], CMD_SAVE_RECENTS);
+}
+
+/// Parse the recents file contents. Tolerant of a missing/empty/garbage file:
+/// any parse failure yields an empty list rather than an error (recents are a
+/// convenience, never load-blocking).
+pub fn parse_loaded_recents(stdout: &[u8]) -> Vec<String> {
+    let content = String::from_utf8_lossy(stdout);
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return Vec::new();
+    }
+    let mut parsed: Vec<String> = serde_json::from_str(trimmed).unwrap_or_default();
+    // Defensive, order-preserving de-dup. `push_recent` already guarantees
+    // uniqueness on write, but the file may be hand-edited or corrupted out of
+    // band — keep the first occurrence of each path and cap the length.
+    let mut seen = std::collections::HashSet::new();
+    parsed.retain(|p| seen.insert(p.clone()));
+    parsed.truncate(MAX_RECENTS);
+    parsed
+}
+
+/// Record a use of `dir`: move it to the front (most-recent), de-duplicating
+/// any earlier occurrence, and trim the list to `MAX_RECENTS`. Empty paths are
+/// ignored. Returns `true` if the list changed (caller should persist).
+pub fn push_recent(list: &mut Vec<String>, dir: &str) -> bool {
+    let dir = dir.trim_end_matches('/');
+    if dir.is_empty() {
+        return false;
+    }
+    // Already at the front with nothing else to do → no change.
+    if list.first().map(|s| s.as_str()) == Some(dir) {
+        return false;
+    }
+    list.retain(|d| d != dir);
+    list.insert(0, dir.to_string());
+    list.truncate(MAX_RECENTS);
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_file_yields_empty() {
+        assert!(parse_loaded_recents(b"").is_empty());
+        assert!(parse_loaded_recents(b"   \n").is_empty());
+    }
+
+    #[test]
+    fn garbage_yields_empty_not_error() {
+        assert!(parse_loaded_recents(b"not json").is_empty());
+    }
+
+    #[test]
+    fn round_trips_paths() {
+        let parsed = parse_loaded_recents(br#"["/a/b", "/c/d"]"#);
+        assert_eq!(parsed, vec!["/a/b".to_string(), "/c/d".to_string()]);
+    }
+
+    #[test]
+    fn parse_dedupes_preserving_order() {
+        // Hand-edited file with duplicates → first occurrence wins, order kept.
+        let parsed = parse_loaded_recents(br#"["/a", "/b", "/a", "/c", "/b"]"#);
+        assert_eq!(parsed, vec!["/a".to_string(), "/b".to_string(), "/c".to_string()]);
+    }
+
+    #[test]
+    fn push_moves_to_front_and_dedupes() {
+        let mut list = vec!["/a".to_string(), "/b".to_string()];
+        assert!(push_recent(&mut list, "/b"));
+        assert_eq!(list, vec!["/b", "/a"]);
+        // Trailing slash is normalized, and a no-op (already front) returns false.
+        assert!(!push_recent(&mut list, "/b/"));
+    }
+
+    #[test]
+    fn push_caps_at_max() {
+        let mut list: Vec<String> = (0..MAX_RECENTS).map(|i| format!("/p{}", i)).collect();
+        assert!(push_recent(&mut list, "/new"));
+        assert_eq!(list.len(), MAX_RECENTS);
+        assert_eq!(list[0], "/new");
+    }
+
+    #[test]
+    fn push_ignores_empty() {
+        let mut list = vec!["/a".to_string()];
+        assert!(!push_recent(&mut list, ""));
+        assert!(!push_recent(&mut list, "/"));
+    }
+}

--- a/lince-dashboard/plugin/src/types.rs
+++ b/lince-dashboard/plugin/src/types.rs
@@ -158,6 +158,34 @@ pub enum WizardStep {
     Confirm,
 }
 
+/// Sub-UI mode for the ProjectDir wizard step (#127).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProjectDirMode {
+    /// Navigable list of recent project dirs with filter-as-you-type.
+    List,
+    /// Free-text path input (legacy behavior; reached via `i`, or used
+    /// automatically when there are no recents yet).
+    Input,
+}
+
+/// Case-insensitive match used by the project-dir picker filter: a hit is
+/// either a substring match or an in-order subsequence match (so `snptc`
+/// matches `synoptic`). Both `haystack` and `needle` must be lowercased by
+/// the caller.
+pub fn project_dir_filter_matches(haystack: &str, needle: &str) -> bool {
+    if needle.is_empty() {
+        return true;
+    }
+    if haystack.contains(needle) {
+        return true;
+    }
+    // Fuzzy fallback: every needle char appears in order in the haystack —
+    // e.g. "sntp" matches "synoptic". Advancing a single shared iterator keeps
+    // the match strictly in-order.
+    let mut chars = haystack.chars();
+    needle.chars().all(|nc| chars.any(|hc| hc == nc))
+}
+
 /// State for the multi-step "New Agent" wizard.
 #[derive(Debug, Clone)]
 pub struct WizardState {
@@ -203,7 +231,17 @@ pub struct WizardState {
     /// True while `project_dir` holds an un-edited pre-fill from the selected
     /// agent (#168). The first Backspace clears the field instead of navigating
     /// to the previous step; any keystroke or completion clears the flag.
+    /// Only meaningful in Input mode (#127).
     pub project_dir_suggested: bool,
+    /// Recent project dirs (most-recently-used first) offered by the picker.
+    /// Seeded from the global recents store when the wizard opens (#127).
+    pub available_project_dirs: Vec<String>,
+    /// Highlighted index into the *filtered* recents list (List mode).
+    pub project_dir_index: usize,
+    /// Filter text typed in List mode (substring / subsequence, case-insensitive).
+    pub project_dir_filter: String,
+    /// Whether the ProjectDir step shows the recents list or the free-text input.
+    pub project_dir_mode: ProjectDirMode,
 }
 
 impl WizardState {
@@ -257,6 +295,17 @@ impl WizardState {
     /// Return the currently selected sandbox level, or None if no levels available.
     pub fn selected_sandbox_level(&self) -> Option<&str> {
         self.available_sandbox_levels.get(self.sandbox_level_index).map(|s| s.as_str())
+    }
+
+    /// Recent project dirs matching the current List-mode filter, preserving
+    /// most-recently-used order. Empty filter → all recents (#127).
+    pub fn filtered_project_dirs(&self) -> Vec<&str> {
+        let needle = self.project_dir_filter.trim().to_lowercase();
+        self.available_project_dirs
+            .iter()
+            .filter(|d| project_dir_filter_matches(&d.to_lowercase(), &needle))
+            .map(|s| s.as_str())
+            .collect()
     }
 
     /// Build the ordered list of active wizard steps, applying skip rules.


### PR DESCRIPTION
## Problem

The wizard's Project dir step was the only free-text step: empty on first use, no paste in the Zellij WASM host, so the user had to type a full absolute path every time.

## Fix

A dual-mode ProjectDir step:

- **List mode** — a navigable, filter-as-you-type list of recent project dirs (most-recently-used first). Type to filter (substring / subsequence, case-insensitive), `↑/↓` to move, `Enter` to select.
- **Input mode** — the legacy free-text entry with Tab completion and absolute-path validation, reached via `i`, or automatically when there are no recents yet.

`i` switches to free-text **only as the first keystroke** (filter still empty), so paths containing "i" (most of them) stay filterable once you start typing.

The focused/selected agent's workdir is moved to the front of the recents so it's pre-highlighted (context default, cf. #168).

## Storage

Recents live in a single **global** file — `~/.config/lince-dashboard/recents.json` (MRU order, capped at 20) — so they follow the user regardless of which directory the dashboard was launched from. Loaded async at startup; recorded on **user-initiated spawns only** (never on session restore).

Timestamps are intentionally omitted: wall-clock is unreliable under WASI, and MRU order is all the picker needs. (Relative-time display can be a follow-up.)

## Per your feedback on #127

> Let's avoid the backward compatibility option; it just messes the config, and we have the "i" fallback to the old behaviour. And consider default based on the selected agent as per #168.

- **No config gate** — the picker is always on; `i` is the fallback to the legacy input.
- **Context default** — focused agent's workdir pre-selected (#168 direction).

## Files

`recents.rs` (new, +unit tests for the MRU/parse logic), `types.rs`, `main.rs`, `dashboard.rs`. Builds clean for `wasm32-wasip1`.

## Out of scope (per the RFC)

Git auto-discovery, declarative bookmarks, fzf-grade ranking — each its own follow-up if this lands.

Closes #127