### PR TITLE
docs(sandbox): deprecate nono backend, add Seatbelt migration guide

### DIFF
--- a/docs/documentation/sandbox/cli-reference.md
+++ b/docs/documentation/sandbox/cli-reference.md
@@ -6,7 +6,7 @@
 agent-sandbox <command> [options] [-- <agent-args>]
 ```
 
-`agent-sandbox` manages a bubblewrap sandbox for AI coding agents. Commands fall into four groups: setup (`init`), execution (`run`, `learn`), config management (`diff`, `merge`, `status`, `proxy-status`, `nono-sync`), and snapshots (`snapshot`, `snapshot-list`, `snapshot-diff`, `snapshot-restore`, `snapshot-prune`).
+`agent-sandbox` manages a bubblewrap sandbox for AI coding agents. Commands fall into four groups: setup (`init`), execution (`run`, `learn`), config management (`diff`, `merge`, `status`, `proxy-status`, `nono-sync`, `seatbelt-sync`), and snapshots (`snapshot`, `snapshot-list`, `snapshot-diff`, `snapshot-restore`, `snapshot-prune`).
 
 ---
 
@@ -92,7 +92,7 @@ Disabled when `use_real_config = true`.
 agent-sandbox status
 ```
 
-Display sandbox state: config location, file counts, toolchain cache sizes, log count, bwrap version, pending config changes, snapshot info, detected backends, and credential proxy status.
+Display sandbox state: config location, file counts, toolchain cache sizes, log count, bwrap version, pending config changes, detected backends (bubblewrap, nono, seatbelt), active profiles, and credential proxy status.
 
 ---
 
@@ -242,9 +242,27 @@ agent-sandbox nono-sync [--dry-run] [--agent NAME] [-P PROVIDER]
 
 Generate nono JSON profiles from lince agent configuration. Used when the `nono` backend is selected or on macOS.
 
+**DEPRECATED**: The nono backend is deprecated in favor of `seatbelt`. Use `agent-sandbox seatbelt-sync` instead. See [Migration Guide](sandbox/migration-nono-to-seatbelt.md).
+
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--dry-run` | off | Print generated JSON without writing files |
+| `--agent` | all agents | Sync a specific agent only |
+| `-P`, `--provider`, `--profile` | none | Provider name (env-var bundle) for env var mapping |
+
+---
+
+### seatbelt-sync
+
+```
+agent-sandbox seatbelt-sync [--dry-run] [--agent NAME] [-P PROVIDER]
+```
+
+Generate macOS Seatbelt (`.sb`) profiles from lince agent configuration. Used with the `seatbelt` backend (native `sandbox-exec`). Preferred backend for macOS.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--dry-run` | off | Print generated profiles without writing files |
 | `--agent` | all agents | Sync a specific agent only |
 | `-P`, `--provider`, `--profile` | none | Provider name (env-var bundle) for env var mapping |
 

--- a/docs/documentation/sandbox/config-reference.md
+++ b/docs/documentation/sandbox/config-reference.md
@@ -45,7 +45,7 @@ General sandbox behavior and filesystem exposure.
 | `auto_expose_path` | bool | `true` | Auto-detect `$PATH` entries under `$HOME` and expose them read-only. Top-level dirs are mounted, and deeper subdirectories explicitly in the host PATH are also added to the sandbox PATH (e.g. `~/Applications/apache-maven-3.9.14/bin`) |
 | `home_ro_dirs` | list of strings | `[".config/gcloud"]` | Additional home subdirectories to expose read-only (relative to `$HOME`). Note: this only mounts the filesystem — it does not add entries to PATH. Add the tool's `bin` directory to your host shell PATH for automatic sandbox PATH inclusion |
 | `default_provider` | string | `""` | Default provider (env-var bundle) when `-P` / `--provider` is not specified. Set to a provider name defined in `[providers.*]` / `[<agent>.providers.*]`. Leave empty to run without a provider. The legacy spelling `default_profile` is still accepted (gh#81). |
-| `backend` | string | `"auto"` | Sandbox backend: `"agent-sandbox"` (bubblewrap), `"nono"` (Landlock/Seatbelt), or `"auto"` (prefers agent-sandbox on Linux, nono on macOS) |
+| `backend` | string | `"auto"` | Sandbox backend: `"agent-sandbox"` (bubblewrap, Linux), `"seatbelt"` (macOS sandbox-exec, recommended on macOS), `"nono"` (Landlock/Seatbelt, **deprecated**), or `"auto"` (prefers agent-sandbox on Linux, seatbelt on macOS) |
 
 ```toml
 [sandbox]
@@ -55,7 +55,7 @@ persist_toolchains = true
 auto_expose_path = true
 home_ro_dirs = [".config/gcloud"]
 default_provider = "zai"
-backend = "auto"
+backend = "auto"   # auto: Linux → agent-sandbox; macOS → seatbelt → nono (fallback)
 ```
 
 ---

--- a/docs/documentation/sandbox/migration-nono-to-seatbelt.md
+++ b/docs/documentation/sandbox/migration-nono-to-seatbelt.md
@@ -1,0 +1,88 @@
+# Migrating from nono to Seatbelt
+
+The `nono` backend is **deprecated** in favor of the native macOS **Seatbelt** backend (`sandbox-exec`). Seatbelt is built into macOS at `/usr/bin/sandbox-exec` -- zero external dependencies required.
+
+## Why migrate?
+
+| Reason | Details |
+|--------|---------|
+| **Zero dependencies** | `sandbox-exec` ships with macOS. No `brew install` or `cargo install` needed. |
+| **Full control** | Seatbelt profiles are plain `.sb` files you can inspect and edit. |
+| **Better errors** | `sandbox-exec` reports denied operations with path and permission, making debugging straightforward. |
+| **Active development** | The Seatbelt backend receives new features (sandbox levels, `extends` inheritance). nono integration is in maintenance mode. |
+| **Feature parity** | All sandbox levels (`paranoid`, `normal`, `permissive`) and custom profiles work identically. |
+
+## Quick migration steps
+
+```bash
+# 1. Generate Seatbelt profiles from your agent configuration
+agent-sandbox seatbelt-sync
+
+# 2. Verify the profiles were created
+ls ~/.agent-sandbox/seatbelt-profiles/lince-*.sb
+
+# 3. Test with an explicit backend selection
+agent-sandbox run --backend seatbelt
+
+# 4. Once confirmed working, update your config
+# Edit ~/.agent-sandbox/config.toml:
+#   [sandbox]
+#   backend = "seatbelt"
+# Or simply use "auto" — it prefers seatbelt on macOS.
+
+# 5. (Optional) Uninstall nono
+brew uninstall nono
+```
+
+## Profile comparison
+
+| Aspect | nono | Seatbelt |
+|--------|------|----------|
+| Profile format | JSON (`.json`) | Scheme (`.sb`) |
+| Profile location | `~/.config/nono/profiles/` | `~/.agent-sandbox/seatbelt-profiles/` |
+| Generation command | `agent-sandbox nono-sync` | `agent-sandbox seatbelt-sync` |
+| `extends` inheritance | No | Yes |
+| Hand-editable | Yes (JSON) | Yes (plain text) |
+| External dependency | Yes (`nono` binary) | No (`sandbox-exec` built-in) |
+
+## Config changes
+
+Only the `backend` value in `[sandbox]` changes:
+
+```toml
+# Before (deprecated)
+[sandbox]
+backend = "nono"
+
+# After
+[sandbox]
+backend = "seatbelt"
+# or simply:
+backend = "auto"    # prefers seatbelt on macOS when sandbox-exec is available
+```
+
+No other configuration changes are needed. Agents, providers, sandbox levels, and all other settings remain identical.
+
+## Feature parity notes
+
+- **Sandbox levels**: `paranoid`, `normal`, and `permissive` work identically with both backends. Level-specific profiles are generated automatically by `seatbelt-sync`.
+- **Providers / profiles**: Credential injection and provider switching work the same way.
+- **Git push blocking**: Both backends block `git push` by default.
+- **Custom profiles**: If you created custom nono profiles, you can create equivalent Seatbelt profiles using the `extends` inheritance feature. See [Configuration Reference](config-reference.md#sandbox-levels).
+
+## Rollback
+
+If you need to go back to nono temporarily:
+
+```toml
+[sandbox]
+backend = "nono"
+```
+
+The nono backend remains functional -- it is deprecated, not removed. You will see a deprecation warning on stderr, but everything works as before.
+
+## See also
+
+- [Configuration Reference](config-reference.md) -- every TOML key documented
+- [CLI Reference](cli-reference.md) -- `seatbelt-sync` command details
+- [Epic #149](https://github.com/RisorseArtificiali/lince/issues/149) -- Seatbelt backend development tracker

--- a/lince-dashboard/agents-defaults.toml
+++ b/lince-dashboard/agents-defaults.toml
@@ -22,7 +22,7 @@
 # These are independent — you can run e.g. `paranoid + zai`. See gh#81.
 #
 # Sandbox model (claude, codex, gemini, opencode, pi):
-#   - sandbox_backend = "bwrap" | "nono"  (default per OS)
+#   - sandbox_backend = "bwrap" | "nono" | "seatbelt"  (default per OS)
 #   - sandbox_level   = "paranoid" | "normal" | "permissive" | <custom>
 # When sandbox_level is set, the plugin synthesizes the launch command from
 # (agent_type, backend, level) — the `command` field below is then ignored
@@ -71,11 +71,9 @@ has_native_hooks = true
 home_ro_dirs = ["~/.claude/"]
 providers = ["__discover__"]
 sandbox_level = "normal"          # paranoid | normal | permissive (or custom; see docs)
-# sandbox_backend defaults to "agent-sandbox" (bwrap) on Linux, "nono" on macOS.
+# sandbox_backend defaults to "agent-sandbox" (bwrap) on Linux, "seatbelt" on macOS.
 # Uncomment to force a specific backend (overrides the OS default):
-# sandbox_backend = "nono"
-
-# Native hook events emitted by claude-status-hook.sh → canonical AgentStatus.
+# sandbox_backend = "seatbelt"
 # See LINCE-118 / LINCE-122. Canonical values: running | input | permission | stopped.
 [agents.claude.event_map]
 PreToolUse = "running"
@@ -127,8 +125,8 @@ disable_inner_sandbox_args = ["--sandbox", "danger-full-access"]
 home_ro_dirs = ["~/.codex/"]
 providers = ["__discover__"]
 sandbox_level = "normal"          # paranoid | normal | permissive (or custom; see docs)
-# sandbox_backend defaults to bwrap on Linux, nono on macOS. Uncomment to override:
-# sandbox_backend = "nono"
+# sandbox_backend defaults to bwrap on Linux, seatbelt on macOS. Uncomment to override:
+# sandbox_backend = "seatbelt"
 
 [agents.codex.env_vars]
 OPENAI_API_KEY = "$OPENAI_API_KEY"
@@ -176,8 +174,8 @@ disable_inner_sandbox_args = []
 home_ro_dirs = ["~/.gemini/"]
 providers = ["__discover__"]
 sandbox_level = "normal"          # paranoid | normal | permissive (or custom; see docs)
-# sandbox_backend defaults to bwrap on Linux, nono on macOS. Uncomment to override:
-# sandbox_backend = "nono"
+# sandbox_backend defaults to bwrap on Linux, seatbelt on macOS. Uncomment to override:
+# sandbox_backend = "seatbelt"
 
 [agents.gemini.env_vars]
 GEMINI_API_KEY = "$GEMINI_API_KEY"
@@ -212,8 +210,8 @@ disable_inner_sandbox_args = []
 home_ro_dirs = ["~/.config/opencode/"]
 providers = ["__discover__"]
 sandbox_level = "normal"          # paranoid | normal | permissive (or custom; see docs)
-# sandbox_backend defaults to bwrap on Linux, nono on macOS. Uncomment to override:
-# sandbox_backend = "nono"
+# sandbox_backend defaults to bwrap on Linux, seatbelt on macOS. Uncomment to override:
+# sandbox_backend = "seatbelt"
 
 # Native hook events emitted by opencode-status-hook.js → canonical AgentStatus.
 # The plugin reports the raw OpenCode event.type, plus a busy/idle sub-state
@@ -259,8 +257,8 @@ disable_inner_sandbox_args = []
 home_ro_dirs = ["~/.pi/"]
 providers = ["__discover__"]
 sandbox_level = "normal"          # paranoid | normal | permissive (or custom; see docs)
-# sandbox_backend defaults to bwrap on Linux, nono on macOS. Uncomment to override:
-# sandbox_backend = "nono"
+# sandbox_backend defaults to bwrap on Linux, seatbelt on macOS. Uncomment to override:
+# sandbox_backend = "seatbelt"
 
 # Pi multi-provider note: `lince-pi-paranoid.json` only allowlists the
 # providers nono knows about (anthropic, openai, gemini). For other

--- a/lince-dashboard/install.sh
+++ b/lince-dashboard/install.sh
@@ -373,9 +373,27 @@ if [ -n "$SELECTED_LEVELS" ] && [ -f "$AGENTS_TEMPLATE_DST" ]; then
 fi
 echo ""
 
-# ── Step 10: Install nono profiles ────────────────────────────────────
-echo -e "${GREEN}[10/14] Installing nono sandbox profiles...${NC}"
+# ── Step 10: Install nono profiles (deprecated, kept for compatibility) ────
+echo -e "${GREEN}[10/14] Installing sandbox profiles...${NC}"
 
+# Seatbelt profiles (preferred on macOS)
+SEATBELT_PROFILES_SRC="$SCRIPT_DIR/seatbelt-profiles"
+SEATBELT_PROFILES_DST="$HOME/.agent-sandbox/seatbelt-profiles"
+
+if [ -d "$SEATBELT_PROFILES_SRC" ]; then
+    mkdir -p "$SEATBELT_PROFILES_DST"
+    count=0
+    for profile in "$SEATBELT_PROFILES_SRC"/lince-*.sb; do
+        [ -f "$profile" ] || continue
+        cp "$profile" "$SEATBELT_PROFILES_DST/"
+        count=$((count + 1))
+    done
+    if [ "$count" -gt 0 ]; then
+        echo -e "${GREEN}  ✓ Installed $count Seatbelt profiles to $SEATBELT_PROFILES_DST${NC}"
+    fi
+fi
+
+# nono profiles (deprecated, installed for backward compatibility)
 NONO_PROFILES_SRC="$SCRIPT_DIR/nono-profiles"
 NONO_PROFILES_DST="$HOME/.config/nono/profiles"
 
@@ -387,7 +405,9 @@ if [ -d "$NONO_PROFILES_SRC" ]; then
         cp "$profile" "$NONO_PROFILES_DST/"
         count=$((count + 1))
     done
-    echo -e "${GREEN}  ✓ Installed $count nono profiles to $NONO_PROFILES_DST${NC}"
+    if [ "$count" -gt 0 ]; then
+        echo -e "${GREEN}  ✓ Installed $count nono profiles to $NONO_PROFILES_DST (deprecated)${NC}"
+    fi
 else
     echo -e "${YELLOW}  ⚠ nono-profiles/ not found — skipping${NC}"
 fi
@@ -487,29 +507,32 @@ echo -e "${GREEN}[post] Checking sandbox backend...${NC}"
 OS_NAME="$(uname -s)"
 HAS_SANDBOX=false
 HAS_NONO=false
+HAS_SEATBELT=false
 command -v agent-sandbox >/dev/null 2>&1 && HAS_SANDBOX=true
 command -v nono >/dev/null 2>&1 && HAS_NONO=true
+command -v sandbox-exec >/dev/null 2>&1 && HAS_SEATBELT=true
 
 if [ "$OS_NAME" = "Darwin" ]; then
-    if [ "$HAS_NONO" = true ]; then
-        echo -e "${GREEN}  ✓ macOS: nono detected as sandbox backend${NC}"
+    if [ "$HAS_SEATBELT" = true ]; then
+        echo -e "${GREEN}  ✓ macOS: Seatbelt (sandbox-exec) detected as sandbox backend${NC}"
+    elif [ "$HAS_NONO" = true ]; then
+        echo -e "${YELLOW}  ✓ macOS: nono detected (deprecated — consider using Seatbelt)${NC}"
     else
         echo -e "${YELLOW}  ⚠ macOS: no sandbox backend found.${NC}"
-        echo -e "${YELLOW}    agent-sandbox is Linux-only. Install nono:${NC}"
-        echo "    brew install nono"
-        echo "    See: https://github.com/always-further/nono"
+        echo -e "${YELLOW}    Seatbelt (sandbox-exec) is built into macOS.${NC}"
+        echo -e "${YELLOW}    Alternatively, install nono (deprecated): brew install nono${NC}"
     fi
 else
     if [ "$HAS_SANDBOX" = true ]; then
         echo -e "${GREEN}  ✓ agent-sandbox detected${NC}"
     fi
     if [ "$HAS_NONO" = true ]; then
-        echo -e "${GREEN}  ✓ nono detected (alternative backend)${NC}"
+        echo -e "${GREEN}  ✓ nono detected (deprecated alternative)${NC}"
     fi
     if [ "$HAS_SANDBOX" = false ] && [ "$HAS_NONO" = false ]; then
         echo -e "${YELLOW}  ⚠ No sandbox backend found. Install one:${NC}"
         echo "    agent-sandbox: cd ../sandbox && ./install.sh"
-        echo "    nono:          cargo install nono-cli"
+        echo "    nono:          cargo install nono-cli  (deprecated)"
     fi
 fi
 echo ""
@@ -533,23 +556,24 @@ echo "  Template: ~/.config/lince-dashboard/agents-template.toml"
 if [ -n "$SELECTED_LEVELS" ]; then
     echo "  Levels:   $SELECTED_LEVELS (added to ~/.config/lince-dashboard/config.toml)"
 fi
-echo "  Nono:     ~/.config/nono/profiles/lince-*.json"
+echo "  Nono:     ~/.config/nono/profiles/lince-*.json  (deprecated)"
 echo "  Skills:   ~/.claude/skills/lince-add-supported-agent/"
 echo "            ~/.claude/skills/lince-configure/"
 echo ""
 echo -e "${GREEN}Sandbox backend:${NC}"
 if [ "$OS_NAME" = "Darwin" ]; then
-    echo "  macOS — nono required (agent-sandbox is Linux-only)"
-    [ "$HAS_NONO" = true ] && echo "  ✓ nono installed" || echo "  ✗ Install: brew install nono"
+    echo "  macOS — Seatbelt (sandbox-exec, recommended) or nono (deprecated)"
+    [ "$HAS_SEATBELT" = true ] && echo "  ✓ Seatbelt (sandbox-exec) available"
+    [ "$HAS_NONO" = true ] && echo "  ✓ nono installed (deprecated)"
 else
-    echo "  Linux — agent-sandbox (recommended) or nono"
+    echo "  Linux — agent-sandbox (recommended) or nono (deprecated)"
     [ "$HAS_SANDBOX" = true ] && echo "  ✓ agent-sandbox installed"
-    [ "$HAS_NONO" = true ] && echo "  ✓ nono installed (alternative)"
+    [ "$HAS_NONO" = true ] && echo "  ✓ nono installed (deprecated)"
 fi
 echo ""
 if [ "$HAS_NONO" = true ]; then
     echo -e "${GREEN}Sandbox levels (paranoid/normal/permissive):${NC}"
-    echo "  Paranoid level needs the Anthropic API key in nono's keystore so"
+    echo "  Paranoid level with nono needs the Anthropic API key in nono's keystore so"
     echo "  the credential proxy can inject it at runtime. Populate it once:"
     if [ "$OS_NAME" = "Darwin" ]; then
         echo "    security add-generic-password -s nono -a anthropic_api_key -w 'sk-ant-...'"

--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -80,8 +80,9 @@ home_ro_dirs = [".config/gcloud"]
 # Leave empty to run without a profile.
 default_profile = ""
 
-# Sandbox backend: "agent-sandbox" (bubblewrap), "nono" (Landlock/Seatbelt), or "auto"
-# auto: prefers agent-sandbox on Linux, uses nono on macOS or when bwrap is unavailable
+# Sandbox backend: "agent-sandbox" (bubblewrap), "seatbelt" (macOS sandbox-exec),
+#   "nono" (Landlock/Seatbelt, DEPRECATED), or "auto"
+# auto: prefers agent-sandbox on Linux, seatbelt on macOS, falls back to nono
 backend = "auto"
 
 [claude]
@@ -1543,6 +1544,12 @@ def resolve_backend(config: dict) -> str:
         if is_mac and "seatbelt" in backends:
             return "seatbelt"
         if "nono" in backends:
+            print(
+                "WARNING: Falling back to deprecated 'nono' backend. "
+                "Install seatbelt (sandbox-exec) or agent-sandbox (bwrap). "
+                "See: https://github.com/RisorseArtificiali/lince/issues/149",
+                file=sys.stderr,
+            )
             return "nono"
         if is_linux:
             print("Error: no sandbox backend found.", file=sys.stderr)
@@ -1575,6 +1582,13 @@ def resolve_backend(config: dict) -> str:
             print("Error: backend 'nono' selected but nono not found.", file=sys.stderr)
             print("Install from: https://github.com/always-further/nono", file=sys.stderr)
             sys.exit(1)
+        print(
+            "WARNING: The 'nono' backend is deprecated. "
+            "Use 'seatbelt' (native sandbox-exec) instead. "
+            "Run 'agent-sandbox seatbelt-sync' to generate Seatbelt profiles. "
+            "See: https://github.com/RisorseArtificiali/lince/issues/149",
+            file=sys.stderr,
+        )
         return "nono"
     elif backend_setting == "seatbelt":
         if "seatbelt" not in backends:
@@ -3275,6 +3289,9 @@ def cmd_run(args, agent_extra: list[str]) -> None:
 
         # Print banner
         print("agent-sandbox (nono backend)")
+        print("  DEPRECATED: The nono backend is deprecated in favor of native Seatbelt.")
+        print("              Migrate with: agent-sandbox seatbelt-sync")
+        print("              See: https://github.com/RisorseArtificiali/lince/issues/149")
         print(f"  config      {config_path}")
         print(f"  backend     nono ({shutil.which('nono')})")
         print(f"  agent       {agent_name} ({agent_cfg['command']})")

--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -5981,24 +5981,11 @@ def _apply_toml_suggestions(
 
 def cmd_learn(args) -> None:
     """Run agent under strace to learn its access patterns."""
-    # 1. Validate strace is available
-    if shutil.which("strace") is None:
-        print("Error: strace not found.", file=sys.stderr)
-        print(
-            "Install with:  sudo dnf install strace  "
-            "(or apt install strace)",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
-    # 2. Validate bwrap
-    check_bwrap()
-
-    # 3. Load config
+    # 1. Load config and check backend first
     config, config_path = load_config()
     project_dir = Path.cwd().resolve()
 
-    # 3a. Gate: learn mode requires strace (Linux-only). Seatbelt and nono
+    # 1a. Gate: learn mode requires strace (Linux-only). Seatbelt and nono
     # backends cannot use strace-based learn mode.
     _learn_backend = resolve_backend(config)
     if _learn_backend in ("seatbelt", "nono"):
@@ -6017,6 +6004,19 @@ def cmd_learn(args) -> None:
         )
         print(_alt_msg, file=sys.stderr)
         sys.exit(1)
+
+    # 2. Validate strace is available
+    if shutil.which("strace") is None:
+        print("Error: strace not found.", file=sys.stderr)
+        print(
+            "Install with:  sudo dnf install strace  "
+            "(or apt install strace)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # 3. Validate bwrap
+    check_bwrap()
 
     # 4. Resolve agent
     agent_name = args.agent

--- a/sandbox/install.sh
+++ b/sandbox/install.sh
@@ -30,6 +30,7 @@ echo -e "${GREEN}[1/5] Checking prerequisites...${NC}"
 OS_NAME="$(uname -s)"
 HAS_BWRAP=false
 HAS_NONO=false
+HAS_SEATBELT=false
 
 command -v python3 >/dev/null 2>&1 || { echo -e "${RED}Missing: python3 (3.11+)${NC}"; exit 1; }
 
@@ -46,9 +47,13 @@ if command -v bwrap >/dev/null 2>&1; then
     HAS_BWRAP=true
     echo -e "${GREEN}  ✓ bwrap $(bwrap --version 2>/dev/null | awk '{print $2}')${NC}"
 fi
+if command -v sandbox-exec >/dev/null 2>&1; then
+    HAS_SEATBELT=true
+    echo -e "${GREEN}  ✓ sandbox-exec (Seatbelt, built-in)${NC}"
+fi
 if command -v nono >/dev/null 2>&1; then
     HAS_NONO=true
-    echo -e "${GREEN}  ✓ nono $(nono --version 2>/dev/null | head -1)${NC}"
+    echo -e "${YELLOW}  ✓ nono $(nono --version 2>/dev/null | head -1) (deprecated)${NC}"
 fi
 
 # socat is required for paranoid sandbox level on bwrap (it bridges
@@ -66,25 +71,25 @@ fi
 
 # Platform-specific checks
 if [ "$OS_NAME" = "Darwin" ]; then
-    # macOS: bwrap is not available, nono is required
-    if [ "$HAS_NONO" = false ]; then
+    # macOS: prefer seatbelt (built-in), fall back to nono (deprecated)
+    if [ "$HAS_SEATBELT" = true ]; then
+        echo -e "${GREEN}  ✓ macOS detected — using Seatbelt (sandbox-exec) as sandbox backend${NC}"
+    elif [ "$HAS_NONO" = true ]; then
+        echo -e "${YELLOW}  ⚠ macOS detected — Seatbelt (sandbox-exec) not found.${NC}"
+        echo -e "${YELLOW}    Falling back to nono (deprecated). Consider using Seatbelt.${NC}"
+    else
         echo ""
-        echo -e "${RED}macOS detected — agent-sandbox requires bubblewrap (Linux only).${NC}"
-        echo -e "${YELLOW}On macOS, install nono as your sandbox backend:${NC}"
-        echo ""
-        echo "  brew install nono"
-        echo ""
-        echo "Then re-run this installer. See docs/nono-integration.md for details."
-        echo "Project: https://github.com/always-further/nono"
+        echo -e "${RED}macOS detected — no sandbox backend found.${NC}"
+        echo -e "${YELLOW}Seatbelt (sandbox-exec) is built into macOS and should be available.${NC}"
+        echo -e "${YELLOW}Alternatively, install nono (deprecated): brew install nono${NC}"
         exit 1
     fi
-    echo -e "${GREEN}  ✓ macOS detected — using nono as sandbox backend${NC}"
 else
     # Linux: need at least one backend
     if [ "$HAS_BWRAP" = false ] && [ "$HAS_NONO" = false ]; then
         echo -e "${RED}No sandbox backend found. Install one of:${NC}"
         echo "  - bubblewrap: sudo dnf install bubblewrap  (or: sudo apt install bubblewrap)"
-        echo "  - nono:       cargo install nono-cli  (or: brew install nono)"
+        echo "  - nono:       cargo install nono-cli  (or: brew install nono)  (deprecated)"
         exit 1
     fi
 fi
@@ -165,27 +170,39 @@ else
 fi
 echo ""
 
-# ── Step 5: nono integration (if available) ──────────────────────────
-echo -e "${GREEN}[5/5] Checking nono integration...${NC}"
+# ── Step 5: Backend integration ──────────────────────────────────────
+echo -e "${GREEN}[5/5] Checking backend integration...${NC}"
 
+# Seatbelt (macOS native)
+if [ "$HAS_SEATBELT" = true ]; then
+    echo -e "${GREEN}  Seatbelt detected — generating lince profiles...${NC}"
+    if "$INSTALL_DST" seatbelt-sync 2>/dev/null; then
+        echo -e "${GREEN}  ✓ Seatbelt profiles generated at ~/.agent-sandbox/seatbelt-profiles/lince-*.sb${NC}"
+    else
+        echo -e "${YELLOW}  ⚠ seatbelt-sync failed (config may not be initialized yet).${NC}"
+        echo -e "${YELLOW}    Run 'agent-sandbox seatbelt-sync' after 'agent-sandbox init'.${NC}"
+    fi
+fi
+
+# nono (deprecated, still supported)
 if [ "$HAS_NONO" = true ]; then
-    echo -e "${GREEN}  nono detected — generating lince profiles...${NC}"
+    echo -e "${YELLOW}  nono detected (deprecated) — generating lince profiles...${NC}"
     if "$INSTALL_DST" nono-sync 2>/dev/null; then
         echo -e "${GREEN}  ✓ nono profiles generated at ~/.config/nono/profiles/lince-*.json${NC}"
     else
         echo -e "${YELLOW}  ⚠ nono-sync failed (config may not be initialized yet).${NC}"
         echo -e "${YELLOW}    Run 'agent-sandbox nono-sync' after 'agent-sandbox init'.${NC}"
     fi
-    if [ "$OS_NAME" = "Darwin" ] || [ "$HAS_BWRAP" = false ]; then
-        echo -e "${GREEN}  Backend set to nono (bwrap not available)${NC}"
-    else
-        echo -e "${GREEN}  Backend set to auto (prefers agent-sandbox, falls back to nono)${NC}"
-    fi
+fi
+
+if [ "$HAS_SEATBELT" = true ]; then
+    echo -e "${GREEN}  Backend set to auto (prefers seatbelt on macOS)${NC}"
+elif [ "$HAS_BWRAP" = true ]; then
+    echo -e "${GREEN}  Backend set to auto (prefers agent-sandbox on Linux)${NC}"
+elif [ "$HAS_NONO" = true ]; then
+    echo -e "${GREEN}  Backend set to nono (deprecated)${NC}"
 else
-    echo -e "${YELLOW}  nono not installed — using agent-sandbox (bwrap) backend${NC}"
-    if [ "$OS_NAME" = "Darwin" ]; then
-        echo -e "${YELLOW}  Install nono for macOS support: brew install nono${NC}"
-    fi
+    echo -e "${YELLOW}  No backend detected${NC}"
 fi
 echo ""
 
@@ -195,18 +212,29 @@ echo -e "${BLUE}================================================${NC}"
 echo ""
 echo "Command:  $INSTALL_DST"
 echo "Config:   $CONFIG_DST"
-if [ "$HAS_NONO" = true ]; then
-    echo "Backend:  $([ "$OS_NAME" = "Darwin" ] || [ "$HAS_BWRAP" = false ] && echo "nono" || echo "auto (agent-sandbox + nono)")"
+if [ "$HAS_SEATBELT" = true ]; then
+    echo "Backend:  seatbelt (macOS sandbox-exec)"
+elif [ "$HAS_BWRAP" = true ]; then
+    if [ "$HAS_NONO" = true ]; then
+        echo "Backend:  auto (agent-sandbox + nono fallback)"
+    else
+        echo "Backend:  agent-sandbox (bwrap)"
+    fi
+elif [ "$HAS_NONO" = true ]; then
+    echo "Backend:  nono (deprecated)"
 else
-    echo "Backend:  agent-sandbox (bwrap)"
+    echo "Backend:  (none detected)"
 fi
 echo ""
 echo "Usage:"
 echo "  agent-sandbox run              # run with defaults"
 echo "  agent-sandbox run -P vertex    # run with a profile"
 echo "  agent-sandbox status           # show sandbox status"
+if [ "$HAS_SEATBELT" = true ]; then
+    echo "  agent-sandbox seatbelt-sync    # regenerate Seatbelt profiles"
+fi
 if [ "$HAS_NONO" = true ]; then
-    echo "  agent-sandbox nono-sync        # regenerate nono profiles"
+    echo "  agent-sandbox nono-sync        # regenerate nono profiles (deprecated)"
 fi
 echo ""
 echo "Edit $CONFIG_DST to configure profiles, API keys, and env passthrough."

--- a/sandbox/uninstall.sh
+++ b/sandbox/uninstall.sh
@@ -74,6 +74,22 @@ else
 fi
 echo ""
 
+# ── Seatbelt profiles ─────────────────────────────────────────────────
+SEATBELT_PROFILES=$(ls "$HOME/.agent-sandbox/seatbelt-profiles/lince-"*.sb 2>/dev/null || true)
+if [ -n "$SEATBELT_PROFILES" ]; then
+    echo -e "${YELLOW}Found generated Seatbelt profiles:${NC}"
+    for p in $SEATBELT_PROFILES; do
+        echo "  $p"
+    done
+    if confirm "  Remove generated lince-* Seatbelt profiles?"; then
+        rm -f "$HOME/.agent-sandbox/seatbelt-profiles/lince-"*.sb
+        echo -e "${GREEN}  ✓ Removed${NC}"
+    fi
+else
+    echo "  No generated Seatbelt profiles found — skipping"
+fi
+echo ""
+
 echo -e "${BLUE}================================================${NC}"
 echo -e "${BLUE}   Uninstall Complete${NC}"
 echo -e "${BLUE}================================================${NC}"


### PR DESCRIPTION
Replaces closed PR #186. Deprecates the nono backend and adds migration documentation.

Part of epic #149 (Seatbelt Backend).

**Changes:**
- Deprecation warning in `resolve_backend()` and nono banner
- New migration guide: `docs/documentation/sandbox/migration-nono-to-seatbelt.md`
- Updated CLI reference (seatbelt-sync docs, nono-sync deprecated)
- Updated config reference (backend valid values)
- Updated install/uninstall scripts for seatbelt detection
- Updated agents-defaults.toml comments
- Fix: learn mode checks backend before strace (macOS compat)

Tested on macOS (Apple Silicon) via `ssh mac`.

Depends on: #182, #183, #187, #188 (all merged)