### PR TITLE
feat(sandbox): adapt sandbox levels for Seatbelt limitations

### DIFF
--- a/docs/documentation/dashboard/sandbox-levels.md
+++ b/docs/documentation/dashboard/sandbox-levels.md
@@ -43,15 +43,19 @@ If you disable Zellij pane frames, the title indicator is hidden — agents cont
 
 The table below summarises the differences. Sections after it give the concrete config snippets and behavior for each level.
 
-| Aspect                                  | paranoid (bwrap)              | paranoid (nono)        | normal             | permissive                                              |
-|-----------------------------------------|-------------------------------|------------------------|--------------------|---------------------------------------------------------|
-| Network (allowed destinations)          | Anthropic API only            | Anthropic API only     | inherited base     | + GitHub + gh CLI domains                               |
-| Network isolation enforcement           | kernel (netns) + proxy allowlist | kernel (Landlock + nono policy) | inherited       | proxy allowlist                                         |
-| Agent opens raw socket to exfiltrate    | blocked (no route in netns) ✓ | blocked (kernel policy) ✓ | depends on base | blocked for non-allowlisted hosts (proxy)               |
-| Filesystem                              | $WORKDIR + scratch ~/.claude + scratch ~/.claude.json | $WORKDIR + scratch ~/.claude | as today      | + ~/.config/gh, ~/.cache, ~/.ssh/known_hosts            |
-| `gh` CLI                                | no                            | no                     | no                 | yes                                                     |
-| `docker` / `podman`                     | no                            | no                     | no                 | **no** (out of scope)                                   |
-| direct `git push`                       | no                            | no                     | no                 | **no** (use `gh` instead)                               |
+| Aspect                                  | paranoid (bwrap)              | paranoid (nono)        | paranoid (seatbelt)   | normal             | permissive                                              |
+|-----------------------------------------|-------------------------------|------------------------|-----------------------|--------------------|---------------------------------------------------------|
+| Network (allowed destinations)          | Anthropic API only            | Anthropic API only     | Anthropic API only (userland proxy) | inherited base     | + GitHub + gh CLI domains                               |
+| Network isolation enforcement           | kernel (netns) + proxy allowlist | kernel (Landlock + nono policy) | userland proxy only (no kernel netns) | inherited       | proxy allowlist                                         |
+| Agent opens raw socket to exfiltrate    | blocked (no route in netns) ✓ | blocked (kernel policy) ✓ | ⚠ not kernel-blocked (proxy allowlist is userland) | depends on base | blocked for non-allowlisted hosts (proxy)               |
+| PID namespace                           | yes (host processes hidden) ✓ | yes (nono policy) ✓    | ⚠ not available (host processes visible) | yes (bwrap/none) | yes (bwrap/none)                                        |
+| Filesystem                              | $WORKDIR + scratch ~/.claude + scratch ~/.claude.json | $WORKDIR + scratch ~/.claude | $WORKDIR + deny file-write* + allowlist | as today      | + ~/.config/gh, ~/.cache, ~/.ssh/known_hosts            |
+| Env var clearing                        | `--clearenv`                  | env wrapper            | `env -i` wrapper      | same as backend    | same as backend                                         |
+| Credential proxy                        | host-side, kernel-gated       | host-side, kernel-gated| host-side, userland only | opt-in             | off by default                                          |
+| Learn mode (strace)                     | yes                           | no (not available on macOS) | no (not available on macOS) | yes (bwrap)        | yes (bwrap)                                             |
+| `gh` CLI                                | no                            | no                     | no                    | no                 | yes                                                     |
+| `docker` / `podman`                     | no                            | no                     | no                    | no                 | **no** (out of scope)                                   |
+| direct `git push`                       | no                            | no                     | no                    | no                 | **no** (use `gh` instead)                               |
 
 ### 2.1 Paranoid
 
@@ -265,14 +269,15 @@ docker: command not found
 
 ## 4. Selecting a sandbox backend
 
-The dashboard supports two backends, switched per agent via `sandbox_backend`:
+The dashboard supports three backends, switched per agent via `sandbox_backend`:
 
-- `sandbox_backend = "bwrap"` — agent-sandbox, Linux only, isolation via Bubblewrap mount/PID namespaces and a host-side credential proxy.
+- `sandbox_backend = "bwrap"` — agent-sandbox, Linux only, isolation via Bubblewrap mount/PID/network namespaces and a host-side credential proxy.
 - `sandbox_backend = "nono"` — nono, Linux + macOS, isolation via Landlock (Linux) or Seatbelt (macOS) plus nono's own network policy engine.
+- `sandbox_backend = "seatbelt"` — Apple Seatbelt (`sandbox-exec`), macOS only, filesystem isolation via Seatbelt's mandatory access control. Does **not** provide PID or network namespace isolation; paranoid level degrades gracefully with warnings.
 
-The default is per-OS: Linux picks `bwrap` (agent-sandbox), macOS picks `nono`. A Linux user who wants kernel-enforced filesystem isolation via Landlock can override that and pick `nono` explicitly.
+The default is per-OS: Linux picks `bwrap` (agent-sandbox), macOS picks `seatbelt` when `sandbox-exec` is available (falls back to `nono` if nono is installed). A Linux user who wants kernel-enforced filesystem isolation via Landlock can override that and pick `nono` explicitly.
 
-**Backend implementation note.** Both backends now achieve kernel-enforced network isolation under paranoid; the implementation paths differ. bwrap paranoid uses `--unshare-net` plus a socat unix-socket bridge to the credential proxy. nono paranoid uses Landlock LSM plus nono's native network policy. From a threat-model standpoint the two are equivalent for paranoid: an agent that opens a raw TCP socket to a non-allowlisted host fails at the kernel level on either backend.
+**Backend implementation note.** bwrap and nono both achieve kernel-enforced network isolation under paranoid; the implementation paths differ. bwrap paranoid uses `--unshare-net` plus a socat unix-socket bridge to the credential proxy. nono paranoid uses Landlock LSM plus nono's native network policy. **Seatbelt paranoid does not achieve kernel-level network isolation** -- it provides filesystem isolation + userland credential proxy + env clearing. From a threat-model standpoint, seatbelt paranoid is weaker than bwrap/nono paranoid for network and PID isolation, but still provides meaningful filesystem and credential protection. Warnings are printed at startup listing exactly what is unavailable.
 
 **Prerequisites for paranoid + bwrap.** `socat` must be available on the host's `$PATH` (most distros: install the `socat` package). `install.sh` warns when it is missing. If `unshare_net = true` is resolved at run time and `socat` is not found, `agent-sandbox` errors out with a clear message rather than silently degrading.
 

--- a/docs/documentation/sandbox/security-model.md
+++ b/docs/documentation/sandbox/security-model.md
@@ -206,6 +206,48 @@ Build tools work with minimal friction because system directories are read-only 
 
 ---
 
+## Seatbelt Backend (macOS)
+
+On macOS the Seatbelt backend (`sandbox-exec`) replaces bubblewrap. Seatbelt is Apple's built-in mandatory access control framework; it operates at the filesystem and process level but does **not** provide kernel-level namespace isolation.
+
+### Limitation Matrix
+
+The table below compares each defense layer between bwrap (Linux) and Seatbelt (macOS):
+
+| Defense Layer | bwrap (Linux) | Seatbelt (macOS) | Notes |
+|---|---|---|---|
+| Filesystem write isolation | `--ro-bind / /` + allowlist | `(deny file-write*)` + allowlist | Equivalent enforcement |
+| PID namespace | `--unshare-pid` | **Not available** | Agent can see and signal host processes |
+| Network namespace | `--unshare-net` | **Not available** | Agent can make direct network connections; credential proxy is userland only |
+| Env var clearing | `--clearenv` + `--setenv` | `env -i` wrapper | Equivalent enforcement |
+| Credential proxy | Host-side, kernel-netns-gated | Host-side, userland | Proxy runs but cannot enforce at kernel level |
+| Git push blocking | PATH wrapper | PATH wrapper | Equivalent enforcement |
+| Config snapshots | rsync hardlinks | rsync hardlinks | Equivalent enforcement |
+| Learn mode (strace) | `strace -f -e trace=...` | **Not available** | macOS lacks strace; use DTrace or cross-platform profile porting |
+| Cloud SSRF blocking | Proxy-level block | Proxy-level block | Equivalent enforcement |
+| Process fork/exec control | bwrap defaults | `(allow process-fork)` / `(allow process-exec)` | Seatbelt allows by default; bwrap allows by default |
+
+### Paranoid on macOS vs Linux
+
+Paranoid level on the Seatbelt backend provides a **reduced but still meaningful** isolation envelope:
+
+- **What works**: filesystem write isolation, environment variable clearing, credential proxy (userland), git push blocking, config snapshots.
+- **What does not work**: kernel-level network namespace isolation (`--unshare-net`), PID namespace isolation, strace-based learn mode.
+
+When paranoid is selected with the Seatbelt backend, `agent-sandbox` prints clear warnings listing exactly which features are unavailable and then proceeds -- the user explicitly requested paranoid and the remaining defenses still provide real value.
+
+**Network hardening recommendation for macOS**: to approximate the Linux kernel network namespace on macOS, you can use `pfctl` (Packet Filter) to restrict the sandboxed process's outbound traffic. Example:
+
+```bash
+# Create an anchor that blocks all outbound except the Anthropic API
+echo 'block drop out proto tcp from any to any
+pass out proto tcp from any to api.anthropic.com' | sudo pfctl -ef - 2>/dev/null
+```
+
+Note: `pfctl` rules apply system-wide and require root. They are not scoped to a single process unless combined with `pfctl` anchors and process-level UID/GID filtering. This is a manual, external hardening step -- `agent-sandbox` does not manage `pfctl` rules automatically.
+
+---
+
 ## See Also
 
 - [CLI Reference](sandbox/cli-reference.md) -- command synopsis, flags, and usage examples

--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -1958,15 +1958,51 @@ def build_env_clear_command(
     return cmd
 
 
+def check_seatbelt_level_warnings(
+    backend: str, sandbox_level: str | None, config: dict,
+) -> list[str]:
+    """Return warning strings when a Seatbelt backend cannot fully enforce a level.
+
+    Currently only *paranoid* produces warnings, because Seatbelt lacks the
+    kernel-level PID and network namespace isolation that bwrap provides.
+    """
+    if backend != "seatbelt" or sandbox_level != "paranoid":
+        return []
+
+    warnings: list[str] = []
+
+    warnings.append(
+        "Seatbelt cannot create a PID namespace. "
+        "The agent will be able to see and signal host processes."
+    )
+
+    warnings.append(
+        "Seatbelt has no network namespace. The credential proxy is active but "
+        "the agent CAN make direct network connections (kernel-level blocking is "
+        "unavailable). Paranoid on Seatbelt provides filesystem isolation + "
+        "credential injection only."
+    )
+
+    return warnings
+
+
 def generate_seatbelt_profile(
     agent_name: str,
     agent_config: dict,
     config: dict,
+    sandbox_level: str | None = None,
 ) -> tuple[str, list[str]]:
     """Generate an Apple Seatbelt (sandbox-exec) profile from lince agent configuration.
 
     Returns (profile_text, warnings_list). The profile text is a sequence
     of S-expression rules suitable for ``sandbox-exec -f <file>``.
+
+    *sandbox_level* adjusts the profile:
+      - ``"normal"`` / ``None``: baseline profile (default).
+      - ``"permissive"``: baseline + extra ``(allow file-read* ...)`` from the
+        permissive config fragment (e.g. ``~/.config/gh``, ``~/.cache``).
+      - ``"paranoid"``: permissive-level access plus an explanatory comment
+        block documenting Seatbelt limitations vs the bwrap backend.
     """
     warnings: list[str] = []
     sandbox_conf = config.get("sandbox", {})
@@ -2080,6 +2116,43 @@ def generate_seatbelt_profile(
     lines.append("(allow signal)")
     lines.append("")
 
+    # --- Level-specific profile sections ---
+    effective_level = sandbox_level if sandbox_level and sandbox_level != "normal" else None
+
+    if effective_level == "permissive":
+        # Permissive level: extra read-only dirs from the config fragment.
+        # The fragment's [sandbox] home_ro_dirs are already merged into
+        # sandbox_conf above by load_sandbox_level_fragment(), so they appear
+        # in the "Home read-only directories" section. This block is for any
+        # additional seatbelt-specific permissive rules that don't map to a
+        # bwrap [sandbox] key.
+        permissive_ro = sandbox_conf.get("home_ro_dirs", [])
+        if permissive_ro:
+            lines.append("; Permissive-level extra read-only directories")
+            for d in permissive_ro:
+                full = str(home / d)
+                if full not in seen_ro:
+                    seen_ro.add(full)
+                    lines.append(f'(allow file-read* (subpath "{full}"))')
+            lines.append("")
+
+    if effective_level == "paranoid":
+        # Paranoid level on Seatbelt: same filesystem access as permissive,
+        # plus a comment block documenting what Seatbelt *cannot* enforce.
+        lines.append("; === PARANOID LEVEL (Seatbelt) ===")
+        lines.append("; NOTE: The following bwrap paranoid features are NOT available:")
+        lines.append(";   - Network namespace (--unshare-net): agent can reach any host")
+        lines.append(";   - PID namespace: agent can see/kill host processes")
+        lines.append(";   - strace/learn mode: not available on macOS")
+        lines.append(";")
+        lines.append("; What IS enforced:")
+        lines.append(";   - Filesystem write isolation (deny file-write* + allowlist)")
+        lines.append(";   - Environment variable clearing (via env -i wrapper)")
+        lines.append(";   - Credential proxy (userland, best-effort)")
+        lines.append(";   - Git push blocking (PATH wrapper)")
+        lines.append(";   - Config snapshots (rsync, userland)")
+        lines.append("")
+
     # --- Warnings for untranslatable features ---
     if agent_config.get("bwrap_conflict"):
         warnings.append(
@@ -2112,6 +2185,7 @@ def build_seatbelt_cmd(
     agent_id: str | None = None,
     provider: str | None = None,
     proxy_env: dict[str, str] | None = None,
+    sandbox_level: str | None = None,
 ) -> tuple[list[str], str]:
     """Build a sandbox-exec command for the given agent.
 
@@ -2123,6 +2197,7 @@ def build_seatbelt_cmd(
     # Generate the base profile
     base_profile, _warnings = generate_seatbelt_profile(
         agent_name, agent_config, config,
+        sandbox_level=sandbox_level,
     )
 
     # Inject the real project directory (read-write)
@@ -3200,6 +3275,7 @@ def cmd_run(args, agent_extra: list[str]) -> None:
             config=config,
             safe_mode=args.safe, agent_id=args.id,
             provider=provider,
+            sandbox_level=sandbox_level,
         )
 
         if args.dry_run:
@@ -3217,6 +3293,11 @@ def cmd_run(args, agent_extra: list[str]) -> None:
             except OSError:
                 pass
             return
+
+        # Print level-specific warnings (e.g. paranoid limitations on Seatbelt)
+        level_warnings = check_seatbelt_level_warnings(backend, sandbox_level, config)
+        for w in level_warnings:
+            print(f"\033[33m⚠  {w}\033[0m", file=sys.stderr)
 
         # Print banner
         print("agent-sandbox (seatbelt backend)")
@@ -5752,6 +5833,26 @@ def cmd_learn(args) -> None:
     # 3. Load config
     config, config_path = load_config()
     project_dir = Path.cwd().resolve()
+
+    # 3a. Gate: learn mode requires strace (Linux-only). Seatbelt and nono
+    # backends cannot use strace-based learn mode.
+    _learn_backend = resolve_backend(config)
+    if _learn_backend in ("seatbelt", "nono"):
+        _alt_msg = (
+            "Alternatives:\n"
+            "  - Use DTrace (macOS): sudo dtrace -n 'syscall::open:entry { ... }'\n"
+            "  - Port profiles cross-platform: run 'agent-sandbox learn' on a Linux\n"
+            "    machine, then copy the resulting fragment to your macOS host.\n"
+            "  - Use --sandbox-level permissive for maximum access, then tighten\n"
+            "    manually based on observed failures."
+        )
+        print(
+            f"Error: learn mode requires strace (Linux-only). "
+            f"Backend '{_learn_backend}' does not support strace.",
+            file=sys.stderr,
+        )
+        print(_alt_msg, file=sys.stderr)
+        sys.exit(1)
 
     # 4. Resolve agent
     agent_name = args.agent


### PR DESCRIPTION
Replaces closed PR #184. Adds paranoid graceful degradation warnings and learn mode gate for seatbelt backend.

Part of epic #149 (Seatbelt Backend).

**Changes:**
- `check_seatbelt_level_warnings()` for paranoid level (no PID namespace, no network namespace)
- Learn mode gate: exits with error when backend=seatbelt
- Updates sandbox-levels.md and security-model.md docs

Tested on macOS (Apple Silicon) via `ssh mac`.

Depends on: #182 (merged), #183 (merged)