### PR TITLE
fix(sandbox): tolerate dangling symlinks in claude-config copy during init

### DIFF
--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -3064,7 +3064,7 @@ def cmd_init(args) -> None:
                         shutil.rmtree(item)
                     else:
                         item.unlink()
-                shutil.copytree(src, dst, dirs_exist_ok=True)
+                shutil.copytree(src, dst, dirs_exist_ok=True, ignore_dangling_symlinks=True)
                 print(f"  claude-config {src} -> {dst}")
                 # Check for secrets in settings.json
                 settings = dst / "settings.json"


### PR DESCRIPTION
## Problem

`agent-sandbox init` mirrors `~/.claude` into the sandbox config dir with `shutil.copytree(src, dst, dirs_exist_ok=True)`. Claude Code keeps `~/.claude/debug/latest` as a symlink to the most recent debug log. Once that target file is cleaned up, the symlink dangles, and `copytree()` raises `shutil.Error` — which **aborts the entire init**: no `config.toml` is written, and (via `install.sh` step 5) `seatbelt-sync` never runs.

Hit live during a fresh macOS install:

```
shutil.Error: [('/Users/.../.claude/debug/latest',
  '/Users/.../.agent-sandbox/claude-config/debug/latest',
  "[Errno 2] No such file or directory: '/Users/.../.claude/debug/latest'")]
```

## Fix

Pass `ignore_dangling_symlinks=True` so a stale symlink anywhere under `~/.claude` is skipped instead of failing the whole copy. One line, in `cmd_init`'s claude-config copy.

## Test

- Repro: leave a dangling symlink under `~/.claude` (e.g. `debug/latest` → a removed log), run `agent-sandbox init` → before: traceback; after: completes, `config.toml` written.
- `agent-sandbox init --force` then `status` shows the full `claude-config` copy and Seatbelt profiles generated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)