### PR TITLE
fix(sandbox): add --backend flag to `run` (was silently passed to the agent)

### DIFF
--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -3188,6 +3188,10 @@ def cmd_run(args, agent_extra: list[str]) -> None:
             sys.exit(1)
         config = merge_sandbox_level(config, fragment)
 
+    # CLI --backend overrides the configured [sandbox].backend for this run.
+    if getattr(args, "backend", None):
+        config.setdefault("sandbox", {})["backend"] = args.backend
+
     backend = resolve_backend(config)
 
     project_dir = Path(args.project).resolve()
@@ -6185,6 +6189,10 @@ def main() -> None:
     p_run = sub.add_parser("run", help="Run an agent inside the sandbox")
     p_run.add_argument("-p", "--project", default=".",
                        help="Project directory (default: cwd)")
+    p_run.add_argument("--backend", default=None,
+                       choices=["auto", "agent-sandbox", "seatbelt", "nono"],
+                       help="Override the configured [sandbox].backend for this "
+                            "run (default: use config, which defaults to auto).")
     p_run.add_argument("-a", "--agent", default="claude",
                        help="Agent to run (default: claude). "
                             "Looks up [agents.<name>] in config.")


### PR DESCRIPTION
## Problem

The Seatbelt migration advertises `agent-sandbox run --backend seatbelt` in three places — the [migration guide](docs/documentation/sandbox/migration-nono-to-seatbelt.md) (step 3), the `seatbelt-sync` output hint (`agent-sandbox:2344`), and the install summary — but the `run` subparser never defined a `--backend` argument.

Because dispatch uses `parse_known_args`, `--backend <x>` was swept into the agent's trailing args and **appended to the agent command**:

```
$ agent-sandbox run --backend seatbelt -a claude --dry-run
... claude --dangerously-skip-permissions --backend seatbelt   # <-- leaked to claude
```

So the exact command macOS users are told to test Seatbelt with passes a bogus flag to the agent. (Backend selection still worked via config `[sandbox].backend = auto`, masking the bug.)

## Fix

- Add `--backend {auto,agent-sandbox,seatbelt,nono}` to the `run` subparser.
- In `cmd_run`, override `config["sandbox"]["backend"]` with it (after the sandbox-level merge, before `resolve_backend`), so the flag selects the backend for that run.

## Test

```
$ agent-sandbox run --backend seatbelt -a claude --sandbox-level permissive --dry-run
# emitted command contains zero '--backend' tokens (was 1 before)

$ agent-sandbox run --backend agent-sandbox -a claude --dry-run   # on macOS
Error: backend 'agent-sandbox' selected but bwrap not found.       # override reaches resolve_backend
```

Found while verifying #113 on macOS Seatbelt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)