### PR TITLE
feat(sandbox): Landlock spike — probe, demo, paranoid gate prototype (#211)

### DIFF
--- a/docs/design/landlock-spike.md
+++ b/docs/design/landlock-spike.md
@@ -3,9 +3,11 @@
 **Status**: spike complete — recommendation: **GO**
 **Date**: 2026-06-10
 **Evidence**: live experiments in [`sandbox/spikes/landlock/`](../../sandbox/spikes/landlock/)
-(stdlib-only ctypes probe + working demo, run on Fedora 44, kernel
-6.19.14-300.fc44.x86_64, Landlock ABI v7 — all checks green, output
-captured in the spike README).
+(stdlib-only ctypes probe, working demo — also run under bwrap for the
+Q4 composition question — and a working prototype gating one agent at
+`--sandbox-level paranoid` through a Landlock launcher shim; all run on
+Fedora 44, kernel 6.19.14-300.fc44.x86_64, Landlock ABI v7 — all checks
+green, output captured in the spike README).
 
 Landlock is evaluated as a **defense-in-depth layer inside the existing
 bubblewrap backend**, not a new backend: bwrap paints the mount picture,
@@ -102,7 +104,11 @@ visible inside; the shim can simply be a hidden subcommand of the
 single-file script (e.g. `agent-sandbox __landlock-exec --rw <dir> ...
 -- <agent argv>`), keeping the zero-extra-files, stdlib-only constraints.
 ~100 lines of ctypes (the demo's `apply_landlock()` is the core, 60
-lines).
+lines). **Prototyped**: the spike's `landlock_exec.py` is exactly this
+shim as a standalone file, and `paranoid_gate.sh` runs it as a custom
+agent's `command` inside the real paranoid chain (`unshare`/socat →
+bwrap → shim → agent payload) — all checks pass with `agent-sandbox`
+itself unmodified.
 
 **Inheritance — confirmed empirically**: rulesets are inherited across
 `fork` + `execve` like `no_new_privs`. The demo restricts the child and
@@ -170,10 +176,15 @@ at `landlock_add_rule` time*, not to a path string. Consequences:
    exactly what bit the `preexec_fn` variant in Q2.
 2. **Bind mounts are transparent** once you open through them: a rule on
    the sandbox-side `/tmp` (tmpfs) or on the bound project dir governs
-   accesses through those mounts. No conflict between bwrap binds and
-   Landlock observed in the spike — bwrap mounts first, Landlock fences
-   second, and mounts created *after* restriction are irrelevant because
-   the agent has no CAP_SYS_ADMIN to mount anything.
+   accesses through those mounts. **Tested**: running `demo.py` inside
+   `bwrap --ro-bind / / --tmpfs /tmp --dev /dev --proc /proc` passes all
+   8 checks — the rw rule opened on the bwrap-created tmpfs works,
+   denials and inheritance hold (output captured in the spike README,
+   "Q4 experiment"). The paranoid gate prototype (`paranoid_gate.sh`)
+   confirms the same inside the real agent-sandbox chain. bwrap mounts
+   first, Landlock fences second, and mounts created *after* restriction
+   are irrelevant because the agent has no CAP_SYS_ADMIN to mount
+   anything.
 3. **Compute everything before `landlock_restrict_self()`.** The shim
    itself must resolve paths/EXE lookups up front — after restriction
    the shim is confined too (spike gotcha: `tempfile.gettempdir()`
@@ -197,11 +208,12 @@ prints the measurement). One-time at spawn — invisible next to bwrap +
 agent startup (hundreds of ms). Per-syscall overhead is a path-walk
 check in-kernel; no agent-visible latency at our scale.
 
-**Code surface (estimated from the working demo):**
+**Code surface (measured from the working shim):**
 ~100 lines for the ctypes layer (constants + 3 structs + `probe_abi` +
-`apply_landlock` — already written and proven in `demo.py`), ~50 lines
-for the `__landlock-exec` shim subcommand + argv plumbing in
-`build_bwrap_cmd()`, ~20 lines of banner/logging. **≈150–200 lines**
+`apply_landlock` — written and proven in `demo.py` and reused verbatim
+in `landlock_exec.py`), ~50 lines for the `__landlock-exec` shim
+subcommand (the prototype shim's `main()` is 55 lines) + argv plumbing
+in `build_bwrap_cmd()`, ~20 lines of banner/logging. **≈150–200 lines**
 added to `sandbox/agent-sandbox`, zero new dependencies, zero new
 installed files.
 
@@ -245,7 +257,17 @@ under `unshare_net`, the ephemeral host port otherwise) + listed extras;
 `mode = "open"` ⇒ net mask not handled (unrestricted). Hosts stay the
 proxy's job; ports are Landlock's.
 
-**Next step** (separate task, out of spike scope): implement the
-`__landlock-exec` shim in `sandbox/agent-sandbox`, gate one agent at
-paranoid, and add a `sandbox/tests/` check mirroring the demo's
-assertions.
+**Prototype status** — the issue's prototype deliverable is met
+in-spike: `paranoid_gate.sh` gates one agent (`landlock-demo`) at
+`--sandbox-level paranoid` with Landlock fs rules **and** net rules
+(connect allowed only to the socat proxy bridge on 8118), via the
+`landlock_exec.py` shim and existing agent-sandbox mechanisms
+(project-local config + custom agent `command`). `sandbox/agent-sandbox`
+is deliberately untouched on this branch only to stay conflict-free with
+the in-flight credential-proxy (#194/#195) and Seatbelt (#196) PRs that
+edit the same file.
+
+**Next step** (follow-up implementation task): fold `landlock_exec.py`
+into `sandbox/agent-sandbox` as the hidden `__landlock-exec` subcommand,
+have `build_bwrap_cmd()` append it for the levels in the table above,
+and add a `sandbox/tests/` check mirroring `gate_check.py`'s assertions.

--- a/docs/design/landlock-spike.md
+++ b/docs/design/landlock-spike.md
@@ -219,6 +219,71 @@ installed files.
 
 ---
 
+## Effective policy: requested vs enforced
+
+Review input on #211 (rpelevin): the spike result must make explicit the
+difference between the policy a launch *requested* and the policy the
+kernel actually *enforced* — per launch, machine-readable. The spike shim
+now emits exactly that: a single-line JSON **effective-policy record** on
+stderr, prefixed `LINCE_EFFECTIVE_POLICY: ` (and mirrored to the file
+named by `LINCE_POLICY_RECORD_PATH` when set). `paranoid_gate.sh`
+captures the record from the real gated run and asserts the enforced
+flags; the captured records are in the spike README.
+
+### Record schema (as emitted by the spike shim)
+
+| Field | Type | Meaning |
+|---|---|---|
+| `backend` | string | Sandbox backend; `LINCE_BACKEND` env, default `"bwrap"`. |
+| `requested_level` | string \| null | Requested isolation level (`LINCE_SANDBOX_LEVEL` env; null if unset). |
+| `requested_fs` | `{rw: [], ro: []}` | Path lists the shim was asked to enforce (`--rw`/`--ro`). |
+| `requested_net` | `{connect_ports: [], bind_ports: []}` | TCP port lists requested (`--connect-port`/`--bind-port`). |
+| `landlock_abi` | int | Probed Landlock ABI (0 = unavailable; capped by `LINCE_LANDLOCK_FORCE_ABI` for the degraded demo). |
+| `fs_enforced` | bool | Filesystem ruleset actually applied. |
+| `net_enforced` | bool | TCP net ruleset actually applied (requires ABI ≥ 4). |
+| `net_limitation` | string | `"port-only, host-unaware"` whenever net rules are active — Landlock can never express host allowlists (rpelevin test 4: no pretending); `"unavailable"` when ABI < 4 or degraded. |
+| `applied_before_exec` | bool | `landlock_restrict_self()` succeeded before `execvp` of the agent. |
+| `inherited_by_subprocesses` | string | `"by-design; verified by gate_check"` — the shim cannot observe the agent after exec; inheritance across fork+execve is a kernel property verified empirically by `demo.py`/`gate_check.py`, not per-run. |
+| `helper_digest` | string | sha256 of the shim file itself, computed at runtime. |
+| `bwrap_args_digest` | null | Always null in the spike: only the launcher knows the bwrap argv; production home is #221 where agent-sandbox assembles the record. |
+| `degraded_reason` | string \| null | Null, or exactly which enforcement dropped and why (e.g. `"landlock unavailable (ABI 0 — …)"`, `"network rules not enforced (ABI 3 < 4)"`). |
+
+### Can paranoid degrade? Fail closed.
+
+Recommendation (decided early, as the review asked): **paranoid never
+degrades silently** — same philosophy as the #196 Seatbelt pre-launch
+guard. When the requested fs boundary cannot be enforced at paranoid,
+the launch fails closed; degraded operation is only ever an explicit
+opt-in, and then the record must name exactly which boundary was not
+enforced. The spike shim demonstrates the contract: by default ABI 0
+stays graceful (record says `fs_enforced: false`, `degraded_reason`
+set), while `--fail-closed` / `LINCE_LANDLOCK_FAIL_CLOSED=1` makes any
+degradation (fs at ABI 0, net at ABI < 4 with ports requested) exit
+non-zero *after* emitting the record, naming the missing boundary. In
+production, paranoid maps to fail-closed; normal/permissive may run
+degraded-but-recorded.
+
+### Coverage of the five review tests
+
+| # | rpelevin test | Where covered |
+|---|---|---|
+| 1 | Denied path stays denied to the agent process *and* a child process | `demo.py` (inherit checks across fork+execve) + `gate_check.py` check 7, inside the real paranoid chain — pre-existing. |
+| 2 | Allowed bind mount stays readable/writable as intended | `demo.py` (rw inside project dir, incl. on bwrap-created tmpfs in the Q4 run) + `gate_check.py` check 1 — pre-existing. |
+| 3 | Old-kernel/no-Landlock path records a degraded effective policy | `LINCE_LANDLOCK_FORCE_ABI=0` demo (spike README, "Degraded path + fail-closed"): record shows `fs_enforced: false, net_enforced: false, degraded_reason` set — new. |
+| 4 | Net rules on ABI ≥ 4 must not pretend to enforce host allowlists | Machine-readable `net_limitation: "port-only, host-unaware"` in every record with active net rules; hosts stay the proxy's job (Q3) — new. |
+| 5 | Config v2 policy compiles to bwrap mounts *and* Landlock rules from one source intent | Adopted as a golden-test requirement in the Config v2 design doc (§4.4); out of spike scope — the policy-key sketch below is the shared source intent. |
+
+### Production home
+
+Tracked as **#221**: agent-sandbox assembles the full record (it is the
+only party that knows the bwrap argv → real `bwrap_args_digest`, the
+level, and the proxy state) and the dashboard surfaces it as a per-run
+badge — the exact boundary the kernel enforced, not just "sandbox
+enabled". Division of labour with Config v2: `lince config resolve
+--json` (#202) is the **requested** view (what policy says should
+happen); the effective-policy record is the **enforced** view (what the
+kernel actually did for that run). Comparing the two is the drift check.
+
 ## Recommendation
 
 **GO.** Ship Landlock as default hardening of the bwrap backend:

--- a/docs/design/landlock-spike.md
+++ b/docs/design/landlock-spike.md
@@ -9,10 +9,13 @@ Q4 composition question — and a working prototype gating one agent at
 Fedora 44, kernel 6.19.14-300.fc44.x86_64, Landlock ABI v7 — all checks
 green, output captured in the spike README).
 
-Landlock is evaluated as a **defense-in-depth layer inside the existing
-bubblewrap backend**, not a new backend: bwrap paints the mount picture,
+Landlock is evaluated as a **hardening layer for the existing bubblewrap
+backend — not a second sandbox product, not a new backend** (framing per
+the review discussion on #211): bwrap paints the mount picture,
 a Landlock ruleset applied just before the agent `exec` adds a second,
 kernel-enforced fence that holds even if something escapes that picture.
+It never replaces `unshare -n` or the credential proxy; it composes with
+them.
 Prior art: Codex CLI (Landlock + seccomp as its native Linux sandbox),
 landrun/nsjail (compose Landlock with namespaces). microsoft/mxc does
 **not** use Landlock (verified, zero references).
@@ -332,7 +335,31 @@ is deliberately untouched on this branch only to stay conflict-free with
 the in-flight credential-proxy (#194/#195) and Seatbelt (#196) PRs that
 edit the same file.
 
-**Next step** (follow-up implementation task): fold `landlock_exec.py`
+**Next step** — tracked as **#222**: fold `landlock_exec.py`
 into `sandbox/agent-sandbox` as the hidden `__landlock-exec` subcommand,
 have `build_bwrap_cmd()` append it for the levels in the table above,
 and add a `sandbox/tests/` check mirroring `gate_check.py`'s assertions.
+The effective-policy record's production assembly is tracked as **#221**.
+
+## Validation plan
+
+What is already validated, and what must be validated where, before the
+spike's conclusions are consumed by implementation (#222) and design
+(#201):
+
+| Check | Status | Where / how |
+|-------|--------|-------------|
+| fs rules: deny outside, allow inside, ro intact | ✅ validated | `demo.py`, Fedora 44 / ABI v7 (captured in README) |
+| Inheritance across fork+execve | ✅ validated | `demo.py` subprocess checks |
+| TCP net rules (connect/bind, port-based) | ✅ validated at ABI v7 | `demo.py` live listener checks |
+| bwrap composition (rules on bwrap-created tmpfs) | ✅ validated | README "Q4 experiment" — `demo.py` under bwrap |
+| Full paranoid chain (unshare/socat → bwrap → shim → agent) | ✅ validated | `paranoid_gate.sh`, 7 checks + record assertion |
+| Degraded path produces a record, fail-closed refuses | ✅ validated (simulated) | `LINCE_LANDLOCK_FORCE_ABI=0` / `--fail-closed` (README) |
+| **ABI v4 floor** (net rules at the *minimum* supported ABI) | ⏳ pending | run probe + demo + gate on **Ubuntu 24.04 GA (kernel 6.8 = ABI v4)** — the matrix row is source-cited, not probed; this is a merge gate for #222 |
+| Real no-Landlock kernel (not simulated) | ⏳ pending | boot/container with `lsm=` excluding landlock; degraded record + fail-closed must behave as in the simulation; gate for #222 |
+| Repeatable check in-repo | ⏳ pending | port `gate_check.py` assertions into `sandbox/tests/` with #222; wire into CI when the repo gains workflows (m-14, #104) |
+
+The two pending rows are listed as explicit validation gates in #222 —
+the spike's GO stands on the probed ABI v7 evidence plus the source-cited
+v4 floor; the v4 row is the one empirical hole to close before shipping
+default-on enforcement.

--- a/docs/design/landlock-spike.md
+++ b/docs/design/landlock-spike.md
@@ -1,0 +1,251 @@
+# Landlock spike — feasibility for the bwrap backend (#211)
+
+**Status**: spike complete — recommendation: **GO**
+**Date**: 2026-06-10
+**Evidence**: live experiments in [`sandbox/spikes/landlock/`](../../sandbox/spikes/landlock/)
+(stdlib-only ctypes probe + working demo, run on Fedora 44, kernel
+6.19.14-300.fc44.x86_64, Landlock ABI v7 — all checks green, output
+captured in the spike README).
+
+Landlock is evaluated as a **defense-in-depth layer inside the existing
+bubblewrap backend**, not a new backend: bwrap paints the mount picture,
+a Landlock ruleset applied just before the agent `exec` adds a second,
+kernel-enforced fence that holds even if something escapes that picture.
+Prior art: Codex CLI (Landlock + seccomp as its native Linux sandbox),
+landrun/nsjail (compose Landlock with namespaces). microsoft/mxc does
+**not** use Landlock (verified, zero references).
+
+---
+
+## Q1 — ABI availability matrix
+
+Kernel → ABI mapping (from kernel `Documentation/userspace-api/landlock.rst`
+and `include/uapi/linux/landlock.h`, cross-checked by the live probe):
+
+| ABI | Kernel | Adds |
+|-----|--------|------|
+| v1 | 5.13 | filesystem access control (execute/read/write/make_* — 13 rights) |
+| v2 | 5.19 | `LANDLOCK_ACCESS_FS_REFER` (re-linking/reparenting across dirs) |
+| v3 | 6.2 | `LANDLOCK_ACCESS_FS_TRUNCATE` |
+| v4 | 6.7 | **TCP network rules**: `LANDLOCK_ACCESS_NET_BIND_TCP` / `CONNECT_TCP` (port-based) |
+| v5 | 6.10 | `LANDLOCK_ACCESS_FS_IOCTL_DEV` |
+| v6 | 6.12 | scopes: abstract unix sockets + signals (IPC isolation) |
+| v7 | 6.15 | audit support (`LANDLOCK_RESTRICT_SELF_LOG_*`) |
+
+Target distros (current and −1, as of June 2026):
+
+| Distro | Kernel | ABI | Enforceable |
+|--------|--------|-----|-------------|
+| Fedora 44 (current) | 6.19 (live-probed on this box) | **v7** (live-probed: `7`) | fs + TCP net + IPC scopes + audit |
+| Fedora 43 (−1) | 6.17 GA | v7 | fs + TCP net + IPC scopes + audit |
+| Ubuntu 26.04 LTS (current) | 7.0 | ≥ v7 | fs + TCP net + IPC scopes + audit |
+| Ubuntu 24.04 LTS (−1) | 6.8 GA / 6.17 HWE (24.04.4) | **v4** GA / v7 HWE | fs + TCP net (GA); everything (HWE) |
+
+(Sources: Fedora 43 ships 6.17 [packages.fedoraproject.org]; Ubuntu 26.04
+LTS ships kernel 7.0 [discourse.ubuntu.com / release notes]; Ubuntu
+24.04.4 HWE moved to 6.17 [Phoronix/OMG Ubuntu, Feb 2026].)
+
+**Floor across all targets is ABI v4** → filesystem *and* TCP network
+rules are enforceable everywhere we care about. Both Fedora and Ubuntu
+enable the `landlock` LSM by default on these releases — but the probe
+must never assume: a custom `lsm=` boot line yields `EOPNOTSUPP`.
+
+**Enforce-per-ABI policy (recommended)** — probe once at startup
+(`landlock_create_ruleset(NULL, 0, LANDLOCK_CREATE_RULESET_VERSION)`,
+see `landlock_probe.py`) and cap the handled-access masks to the probed
+ABI, exactly as the demo's `fs_rights_for_abi()` does:
+
+- ABI 0 (ENOSYS/EOPNOTSUPP): skip layer, log
+  `landlock: not available — bwrap-only containment` (never fail).
+- ABI 1–3: fs rules only (mask out REFER/TRUNCATE bits below their ABI);
+  log `network rules not enforced (ABI < 4)`.
+- ABI ≥ 4: fs + TCP bind/connect rules.
+- ABI ≥ 6: optionally add `LANDLOCK_SCOPE_*` later (out of scope here —
+  signal scoping can break agent⇄hook interactions and needs its own test
+  pass).
+
+Critical Landlock semantics that make this safe: **the handled-access
+mask is deny-by-default** — every right listed as handled is denied
+unless a rule grants it, and rights *not* handled (because the ABI is
+old) are simply not restricted. Best-effort degradation is built into
+the API design.
+
+## Q2 — Application point in `sandbox/agent-sandbox`
+
+Today the flow is: `cmd_run()` → `build_bwrap_cmd()` builds a `bwrap`
+argv (optionally wrapped in `unshare -U -n -r bash -c <netns setup>` for
+paranoid) → `subprocess.run(cmd)` (line ~3893). Two candidate points:
+
+**Option A — `preexec_fn` on the host-side `subprocess.run()`** (restrict
+before bwrap even starts). Rejected:
+
+- The ruleset would be built against the **host** mount namespace, but
+  bwrap then creates *new* filesystems: `--tmpfs /tmp`,
+  `--tmpfs /run/user/<uid>`, etc. A fresh tmpfs is not beneath any
+  rule's opened directory FD, so it is **denied by default** — the agent
+  could not write `/tmp` at all. (Observed in the spike: even
+  `tempfile.gettempdir()` dies once no writable dir is reachable.)
+- It would also restrict bwrap itself and, for paranoid, the
+  `unshare`/`bash`/`socat` wrapper — trusted plumbing we don't need to
+  fence, and whose socket/FS needs would bloat the ruleset.
+- `preexec_fn` is documented as not thread-safe with threads in the
+  parent — and the credential proxy runs threads in our process.
+
+**Option B — a tiny launcher shim INSIDE the sandbox (recommended)**:
+make the shim the last element of the bwrap argv, so the chain is
+`bwrap <mounts...> -- <shim> -- <agent argv>`. The shim opens its
+directory FDs in the **final** mount namespace (so the bwrap tmpfs and
+bind mounts are exactly what the rules attach to), applies the ruleset,
+then `os.execvp()`s the agent. Since `agent-sandbox` ro-binds the whole
+host `/` into the sandbox, `python3` and the script itself are already
+visible inside; the shim can simply be a hidden subcommand of the
+single-file script (e.g. `agent-sandbox __landlock-exec --rw <dir> ...
+-- <agent argv>`), keeping the zero-extra-files, stdlib-only constraints.
+~100 lines of ctypes (the demo's `apply_landlock()` is the core, 60
+lines).
+
+**Inheritance — confirmed empirically**: rulesets are inherited across
+`fork` + `execve` like `no_new_privs`. The demo restricts the child and
+then `subprocess.run()`s a *fresh* `python3`; the grandchild is still
+denied outside writes and still allowed inside writes (`[PASS] inherit:`
+lines in the captured output). So restricting once in the shim covers
+every shell, compiler, and MCP server the agent spawns. Nothing in the
+sandbox can lift the fence — rulesets only compose (each
+`landlock_restrict_self` can only intersect, never widen).
+
+## Q3 — Network rules vs. the credential proxy
+
+Landlock ABI 4+ network rules are **TCP and port-based, not host-based**
+(`LANDLOCK_ACCESS_NET_BIND_TCP` / `CONNECT_TCP` against a port number).
+That maps cleanly onto how agent-sandbox already does egress:
+
+- **Normal level + proxy**: the proxy listens on host loopback at an
+  ephemeral port (`CredentialProxy.start()`); the agent shares the host
+  netns and connects to `127.0.0.1:<port>`. The port is known *before*
+  `build_bwrap_cmd()` is called → pass it to the shim as the single
+  allowed `CONNECT_TCP` port. **This closes today's biggest normal-level
+  gap**: `HTTP_PROXY`/base-URL env rewriting is *cooperative* — a
+  malicious tool can ignore the env vars and `connect()` anywhere. With
+  Landlock, direct TCP egress is denied at the kernel; the proxy becomes
+  mandatory, not advisory. Caveat: port-based means another local
+  service on an allowed port number is reachable — acceptable because
+  the rule allows only the proxy's ephemeral port (and the proxy's own
+  CONNECT allowlist does host filtering).
+- **Paranoid level (`unshare_net = true`)**: the wrapper runs
+  `unshare -U -n -r`, brings up `lo`, and socat listens on the **fixed
+  port 8118** inside the fresh netns, forwarding to the host proxy
+  through a bind-mounted unix socket (`proxy-<pid>.sock`). With the shim
+  inside bwrap, socat is *outside* the Landlock domain (it execs before/
+  alongside bwrap), so it binds 8118 unrestricted; the agent only needs
+  `CONNECT_TCP` to port 8118. Note Landlock net rules cover **only TCP**
+  — they do not see (and cannot break) the unix-socket bridge, and
+  pathname unix-socket `connect()` is not blocked by Landlock fs rights
+  either. The composition is conflict-free.
+- **Defense-in-depth, not replacement**: Landlock does not restrict UDP,
+  ICMP or raw sockets (as of ABI v7). DNS over UDP and QUIC/HTTP-3 are
+  uncovered → paranoid still needs `unshare -n`; Landlock adds the TCP
+  fence at normal where there is no netns at all.
+- **Future `allowed_hosts` policy**: host filtering **stays the proxy's
+  job** (it already has `allow_domains` on the CONNECT path). Landlock's
+  contribution is port-level deny-by-default for everything that tries
+  to bypass the proxy. One intent, two mechanisms: `[network]`
+  `allowed_hosts` compiles to proxy allowlist; the proxy port (plus any
+  explicitly opened ports) compiles to Landlock `CONNECT_TCP` rules.
+- **Bind**: with `handled_access_net` including `BIND_TCP` and no bind
+  rules, the agent cannot open listeners at all (demo: `bind` →
+  `EACCES`). Dev servers (`npm run dev`) need an explicit
+  `allow_bind_ports` policy key at normal level; paranoid should default
+  to no bind.
+
+## Q4 — Ordering with bwrap binds (opened FDs vs. mount namespace)
+
+`LANDLOCK_RULE_PATH_BENEATH` rules take an **opened directory FD**
+(`O_PATH`); the rule attaches to the *file hierarchy that FD resolves to
+at `landlock_add_rule` time*, not to a path string. Consequences:
+
+1. **Open after the mount picture is final.** All rule FDs must be
+   opened inside the bwrap mount namespace (Option B guarantees this),
+   so rules attach to the bind-mounted views and the bwrap-created
+   tmpfs (`/tmp`, `/run/user/<uid>`) the agent actually sees. This is
+   exactly what bit the `preexec_fn` variant in Q2.
+2. **Bind mounts are transparent** once you open through them: a rule on
+   the sandbox-side `/tmp` (tmpfs) or on the bound project dir governs
+   accesses through those mounts. No conflict between bwrap binds and
+   Landlock observed in the spike — bwrap mounts first, Landlock fences
+   second, and mounts created *after* restriction are irrelevant because
+   the agent has no CAP_SYS_ADMIN to mount anything.
+3. **Compute everything before `landlock_restrict_self()`.** The shim
+   itself must resolve paths/EXE lookups up front — after restriction
+   the shim is confined too (spike gotcha: `tempfile.gettempdir()`
+   fails post-restriction). The shim's last act is `execvp(agent)`,
+   which only needs EXECUTE+READ on the agent binary's hierarchy
+   (granted by the ro rules on `/usr` etc.).
+4. **Rule list = mirror of the bind list.** The shim's rule set is
+   mechanical: rw rules for project dir + every `--bind` target
+   agent-sandbox already computes (agent config dir, scratch binds,
+   extra `--rw`), ro+execute rules for the ro-bound system hierarchy,
+   rw on `/tmp` and `/run/user/<uid>` tmpfs, plus `/dev` read/write for
+   `/dev/null` & co. No new policy inputs are needed for v1 — it reuses
+   the inputs `build_bwrap_cmd()` already has.
+
+## Q5 — Cost
+
+**Runtime (measured, this box, ABI v7, 10 path rules + 1 net rule):**
+ruleset create + add rules + `restrict_self` = **60–75 µs** across runs
+(`60.1 / 65.5 / 66.0 / 71.6 / 74.1 µs` over 5 consecutive runs; the demo
+prints the measurement). One-time at spawn — invisible next to bwrap +
+agent startup (hundreds of ms). Per-syscall overhead is a path-walk
+check in-kernel; no agent-visible latency at our scale.
+
+**Code surface (estimated from the working demo):**
+~100 lines for the ctypes layer (constants + 3 structs + `probe_abi` +
+`apply_landlock` — already written and proven in `demo.py`), ~50 lines
+for the `__landlock-exec` shim subcommand + argv plumbing in
+`build_bwrap_cmd()`, ~20 lines of banner/logging. **≈150–200 lines**
+added to `sandbox/agent-sandbox`, zero new dependencies, zero new
+installed files.
+
+---
+
+## Recommendation
+
+**GO.** Ship Landlock as default hardening of the bwrap backend:
+
+| Level | Landlock fs | Landlock net (ABI ≥ 4) |
+|-------|-------------|------------------------|
+| paranoid | **on** (rw = project + binds; ro = system) | **on**: `CONNECT_TCP` → 8118 only; no bind |
+| normal | **on** (same rule set) | **on when proxy active**: `CONNECT_TCP` → proxy port (+ `allow_connect_ports`); bind per `allow_bind_ports`. Proxy off → net unrestricted (handled mask = 0) |
+| permissive | off | off |
+
+Always probe, never require: ABI 0 → log + continue (bwrap-only); ABI
+1–3 → fs only + log that net is not enforced. Surface the enforced state
+in the run banner (`landlock    fs+net (ABI 7)` / `fs only (ABI 3)` /
+`unavailable`).
+
+**Policy keys for the #201 Config v2 design** — the same intent must
+compile to bind mounts *and* Landlock rules (and proxy allowlist):
+
+```toml
+[filesystem]
+write = ["{project}", "{agent_config}", "/tmp"]   # → bwrap --bind + Landlock rw path rules
+read  = ["/"]                                     # → bwrap --ro-bind + Landlock ro+execute rules
+# deny-by-default guarantee: anything not listed is neither mounted rw
+# nor granted by Landlock — two mechanisms, one intent.
+
+[network]
+mode = "proxy"          # "proxy" | "open" | "none"
+allowed_hosts = ["api.anthropic.com"]  # enforced by the credential proxy (host-based)
+allow_connect_ports = []               # extra Landlock CONNECT_TCP rules (port-based)
+allow_bind_ports = []                  # Landlock BIND_TCP rules (dev servers)
+```
+
+`mode = "proxy"` ⇒ Landlock allows connect only to the proxy port (8118
+under `unshare_net`, the ephemeral host port otherwise) + listed extras;
+`mode = "none"` ⇒ handled net mask set, zero rules (full TCP deny);
+`mode = "open"` ⇒ net mask not handled (unrestricted). Hosts stay the
+proxy's job; ports are Landlock's.
+
+**Next step** (separate task, out of spike scope): implement the
+`__landlock-exec` shim in `sandbox/agent-sandbox`, gate one agent at
+paranoid, and add a `sandbox/tests/` check mirroring the demo's
+assertions.

--- a/sandbox/spikes/landlock/README.md
+++ b/sandbox/spikes/landlock/README.md
@@ -11,15 +11,25 @@ dependencies — the same constraint as `sandbox/agent-sandbox`.
 |---|---|
 | `landlock_probe.py` | Queries the kernel's Landlock ABI version via `landlock_create_ruleset(NULL, 0, LANDLOCK_CREATE_RULESET_VERSION)` and prints the implied feature set. This is the startup probe agent-sandbox would run to decide what to enforce. |
 | `demo.py` | Working self-restriction demo: a child process applies a Landlock ruleset (rw beneath a temp project dir, ro+execute on system paths, TCP connect allowed only to one port), then proves the fence holds — including across `fork`+`execve` into a fresh subprocess. |
+| `landlock_exec.py` | The launcher shim (prototype of the future `agent-sandbox __landlock-exec` subcommand): runs as the last element of the bwrap argv, opens its rule FDs in the final mount namespace, applies fs (+net if ABI ≥ 4) rules, then `execvp`s the agent argv. Graceful on ABI 0. |
+| `gate_check.py` | In-sandbox assertion payload run by the shim in place of a real agent binary: proves the fence inside the actual paranoid sandbox (denied write to bwrap's own rw tmpfs `/tmp`, connect allowed only to the socat bridge on 8118, bind denied, inheritance). |
+| `paranoid_gate.sh` | **The prototype gate**: gates agent `landlock-demo` at `--sandbox-level paranoid` through the shim using only existing agent-sandbox mechanisms (project-local config + custom agent command — `sandbox/agent-sandbox` is NOT modified). Chain: `unshare`/socat wrapper → bwrap → `landlock_exec.py` → `gate_check.py`. |
 
 ## How to run
 
 ```bash
 python3 sandbox/spikes/landlock/landlock_probe.py
 python3 sandbox/spikes/landlock/demo.py
+
+# Q4 composition experiment: same demo inside a bwrap mount namespace
+bwrap --ro-bind / / --tmpfs /tmp --dev /dev --proc /proc -- \
+  python3 sandbox/spikes/landlock/demo.py
+
+# Paranoid gate prototype: one agent gated at --sandbox-level paranoid
+bash sandbox/spikes/landlock/paranoid_gate.sh
 ```
 
-Exit code 0 = available/all checks pass. On kernels without Landlock both
+Exit code 0 = available/all checks pass. On kernels without Landlock the
 scripts degrade gracefully (clear message, no crash) — the same pattern
 agent-sandbox would use.
 
@@ -69,6 +79,77 @@ RESULT: ALL CHECKS PASSED
 Setup-time over 5 consecutive runs: 60.1 / 65.5 / 66.0 / 71.6 / 74.1 µs
 (10 `landlock_add_rule` calls + `landlock_restrict_self`).
 
+### Q4 experiment — `demo.py` inside a bwrap mount namespace
+
+The composition question (#211 Q4: bwrap binds vs. Landlock rule FDs) is
+answered by running the same demo inside a bwrap sandbox with a **fresh
+tmpfs `/tmp`** — the case that breaks the host-side `preexec_fn` variant:
+
+```
+$ bwrap --ro-bind / / --tmpfs /tmp --dev /dev --proc /proc -- \
+    python3 sandbox/spikes/landlock/demo.py
+child: Landlock ABI 7, restricting self...
+child: ruleset built + applied in 59.6 us (9 path rules, 1 net rules)
+  [PASS] fs: write inside allowed dir succeeds — /tmp/landlock_demo_92vjy2ai/inside.txt
+  [PASS] fs: write outside allowed dir denied — errno=EACCES
+  [PASS] fs: read /etc (ro rule) still works
+  [PASS] net: connect to allowed port 38299 succeeds
+  [PASS] net: connect to denied port 39993 blocked — errno=EACCES (listener IS running — denial is Landlock's)
+  [PASS] net: bind blocked (no bind rule added) — errno=EACCES
+  [PASS] inherit: subprocess (fork+execve) still denied outside write — rc=1
+  [PASS] inherit: subprocess can still write inside allowed dir — rc=0
+Landlock demo — kernel 6.19.14-300.fc44.x86_64
+parent: project dir /tmp/landlock_demo_92vjy2ai
+parent: allowed port 38299, denied port 39993 (both have live listeners)
+
+RESULT: ALL CHECKS PASSED
+```
+
+All 8 checks pass: the rw rule opened on the bwrap-created tmpfs `/tmp`
+works (project dir lives there), denials hold, and inheritance holds —
+applying a Landlock ruleset inside a bwrap mount namespace composes with
+no conflict, as long as rule FDs are opened after the mount picture is
+final.
+
+### `paranoid_gate.sh` — one agent gated at paranoid
+
+The issue's prototype deliverable: agent `landlock-demo` runs at
+`--sandbox-level paranoid` (fresh netns + credential proxy + socat
+bridge on 8118), with the shim applying Landlock fs + net rules between
+bwrap setup and the agent exec:
+
+```
+$ bash sandbox/spikes/landlock/paranoid_gate.sh
+landlock: fs+net (ABI 7) applied in 47.5 us — rw=['/tmp/landlock_gate_sj7Vzj'] connect=[8118] bind=[]
+gate_check: pid 2 inside paranoid sandbox, project /tmp/landlock_gate_sj7Vzj
+  [PASS] fs: write inside project dir succeeds — /tmp/landlock_gate_sj7Vzj/inside.txt
+  [PASS] fs: write to bwrap rw tmpfs /tmp denied by Landlock — errno=EACCES
+  [PASS] fs: read /etc (ro rule) still works
+  [PASS] net: connect to proxy bridge port 8118 succeeds — socat listener reached
+  [PASS] net: connect to denied port 9 blocked — errno=EACCES (ECONNREFUSED would mean Landlock let it through)
+  [PASS] net: bind blocked (no bind rule) — errno=EACCES
+  [PASS] inherit: subprocess still denied /tmp write — rc=1
+
+GATE RESULT: ALL CHECKS PASSED
+```
+
+Two details make this run self-proving:
+
+- bwrap mounts `/tmp` as a fresh **rw** tmpfs at paranoid, so the EACCES
+  on the `/tmp` write can only come from Landlock (bwrap would have
+  allowed it; a bwrap ro denial would be EROFS);
+- the denied port has no listener in the fresh netns, so without
+  Landlock the connect would fail ECONNREFUSED — the observed EACCES is
+  the LSM's.
+
+The gate uses only existing agent-sandbox mechanisms (project-local
+`.agent-sandbox/config.toml` defining the agent's `command` as the shim,
+plus a project-local paranoid fragment) — `sandbox/agent-sandbox` is not
+modified, keeping this branch conflict-free with the in-flight
+credential-proxy and seatbelt PRs. Productizing means moving
+`landlock_exec.py` into the script as a hidden `__landlock-exec`
+subcommand appended to the bwrap argv by `build_bwrap_cmd()`.
+
 ## What this proves
 
 1. **Availability**: this Fedora 44 box exposes Landlock ABI v7 — full fs
@@ -90,6 +171,13 @@ Setup-time over 5 consecutive runs: 60.1 / 65.5 / 66.0 / 71.6 / 74.1 µs
 6. **Graceful degradation is trivial**: a single probe call distinguishes
    ENOSYS / EOPNOTSUPP / ABI level; the enforcement code simply caps the
    handled-access mask to what the probed ABI supports.
+7. **bwrap composition works** (Q4, tested — see the bwrap-wrapped run
+   above): a ruleset applied inside the bwrap mount namespace attaches to
+   the bwrap-created tmpfs and bind-mounted views with no conflict.
+8. **End-to-end gating at paranoid works** (`paranoid_gate.sh`): the shim
+   slots into the real paranoid chain (`unshare`/socat → bwrap → shim →
+   agent) and enforces rw-project-only fs plus connect-to-proxy-only net,
+   without modifying `sandbox/agent-sandbox`.
 
 ## Gotchas found while building this (feed into implementation)
 

--- a/sandbox/spikes/landlock/README.md
+++ b/sandbox/spikes/landlock/README.md
@@ -1,0 +1,105 @@
+# Landlock spike — probe + demo (#211)
+
+Live experiments backing the feasibility doc at
+[`docs/design/landlock-spike.md`](../../../docs/design/landlock-spike.md).
+Both scripts are **stdlib-only** (ctypes), Python 3.11+, no external
+dependencies — the same constraint as `sandbox/agent-sandbox`.
+
+## Files
+
+| File | What it does |
+|---|---|
+| `landlock_probe.py` | Queries the kernel's Landlock ABI version via `landlock_create_ruleset(NULL, 0, LANDLOCK_CREATE_RULESET_VERSION)` and prints the implied feature set. This is the startup probe agent-sandbox would run to decide what to enforce. |
+| `demo.py` | Working self-restriction demo: a child process applies a Landlock ruleset (rw beneath a temp project dir, ro+execute on system paths, TCP connect allowed only to one port), then proves the fence holds — including across `fork`+`execve` into a fresh subprocess. |
+
+## How to run
+
+```bash
+python3 sandbox/spikes/landlock/landlock_probe.py
+python3 sandbox/spikes/landlock/demo.py
+```
+
+Exit code 0 = available/all checks pass. On kernels without Landlock both
+scripts degrade gracefully (clear message, no crash) — the same pattern
+agent-sandbox would use.
+
+## Captured output (Fedora 44, kernel 6.19.14-300.fc44.x86_64, 2026-06-10)
+
+### `landlock_probe.py`
+
+```
+Landlock ABI version: 7
+Kernel: 6.19.14-300.fc44.x86_64
+
+Feature set implied by this ABI:
+  [x] v1 (kernel >= 5.13): filesystem access control (13 FS access rights, execute/read/write/make_*)
+  [x] v2 (kernel >= 5.19): + LANDLOCK_ACCESS_FS_REFER (file reparenting/linking across directories)
+  [x] v3 (kernel >= 6.2): + LANDLOCK_ACCESS_FS_TRUNCATE (truncate(2)/O_TRUNC)
+  [x] v4 (kernel >= 6.7): + TCP network control: LANDLOCK_ACCESS_NET_BIND_TCP / CONNECT_TCP (port-based)
+  [x] v5 (kernel >= 6.10): + LANDLOCK_ACCESS_FS_IOCTL_DEV (ioctl on device files)
+  [x] v6 (kernel >= 6.12): + scopes: LANDLOCK_SCOPE_ABSTRACT_UNIX_SOCKET, LANDLOCK_SCOPE_SIGNAL (IPC isolation)
+  [x] v7 (kernel >= 6.15): + audit support: LANDLOCK_RESTRICT_SELF_LOG_* flags (denials visible in audit log)
+
+Enforceable by agent-sandbox on this kernel:
+  filesystem rules : yes
+  network rules    : yes (TCP bind/connect, port-based)
+  IPC scoping      : yes (signals + abstract unix sockets)
+```
+
+### `demo.py`
+
+```
+child: Landlock ABI 7, restricting self...
+child: ruleset built + applied in 67.2 us (9 path rules, 1 net rules)
+  [PASS] fs: write inside allowed dir succeeds — /tmp/landlock_demo_05j71czg/inside.txt
+  [PASS] fs: write outside allowed dir denied — errno=EACCES
+  [PASS] fs: read /etc (ro rule) still works
+  [PASS] net: connect to allowed port 35427 succeeds
+  [PASS] net: connect to denied port 57021 blocked — errno=EACCES (listener IS running — denial is Landlock's)
+  [PASS] net: bind blocked (no bind rule added) — errno=EACCES
+  [PASS] inherit: subprocess (fork+execve) still denied outside write — rc=1
+  [PASS] inherit: subprocess can still write inside allowed dir — rc=0
+Landlock demo — kernel 6.19.14-300.fc44.x86_64
+parent: project dir /tmp/landlock_demo_05j71czg
+parent: allowed port 35427, denied port 57021 (both have live listeners)
+
+RESULT: ALL CHECKS PASSED
+```
+
+Setup-time over 5 consecutive runs: 60.1 / 65.5 / 66.0 / 71.6 / 74.1 µs
+(10 `landlock_add_rule` calls + `landlock_restrict_self`).
+
+## What this proves
+
+1. **Availability**: this Fedora 44 box exposes Landlock ABI v7 — full fs
+   + TCP-port network rules + IPC scoping + audit.
+2. **Filesystem fence works**: deny-by-default for every handled access
+   right; only the explicitly allowed project dir is writable, system
+   paths stay readable/executable via ro rules. The denial is `EACCES`
+   (clean error an agent can surface), not a crash.
+3. **Network fence works and is provably Landlock's**: the denied port has
+   a *live listener*, so the `EACCES` (instead of `ECONNREFUSED`) can only
+   come from the LSM. `bind()` is also denied since no bind rule was added.
+4. **Inheritance across exec**: a `subprocess.run()` launched *after*
+   `landlock_restrict_self()` is still confined (denied outside, allowed
+   inside). This is the property that makes Landlock useful for
+   agent-sandbox: restrict once in the launcher, every agent subprocess
+   (shells, compilers, MCP servers) inherits the fence.
+5. **Cost is negligible**: ~60–75 µs one-time setup at spawn;
+   no measurable per-syscall overhead concern at our scale.
+6. **Graceful degradation is trivial**: a single probe call distinguishes
+   ENOSYS / EOPNOTSUPP / ABI level; the enforcement code simply caps the
+   handled-access mask to what the probed ABI supports.
+
+## Gotchas found while building this (feed into implementation)
+
+- `struct landlock_path_beneath_attr` is `__attribute__((packed))` — in
+  ctypes you need `_pack_ = 1` (and `_layout_ = "ms"` to silence the
+  Python 3.14 deprecation warning).
+- Rules reference **opened directory FDs** (`O_PATH`), resolved in the
+  *current mount namespace at open time* — ordering with bwrap binds
+  matters (see Q4 in the design doc).
+- Don't call `tempfile.gettempdir()` after restriction: it probes for a
+  writable temp dir by creating files and finds none — amusing proof the
+  fence works, but it breaks code that runs after restriction. The real
+  launcher must compute paths *before* `landlock_restrict_self()`.

--- a/sandbox/spikes/landlock/README.md
+++ b/sandbox/spikes/landlock/README.md
@@ -11,9 +11,9 @@ dependencies — the same constraint as `sandbox/agent-sandbox`.
 |---|---|
 | `landlock_probe.py` | Queries the kernel's Landlock ABI version via `landlock_create_ruleset(NULL, 0, LANDLOCK_CREATE_RULESET_VERSION)` and prints the implied feature set. This is the startup probe agent-sandbox would run to decide what to enforce. |
 | `demo.py` | Working self-restriction demo: a child process applies a Landlock ruleset (rw beneath a temp project dir, ro+execute on system paths, TCP connect allowed only to one port), then proves the fence holds — including across `fork`+`execve` into a fresh subprocess. |
-| `landlock_exec.py` | The launcher shim (prototype of the future `agent-sandbox __landlock-exec` subcommand): runs as the last element of the bwrap argv, opens its rule FDs in the final mount namespace, applies fs (+net if ABI ≥ 4) rules, then `execvp`s the agent argv. Graceful on ABI 0. |
+| `landlock_exec.py` | The launcher shim (prototype of the future `agent-sandbox __landlock-exec` subcommand): runs as the last element of the bwrap argv, opens its rule FDs in the final mount namespace, applies fs (+net if ABI ≥ 4) rules, then `execvp`s the agent argv. Graceful on ABI 0 by default, fail-closed on demand (`--fail-closed` / `LINCE_LANDLOCK_FAIL_CLOSED=1`). Every run emits a single-line JSON **effective-policy record** (`LINCE_EFFECTIVE_POLICY: ` on stderr, optionally to `LINCE_POLICY_RECORD_PATH`) — requested vs enforced, see the design doc. `LINCE_LANDLOCK_FORCE_ABI=N` caps the probed ABI to simulate older kernels. |
 | `gate_check.py` | In-sandbox assertion payload run by the shim in place of a real agent binary: proves the fence inside the actual paranoid sandbox (denied write to bwrap's own rw tmpfs `/tmp`, connect allowed only to the socat bridge on 8118, bind denied, inheritance). |
-| `paranoid_gate.sh` | **The prototype gate**: gates agent `landlock-demo` at `--sandbox-level paranoid` through the shim using only existing agent-sandbox mechanisms (project-local config + custom agent command — `sandbox/agent-sandbox` is NOT modified). Chain: `unshare`/socat wrapper → bwrap → `landlock_exec.py` → `gate_check.py`. |
+| `paranoid_gate.sh` | **The prototype gate**: gates agent `landlock-demo` at `--sandbox-level paranoid` through the shim using only existing agent-sandbox mechanisms (project-local config + custom agent command — `sandbox/agent-sandbox` is NOT modified). Chain: `unshare`/socat wrapper → bwrap → `landlock_exec.py` → `gate_check.py`. Also captures the effective-policy record from the gated run and asserts `fs_enforced=true`, `net_enforced=true`, `net_limitation="port-only, host-unaware"`. |
 
 ## How to run
 
@@ -120,9 +120,10 @@ bwrap setup and the agent exec:
 
 ```
 $ bash sandbox/spikes/landlock/paranoid_gate.sh
-landlock: fs+net (ABI 7) applied in 47.5 us — rw=['/tmp/landlock_gate_sj7Vzj'] connect=[8118] bind=[]
-gate_check: pid 2 inside paranoid sandbox, project /tmp/landlock_gate_sj7Vzj
-  [PASS] fs: write inside project dir succeeds — /tmp/landlock_gate_sj7Vzj/inside.txt
+LINCE_EFFECTIVE_POLICY: {"backend": "bwrap", "requested_level": "paranoid", "requested_fs": {"rw": ["/tmp/landlock_gate_LoteBP"], "ro": ["/"]}, "requested_net": {"connect_ports": [8118], "bind_ports": []}, "landlock_abi": 7, "fs_enforced": true, "net_enforced": true, "net_limitation": "port-only, host-unaware", "applied_before_exec": true, "inherited_by_subprocesses": "by-design; verified by gate_check", "helper_digest": "4f8c5c8da5907e4efdae7f2bf35642f5941dfb967a3be9f4ba064faac44f296d", "bwrap_args_digest": null, "degraded_reason": null}
+landlock: fs+net (ABI 7) applied in 47.4 us — rw=['/tmp/landlock_gate_LoteBP'] connect=[8118] bind=[]
+gate_check: pid 2 inside paranoid sandbox, project /tmp/landlock_gate_LoteBP
+  [PASS] fs: write inside project dir succeeds — /tmp/landlock_gate_LoteBP/inside.txt
   [PASS] fs: write to bwrap rw tmpfs /tmp denied by Landlock — errno=EACCES
   [PASS] fs: read /etc (ro rule) still works
   [PASS] net: connect to proxy bridge port 8118 succeeds — socat listener reached
@@ -131,6 +132,11 @@ gate_check: pid 2 inside paranoid sandbox, project /tmp/landlock_gate_sj7Vzj
   [PASS] inherit: subprocess still denied /tmp write — rc=1
 
 GATE RESULT: ALL CHECKS PASSED
+[...agent-sandbox banner...]
+
+gate: effective-policy record from the gated run:
+  LINCE_EFFECTIVE_POLICY: {... same record as above ...}
+gate: record asserts fs_enforced=true, net_enforced=true, net_limitation="port-only, host-unaware" — OK
 ```
 
 Two details make this run self-proving:
@@ -149,6 +155,44 @@ modified, keeping this branch conflict-free with the in-flight
 credential-proxy and seatbelt PRs. Productizing means moving
 `landlock_exec.py` into the script as a hidden `__landlock-exec`
 subcommand appended to the bwrap argv by `build_bwrap_cmd()`.
+
+### Degraded path + fail-closed (rpelevin test 3)
+
+`LINCE_LANDLOCK_FORCE_ABI=0` makes the shim behave as on a kernel without
+Landlock. By default it stays graceful — the payload still runs, but the
+effective-policy record says exactly which boundaries were NOT enforced:
+
+```
+$ LINCE_LANDLOCK_FORCE_ABI=0 LINCE_SANDBOX_LEVEL=paranoid \
+    python3 sandbox/spikes/landlock/landlock_exec.py \
+    --rw /tmp --connect-port 8118 -- echo "payload ran (degraded, fail-open)"
+LINCE_EFFECTIVE_POLICY: {"backend": "bwrap", "requested_level": "paranoid", "requested_fs": {"rw": ["/tmp"], "ro": ["/"]}, "requested_net": {"connect_ports": [8118], "bind_ports": []}, "landlock_abi": 0, "fs_enforced": false, "net_enforced": false, "net_limitation": "unavailable", "applied_before_exec": false, "inherited_by_subprocesses": "by-design; verified by gate_check", "helper_digest": "4f8c5c8da5907e4efdae7f2bf35642f5941dfb967a3be9f4ba064faac44f296d", "bwrap_args_digest": null, "degraded_reason": "landlock unavailable (ABI 0 — kernel without Landlock or LSM disabled)"}
+landlock: not available — bwrap-only containment
+payload ran (degraded, fail-open)
+$ echo $?
+0
+```
+
+With `--fail-closed` (or `LINCE_LANDLOCK_FAIL_CLOSED=1`) the same
+degradation refuses to exec — the recommended contract for paranoid
+(see the design doc, "Effective policy: requested vs enforced"):
+
+```
+$ LINCE_LANDLOCK_FORCE_ABI=0 LINCE_SANDBOX_LEVEL=paranoid LINCE_LANDLOCK_FAIL_CLOSED=1 \
+    python3 sandbox/spikes/landlock/landlock_exec.py \
+    --rw /tmp --connect-port 8118 -- echo "payload must NOT run"
+LINCE_EFFECTIVE_POLICY: {"backend": "bwrap", "requested_level": "paranoid", "requested_fs": {"rw": ["/tmp"], "ro": ["/"]}, "requested_net": {"connect_ports": [8118], "bind_ports": []}, "landlock_abi": 0, "fs_enforced": false, "net_enforced": false, "net_limitation": "unavailable", "applied_before_exec": false, "inherited_by_subprocesses": "by-design; verified by gate_check", "helper_digest": "4f8c5c8da5907e4efdae7f2bf35642f5941dfb967a3be9f4ba064faac44f296d", "bwrap_args_digest": null, "degraded_reason": "landlock unavailable (ABI 0 — kernel without Landlock or LSM disabled)"}
+landlock_exec: FAIL-CLOSED — requested filesystem and network boundaries cannot be enforced (Landlock ABI 0); refusing to exec the agent
+$ echo $?
+1
+```
+
+Note the payload is never executed and the record is emitted *before*
+the refusal — degraded is only ever explicit + recorded, never silent.
+(The forced ABI can only lower the probed value: `min(probed, forced)`.
+Forcing 1–3 with net ports requested demonstrates the partial case:
+`fs_enforced: true, net_enforced: false, degraded_reason: "network rules
+not enforced (ABI n < 4)"` — fail-closed refuses there too.)
 
 ## What this proves
 

--- a/sandbox/spikes/landlock/demo.py
+++ b/sandbox/spikes/landlock/demo.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Landlock self-restriction demo — stdlib-only (ctypes), no external deps.
+
+Demonstrates the exact pattern agent-sandbox would use as a
+defense-in-depth layer inside the bwrap backend (#211):
+
+  parent (host side)
+    - creates a temp "project dir" and two local TCP listeners
+      (one allowed port, one denied port — both REAL listeners so a
+      blocked connect is provably Landlock, not ECONNREFUSED)
+    - spawns a child process (stand-in for the launcher between bwrap
+      setup and agent exec)
+
+  child (sandbox side)
+    - probes the Landlock ABI (graceful degradation on ENOSYS et al.)
+    - builds a ruleset: full rw beneath the project dir, ro+execute on
+      system paths (/usr, /etc, ...), TCP connect allowed ONLY to the
+      allowed port (ABI >= 4)
+    - landlock_restrict_self() — measured with perf_counter_ns
+    - proves: write inside allowed dir OK, write outside EACCES,
+      connect allowed port OK, connect denied port EACCES
+    - INHERITANCE: subprocess.run() a fresh python3 after restriction —
+      the grandchild is still confined (Landlock rulesets are inherited
+      across fork+execve, like no_new_privs)
+
+Run:  python3 sandbox/spikes/landlock/demo.py
+Exit: 0 all checks pass (or Landlock unavailable -> graceful skip),
+      1 a check failed.
+"""
+
+import ctypes
+import errno
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+
+# --- Landlock UAPI (include/uapi/linux/landlock.h) -------------------------
+
+SYS_LANDLOCK_CREATE_RULESET = 444
+SYS_LANDLOCK_ADD_RULE = 445
+SYS_LANDLOCK_RESTRICT_SELF = 446
+
+LANDLOCK_CREATE_RULESET_VERSION = 1 << 0
+
+LANDLOCK_RULE_PATH_BENEATH = 1
+LANDLOCK_RULE_NET_PORT = 2
+
+# Filesystem access rights (bit -> minimum ABI)
+FS_RIGHTS = {
+    "EXECUTE":     (1 << 0, 1),
+    "WRITE_FILE":  (1 << 1, 1),
+    "READ_FILE":   (1 << 2, 1),
+    "READ_DIR":    (1 << 3, 1),
+    "REMOVE_DIR":  (1 << 4, 1),
+    "REMOVE_FILE": (1 << 5, 1),
+    "MAKE_CHAR":   (1 << 6, 1),
+    "MAKE_DIR":    (1 << 7, 1),
+    "MAKE_REG":    (1 << 8, 1),
+    "MAKE_SOCK":   (1 << 9, 1),
+    "MAKE_FIFO":   (1 << 10, 1),
+    "MAKE_BLOCK":  (1 << 11, 1),
+    "MAKE_SYM":    (1 << 12, 1),
+    "REFER":       (1 << 13, 2),
+    "TRUNCATE":    (1 << 14, 3),
+    "IOCTL_DEV":   (1 << 15, 5),
+}
+
+NET_BIND_TCP = 1 << 0     # ABI >= 4
+NET_CONNECT_TCP = 1 << 1  # ABI >= 4
+
+PR_SET_NO_NEW_PRIVS = 38
+
+_libc = ctypes.CDLL(None, use_errno=True)
+
+
+def _check(res: int, what: str) -> int:
+    if res < 0:
+        err = ctypes.get_errno()
+        raise OSError(err, f"{what}: {os.strerror(err)}")
+    return res
+
+
+class RulesetAttr(ctypes.Structure):
+    # struct landlock_ruleset_attr (ABI >= 6 layout; kernel accepts any
+    # prefix size, we send only the fields the probed ABI knows about).
+    _fields_ = [
+        ("handled_access_fs", ctypes.c_uint64),
+        ("handled_access_net", ctypes.c_uint64),  # ABI >= 4
+        ("scoped", ctypes.c_uint64),              # ABI >= 6
+    ]
+
+
+class PathBeneathAttr(ctypes.Structure):
+    _pack_ = 1  # __attribute__((packed)) in the UAPI header
+    _layout_ = "ms"  # silence 3.14 DeprecationWarning; ignored pre-3.13
+    _fields_ = [
+        ("allowed_access", ctypes.c_uint64),
+        ("parent_fd", ctypes.c_int32),
+    ]
+
+
+class NetPortAttr(ctypes.Structure):
+    _fields_ = [
+        ("allowed_access", ctypes.c_uint64),
+        ("port", ctypes.c_uint64),
+    ]
+
+
+def probe_abi() -> int:
+    """Landlock ABI version, 0 if unavailable (graceful degradation)."""
+    res = _libc.syscall(SYS_LANDLOCK_CREATE_RULESET, None,
+                        ctypes.c_size_t(0),
+                        ctypes.c_uint32(LANDLOCK_CREATE_RULESET_VERSION))
+    if res < 0:
+        err = ctypes.get_errno()
+        if err in (errno.ENOSYS, errno.EOPNOTSUPP):
+            return 0
+        raise OSError(err, os.strerror(err))
+    return res
+
+
+def fs_rights_for_abi(abi: int) -> int:
+    return sum(bit for bit, min_abi in FS_RIGHTS.values() if abi >= min_abi)
+
+
+RO_EXEC = (FS_RIGHTS["EXECUTE"][0] | FS_RIGHTS["READ_FILE"][0]
+           | FS_RIGHTS["READ_DIR"][0])
+
+
+def apply_landlock(abi: int, rw_dirs: list, ro_dirs: list,
+                   allowed_connect_ports: list) -> float:
+    """Self-restrict; returns setup time in microseconds."""
+    t0 = time.perf_counter_ns()
+
+    handled_fs = fs_rights_for_abi(abi)
+    attr = RulesetAttr(handled_access_fs=handled_fs,
+                       handled_access_net=0, scoped=0)
+    size = 8                       # ABI 1-3: fs field only
+    if abi >= 4:
+        attr.handled_access_net = NET_BIND_TCP | NET_CONNECT_TCP
+        size = 16
+    # NOTE: we deliberately do NOT handle `scoped` (ABI 6 IPC scoping)
+    # in this demo — agent subprocesses must signal each other.
+
+    ruleset_fd = _check(
+        _libc.syscall(SYS_LANDLOCK_CREATE_RULESET, ctypes.byref(attr),
+                      ctypes.c_size_t(size), ctypes.c_uint32(0)),
+        "landlock_create_ruleset")
+    try:
+        for path, rights in ([(d, handled_fs) for d in rw_dirs]
+                             + [(d, RO_EXEC) for d in ro_dirs]):
+            if not os.path.isdir(path):
+                continue
+            # O_PATH dir FD — Landlock rules reference *opened* FDs, so
+            # what matters is the file the path resolves to NOW (in the
+            # current mount namespace), not the string.
+            dir_fd = os.open(path, os.O_PATH | os.O_CLOEXEC)
+            try:
+                pb = PathBeneathAttr(
+                    allowed_access=rights & handled_fs, parent_fd=dir_fd)
+                _check(_libc.syscall(
+                    SYS_LANDLOCK_ADD_RULE, ruleset_fd,
+                    LANDLOCK_RULE_PATH_BENEATH, ctypes.byref(pb),
+                    ctypes.c_uint32(0)), f"landlock_add_rule({path})")
+            finally:
+                os.close(dir_fd)
+        if abi >= 4:
+            for port in allowed_connect_ports:
+                np = NetPortAttr(allowed_access=NET_CONNECT_TCP, port=port)
+                _check(_libc.syscall(
+                    SYS_LANDLOCK_ADD_RULE, ruleset_fd,
+                    LANDLOCK_RULE_NET_PORT, ctypes.byref(np),
+                    ctypes.c_uint32(0)), f"landlock_add_rule(port {port})")
+        _check(_libc.prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0), "prctl(nnp)")
+        _check(_libc.syscall(SYS_LANDLOCK_RESTRICT_SELF, ruleset_fd,
+                             ctypes.c_uint32(0)),
+               "landlock_restrict_self")
+    finally:
+        os.close(ruleset_fd)
+
+    return (time.perf_counter_ns() - t0) / 1000.0
+
+
+# --- test harness -----------------------------------------------------------
+
+PASS, FAIL = "PASS", "FAIL"
+_results: list = []
+
+
+def report(name: str, ok: bool, detail: str = "") -> None:
+    _results.append(ok)
+    suffix = f" — {detail}" if detail else ""
+    print(f"  [{PASS if ok else FAIL}] {name}{suffix}")
+
+
+def child_main(project_dir: str, allowed_port: int, denied_port: int) -> int:
+    abi = probe_abi()
+    if abi == 0:
+        # Graceful degradation: exactly what agent-sandbox would do.
+        print("Landlock unavailable on this kernel (ENOSYS/EOPNOTSUPP).")
+        print("agent-sandbox would log a warning and continue with "
+              "bwrap-only containment. Skipping demo (not a failure).")
+        return 0
+    print(f"child: Landlock ABI {abi}, restricting self...")
+
+    ro_dirs = ["/usr", "/etc", "/lib", "/lib64", "/bin", "/sbin",
+               "/proc", "/dev"]
+    setup_us = apply_landlock(
+        abi, rw_dirs=[project_dir], ro_dirs=ro_dirs,
+        allowed_connect_ports=[allowed_port])
+    print(f"child: ruleset built + applied in {setup_us:.1f} us "
+          f"({len(ro_dirs) + 1} path rules, "
+          f"{1 if abi >= 4 else 0} net rules)")
+
+    # 1. write INSIDE the allowed project dir -> must succeed
+    try:
+        inside = os.path.join(project_dir, "inside.txt")
+        with open(inside, "w") as f:
+            f.write("ok\n")
+        report("fs: write inside allowed dir succeeds", True, inside)
+    except OSError as exc:
+        report("fs: write inside allowed dir succeeds", False, str(exc))
+
+    # 2. write OUTSIDE (parent of the project dir) -> EACCES.
+    # NB: do not call tempfile.gettempdir() after restriction — it probes
+    # for a writable dir and finds none (which itself proves the lockdown).
+    outside = os.path.join(os.path.dirname(project_dir),
+                           f"landlock_denied_{os.getpid()}.txt")
+    try:
+        with open(outside, "w") as f:
+            f.write("should not happen\n")
+        report("fs: write outside allowed dir denied", False,
+               f"{outside} was writable!")
+        os.unlink(outside)
+    except OSError as exc:
+        report("fs: write outside allowed dir denied",
+               exc.errno == errno.EACCES,
+               f"errno={errno.errorcode.get(exc.errno, exc.errno)}")
+
+    # 3. read of system files still works (ro rule)
+    try:
+        with open("/etc/hostname") as f:
+            f.read()
+        report("fs: read /etc (ro rule) still works", True)
+    except OSError as exc:
+        report("fs: read /etc (ro rule) still works", False, str(exc))
+
+    # 4. network (ABI >= 4): port-based TCP connect rules
+    if abi >= 4:
+        try:
+            with socket.create_connection(("127.0.0.1", allowed_port),
+                                          timeout=3):
+                pass
+            report(f"net: connect to allowed port {allowed_port} succeeds",
+                   True)
+        except OSError as exc:
+            report(f"net: connect to allowed port {allowed_port} succeeds",
+                   False, str(exc))
+        try:
+            with socket.create_connection(("127.0.0.1", denied_port),
+                                          timeout=3):
+                pass
+            report(f"net: connect to denied port {denied_port} blocked",
+                   False, "connect succeeded despite Landlock!")
+        except OSError as exc:
+            report(f"net: connect to denied port {denied_port} blocked",
+                   exc.errno == errno.EACCES,
+                   f"errno={errno.errorcode.get(exc.errno, exc.errno)} "
+                   f"(listener IS running — denial is Landlock's)")
+        try:
+            s = socket.socket()
+            s.bind(("127.0.0.1", 0))
+            s.close()
+            report("net: bind blocked (no bind rule added)", False,
+                   "bind succeeded")
+        except OSError as exc:
+            report("net: bind blocked (no bind rule added)",
+                   exc.errno == errno.EACCES,
+                   f"errno={errno.errorcode.get(exc.errno, exc.errno)}")
+    else:
+        print(f"  [SKIP] net rules: ABI {abi} < 4 — agent-sandbox would "
+              f"enforce fs only and log this")
+
+    # 5. INHERITANCE: restriction survives fork + execve of a subprocess
+    grand = subprocess.run(
+        [sys.executable, "-c",
+         f"open({outside!r}, 'w').write('x')"],
+        capture_output=True, text=True)
+    report("inherit: subprocess (fork+execve) still denied outside write",
+           grand.returncode != 0 and "PermissionError" in grand.stderr,
+           f"rc={grand.returncode}")
+    grand_ok = subprocess.run(
+        [sys.executable, "-c",
+         f"open({os.path.join(project_dir, 'sub.txt')!r}, 'w').write('x')"],
+        capture_output=True, text=True)
+    report("inherit: subprocess can still write inside allowed dir",
+           grand_ok.returncode == 0,
+           f"rc={grand_ok.returncode} {grand_ok.stderr.strip()}")
+
+    return 0 if all(_results) else 1
+
+
+def parent_main() -> int:
+    print(f"Landlock demo — kernel {os.uname().release}")
+    abi = probe_abi()
+    if abi == 0:
+        print("Landlock unavailable (ENOSYS/EOPNOTSUPP) — graceful skip.")
+        return 0
+
+    with tempfile.TemporaryDirectory(prefix="landlock_demo_") as project:
+        # Two REAL listeners: blocked connect must be EACCES, never
+        # ECONNREFUSED, to prove it is Landlock doing the blocking.
+        allowed_srv = socket.socket()
+        allowed_srv.bind(("127.0.0.1", 0))
+        allowed_srv.listen(8)
+        denied_srv = socket.socket()
+        denied_srv.bind(("127.0.0.1", 0))
+        denied_srv.listen(8)
+        allowed_port = allowed_srv.getsockname()[1]
+        denied_port = denied_srv.getsockname()[1]
+        print(f"parent: project dir {project}")
+        print(f"parent: allowed port {allowed_port}, "
+              f"denied port {denied_port} (both have live listeners)")
+
+        child = subprocess.run(
+            [sys.executable, os.path.abspath(__file__), "--child",
+             project, str(allowed_port), str(denied_port)])
+        allowed_srv.close()
+        denied_srv.close()
+
+        print()
+        if child.returncode == 0:
+            print("RESULT: ALL CHECKS PASSED")
+        else:
+            print("RESULT: FAILURES — see above")
+        return child.returncode
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 5 and sys.argv[1] == "--child":
+        sys.exit(child_main(sys.argv[2], int(sys.argv[3]),
+                            int(sys.argv[4])))
+    sys.exit(parent_main())

--- a/sandbox/spikes/landlock/gate_check.py
+++ b/sandbox/spikes/landlock/gate_check.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""In-sandbox assertions for the paranoid Landlock gate prototype (#211).
+
+Executed by landlock_exec.py (already restricted) INSIDE the paranoid
+bwrap sandbox, in place of a real agent binary. Proves the Landlock fence
+holds in the exact runtime the agent would get:
+
+  - bwrap mounts /tmp as a FRESH RW tmpfs at paranoid, so a denied write
+    there can only be Landlock's doing (bwrap would have allowed it);
+  - the denied TCP port has no listener in the fresh netns, so EACCES
+    (instead of ECONNREFUSED) can only be Landlock's doing;
+  - port 8118 is the in-sandbox socat bridge to the credential proxy —
+    the one connect the paranoid policy allows.
+
+Usage: gate_check.py <project_dir> (rw-allowed dir; everything else ro)
+"""
+
+import errno
+import os
+import socket
+import subprocess
+import sys
+
+PROXY_PORT = 8118
+DENIED_PORT = 9  # discard; nothing listens in the fresh netns
+
+_results: list = []
+
+
+def report(name: str, ok: bool, detail: str = "") -> None:
+    _results.append(ok)
+    suffix = f" — {detail}" if detail else ""
+    print(f"  [{'PASS' if ok else 'FAIL'}] {name}{suffix}", flush=True)
+
+
+def main(project_dir: str) -> int:
+    print(f"gate_check: pid {os.getpid()} inside paranoid sandbox, "
+          f"project {project_dir}", flush=True)
+
+    # 1. write inside the project dir (rw rule) -> must succeed
+    inside = os.path.join(project_dir, "inside.txt")
+    try:
+        with open(inside, "w") as f:
+            f.write("ok\n")
+        report("fs: write inside project dir succeeds", True, inside)
+    except OSError as exc:
+        report("fs: write inside project dir succeeds", False, str(exc))
+
+    # 2. write to /tmp -> EACCES. bwrap mounted /tmp as a fresh RW tmpfs,
+    # so this denial is provably Landlock's (EROFS would be bwrap's).
+    denied_path = f"/tmp/landlock_denied_{os.getpid()}.txt"
+    try:
+        with open(denied_path, "w") as f:
+            f.write("should not happen\n")
+        report("fs: write to bwrap rw tmpfs /tmp denied by Landlock", False,
+               f"{denied_path} was writable!")
+    except OSError as exc:
+        report("fs: write to bwrap rw tmpfs /tmp denied by Landlock",
+               exc.errno == errno.EACCES,
+               f"errno={errno.errorcode.get(exc.errno, exc.errno)}")
+
+    # 3. read system files still works (ro rule on /)
+    try:
+        with open("/etc/os-release") as f:
+            f.read()
+        report("fs: read /etc (ro rule) still works", True)
+    except OSError as exc:
+        report("fs: read /etc (ro rule) still works", False, str(exc))
+
+    # 4. connect to the socat proxy bridge on 8118 -> allowed
+    try:
+        with socket.create_connection(("127.0.0.1", PROXY_PORT), timeout=3):
+            pass
+        report(f"net: connect to proxy bridge port {PROXY_PORT} succeeds",
+               True, "socat listener reached")
+    except OSError as exc:
+        report(f"net: connect to proxy bridge port {PROXY_PORT} succeeds",
+               False, str(exc))
+
+    # 5. connect to any other port -> EACCES (no listener in this netns,
+    # so without Landlock this would be ECONNREFUSED)
+    try:
+        with socket.create_connection(("127.0.0.1", DENIED_PORT), timeout=3):
+            pass
+        report(f"net: connect to denied port {DENIED_PORT} blocked", False,
+               "connect succeeded despite Landlock!")
+    except OSError as exc:
+        report(f"net: connect to denied port {DENIED_PORT} blocked",
+               exc.errno == errno.EACCES,
+               f"errno={errno.errorcode.get(exc.errno, exc.errno)} "
+               f"(ECONNREFUSED would mean Landlock let it through)")
+
+    # 6. bind -> EACCES (no bind rule in the paranoid gate)
+    try:
+        s = socket.socket()
+        s.bind(("127.0.0.1", 0))
+        s.close()
+        report("net: bind blocked (no bind rule)", False, "bind succeeded")
+    except OSError as exc:
+        report("net: bind blocked (no bind rule)",
+               exc.errno == errno.EACCES,
+               f"errno={errno.errorcode.get(exc.errno, exc.errno)}")
+
+    # 7. inheritance: a fresh subprocess (fork+execve) is still confined
+    grand = subprocess.run(
+        [sys.executable, "-c", f"open({denied_path!r}, 'w').write('x')"],
+        capture_output=True, text=True)
+    report("inherit: subprocess still denied /tmp write",
+           grand.returncode != 0 and "PermissionError" in grand.stderr,
+           f"rc={grand.returncode}")
+
+    print(flush=True)
+    if all(_results):
+        print("GATE RESULT: ALL CHECKS PASSED", flush=True)
+        return 0
+    print("GATE RESULT: FAILURES — see above", flush=True)
+    return 1
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: gate_check.py <project_dir>", file=sys.stderr)
+        sys.exit(2)
+    sys.exit(main(sys.argv[1]))

--- a/sandbox/spikes/landlock/landlock_exec.py
+++ b/sandbox/spikes/landlock/landlock_exec.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Landlock launcher shim — spike prototype of the future `agent-sandbox __landlock-exec` subcommand (#211).
+
+Runs as the LAST element of the bwrap argv (Option B in
+docs/design/landlock-spike.md Q2): it starts inside the final mount
+namespace, opens its rule FDs there (so bwrap tmpfs and bind mounts are
+exactly what the rules attach to), applies the ruleset, then execs the
+real agent argv. Stdlib-only (ctypes), Python 3.11+.
+
+Usage (everything before `--` is shim policy, everything after is the
+agent command):
+
+    landlock_exec.py [--rw DIR]... [--ro DIR]... \
+                     [--connect-port N]... [--bind-port N]... -- ARGV...
+
+Behaviour mirrors the recommendation in the design doc:
+  - probe once; ABI 0 -> log and exec unrestricted (never fail);
+  - ABI 1-3 -> fs rules only, log that net is not enforced;
+  - ABI >= 4 -> fs + TCP connect/bind port rules (deny-by-default).
+"""
+
+import argparse
+import ctypes
+import errno
+import os
+import sys
+import time
+
+# --- Landlock UAPI (include/uapi/linux/landlock.h) -------------------------
+
+SYS_LANDLOCK_CREATE_RULESET = 444
+SYS_LANDLOCK_ADD_RULE = 445
+SYS_LANDLOCK_RESTRICT_SELF = 446
+
+LANDLOCK_CREATE_RULESET_VERSION = 1 << 0
+
+LANDLOCK_RULE_PATH_BENEATH = 1
+LANDLOCK_RULE_NET_PORT = 2
+
+# Filesystem access rights (bit -> minimum ABI)
+FS_RIGHTS = {
+    "EXECUTE":     (1 << 0, 1),
+    "WRITE_FILE":  (1 << 1, 1),
+    "READ_FILE":   (1 << 2, 1),
+    "READ_DIR":    (1 << 3, 1),
+    "REMOVE_DIR":  (1 << 4, 1),
+    "REMOVE_FILE": (1 << 5, 1),
+    "MAKE_CHAR":   (1 << 6, 1),
+    "MAKE_DIR":    (1 << 7, 1),
+    "MAKE_REG":    (1 << 8, 1),
+    "MAKE_SOCK":   (1 << 9, 1),
+    "MAKE_FIFO":   (1 << 10, 1),
+    "MAKE_BLOCK":  (1 << 11, 1),
+    "MAKE_SYM":    (1 << 12, 1),
+    "REFER":       (1 << 13, 2),
+    "TRUNCATE":    (1 << 14, 3),
+    "IOCTL_DEV":   (1 << 15, 5),
+}
+
+NET_BIND_TCP = 1 << 0     # ABI >= 4
+NET_CONNECT_TCP = 1 << 1  # ABI >= 4
+
+PR_SET_NO_NEW_PRIVS = 38
+
+_libc = ctypes.CDLL(None, use_errno=True)
+
+
+def _check(res: int, what: str) -> int:
+    if res < 0:
+        err = ctypes.get_errno()
+        raise OSError(err, f"{what}: {os.strerror(err)}")
+    return res
+
+
+class RulesetAttr(ctypes.Structure):
+    _fields_ = [
+        ("handled_access_fs", ctypes.c_uint64),
+        ("handled_access_net", ctypes.c_uint64),  # ABI >= 4
+        ("scoped", ctypes.c_uint64),              # ABI >= 6
+    ]
+
+
+class PathBeneathAttr(ctypes.Structure):
+    _pack_ = 1  # __attribute__((packed)) in the UAPI header
+    _layout_ = "ms"  # silence 3.14 DeprecationWarning; ignored pre-3.13
+    _fields_ = [
+        ("allowed_access", ctypes.c_uint64),
+        ("parent_fd", ctypes.c_int32),
+    ]
+
+
+class NetPortAttr(ctypes.Structure):
+    _fields_ = [
+        ("allowed_access", ctypes.c_uint64),
+        ("port", ctypes.c_uint64),
+    ]
+
+
+def probe_abi() -> int:
+    """Landlock ABI version, 0 if unavailable (graceful degradation)."""
+    res = _libc.syscall(SYS_LANDLOCK_CREATE_RULESET, None,
+                        ctypes.c_size_t(0),
+                        ctypes.c_uint32(LANDLOCK_CREATE_RULESET_VERSION))
+    if res < 0:
+        err = ctypes.get_errno()
+        if err in (errno.ENOSYS, errno.EOPNOTSUPP):
+            return 0
+        raise OSError(err, os.strerror(err))
+    return res
+
+
+def fs_rights_for_abi(abi: int) -> int:
+    return sum(bit for bit, min_abi in FS_RIGHTS.values() if abi >= min_abi)
+
+
+RO_EXEC = (FS_RIGHTS["EXECUTE"][0] | FS_RIGHTS["READ_FILE"][0]
+           | FS_RIGHTS["READ_DIR"][0])
+
+
+def apply_landlock(abi: int, rw_dirs: list, ro_dirs: list,
+                   connect_ports: list, bind_ports: list) -> float:
+    """Self-restrict; returns setup time in microseconds."""
+    t0 = time.perf_counter_ns()
+
+    handled_fs = fs_rights_for_abi(abi)
+    attr = RulesetAttr(handled_access_fs=handled_fs,
+                       handled_access_net=0, scoped=0)
+    size = 8                       # ABI 1-3: fs field only
+    if abi >= 4:
+        attr.handled_access_net = NET_BIND_TCP | NET_CONNECT_TCP
+        size = 16
+
+    ruleset_fd = _check(
+        _libc.syscall(SYS_LANDLOCK_CREATE_RULESET, ctypes.byref(attr),
+                      ctypes.c_size_t(size), ctypes.c_uint32(0)),
+        "landlock_create_ruleset")
+    try:
+        for path, rights in ([(d, handled_fs) for d in rw_dirs]
+                             + [(d, RO_EXEC) for d in ro_dirs]):
+            if not os.path.isdir(path):
+                continue
+            dir_fd = os.open(path, os.O_PATH | os.O_CLOEXEC)
+            try:
+                pb = PathBeneathAttr(
+                    allowed_access=rights & handled_fs, parent_fd=dir_fd)
+                _check(_libc.syscall(
+                    SYS_LANDLOCK_ADD_RULE, ruleset_fd,
+                    LANDLOCK_RULE_PATH_BENEATH, ctypes.byref(pb),
+                    ctypes.c_uint32(0)), f"landlock_add_rule({path})")
+            finally:
+                os.close(dir_fd)
+        if abi >= 4:
+            for access, ports in ((NET_CONNECT_TCP, connect_ports),
+                                  (NET_BIND_TCP, bind_ports)):
+                for port in ports:
+                    np = NetPortAttr(allowed_access=access, port=port)
+                    _check(_libc.syscall(
+                        SYS_LANDLOCK_ADD_RULE, ruleset_fd,
+                        LANDLOCK_RULE_NET_PORT, ctypes.byref(np),
+                        ctypes.c_uint32(0)),
+                        f"landlock_add_rule(port {port})")
+        _check(_libc.prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0), "prctl(nnp)")
+        _check(_libc.syscall(SYS_LANDLOCK_RESTRICT_SELF, ruleset_fd,
+                             ctypes.c_uint32(0)),
+               "landlock_restrict_self")
+    finally:
+        os.close(ruleset_fd)
+
+    return (time.perf_counter_ns() - t0) / 1000.0
+
+
+def main() -> int:
+    argv = sys.argv[1:]
+    if "--" not in argv:
+        print("landlock_exec: usage: landlock_exec.py [--rw DIR]... "
+              "[--ro DIR]... [--connect-port N]... [--bind-port N]... "
+              "-- ARGV...", file=sys.stderr)
+        return 2
+    sep = argv.index("--")
+    shim_argv, agent_argv = argv[:sep], argv[sep + 1:]
+    if not agent_argv:
+        print("landlock_exec: no agent command after '--'", file=sys.stderr)
+        return 2
+
+    parser = argparse.ArgumentParser(prog="landlock_exec.py")
+    parser.add_argument("--rw", action="append", default=[], metavar="DIR")
+    parser.add_argument("--ro", action="append", default=[], metavar="DIR")
+    parser.add_argument("--connect-port", action="append", type=int,
+                        default=[], metavar="N")
+    parser.add_argument("--bind-port", action="append", type=int,
+                        default=[], metavar="N")
+    args = parser.parse_args(shim_argv)
+
+    # Defaults mirror the design doc Q4.4: ro+execute on the whole ro-bound
+    # system view; rw must be explicit (project dir + binds).
+    ro_dirs = args.ro if args.ro else ["/"]
+
+    abi = probe_abi()
+    if abi == 0:
+        print("landlock: not available — bwrap-only containment",
+              file=sys.stderr)
+        os.execvp(agent_argv[0], agent_argv)
+
+    # Compute everything BEFORE restriction (design doc Q4.3): after
+    # landlock_restrict_self() the shim itself is confined.
+    setup_us = apply_landlock(abi, rw_dirs=args.rw, ro_dirs=ro_dirs,
+                              connect_ports=args.connect_port,
+                              bind_ports=args.bind_port)
+
+    enforced = "fs+net" if abi >= 4 else "fs only"
+    if abi < 4 and (args.connect_port or args.bind_port):
+        print(f"landlock: network rules not enforced (ABI {abi} < 4)",
+              file=sys.stderr)
+    print(f"landlock: {enforced} (ABI {abi}) applied in {setup_us:.1f} us — "
+          f"rw={args.rw} connect={args.connect_port} bind={args.bind_port}",
+          file=sys.stderr)
+    os.execvp(agent_argv[0], agent_argv)
+    return 1  # unreachable
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sandbox/spikes/landlock/landlock_exec.py
+++ b/sandbox/spikes/landlock/landlock_exec.py
@@ -11,17 +11,28 @@ Usage (everything before `--` is shim policy, everything after is the
 agent command):
 
     landlock_exec.py [--rw DIR]... [--ro DIR]... \
-                     [--connect-port N]... [--bind-port N]... -- ARGV...
+                     [--connect-port N]... [--bind-port N]... \
+                     [--fail-closed] -- ARGV...
 
 Behaviour mirrors the recommendation in the design doc:
-  - probe once; ABI 0 -> log and exec unrestricted (never fail);
+  - probe once; ABI 0 -> log and exec unrestricted (never fail), unless
+    --fail-closed / LINCE_LANDLOCK_FAIL_CLOSED=1 (paranoid contract);
   - ABI 1-3 -> fs rules only, log that net is not enforced;
   - ABI >= 4 -> fs + TCP connect/bind port rules (deny-by-default).
+
+Every run emits a single-line JSON **effective-policy record** to stderr
+(prefix `LINCE_EFFECTIVE_POLICY: `; also written to the file named by
+LINCE_POLICY_RECORD_PATH when set) stating what was *requested* vs what
+the kernel actually *enforced* — see docs/design/landlock-spike.md
+"Effective policy: requested vs enforced". LINCE_LANDLOCK_FORCE_ABI=N
+caps the probed ABI to simulate older kernels (degraded-path demo).
 """
 
 import argparse
 import ctypes
 import errno
+import hashlib
+import json
 import os
 import sys
 import time
@@ -169,12 +180,27 @@ def apply_landlock(abi: int, rw_dirs: list, ro_dirs: list,
     return (time.perf_counter_ns() - t0) / 1000.0
 
 
+def _self_digest() -> str:
+    """sha256 of this shim file — the record's helper_digest field."""
+    with open(__file__, "rb") as f:
+        return hashlib.sha256(f.read()).hexdigest()
+
+
+def emit_record(record: dict, record_file) -> None:
+    """Single-line JSON to stderr (+ optional pre-opened record file)."""
+    line = json.dumps(record, ensure_ascii=False)
+    print(f"LINCE_EFFECTIVE_POLICY: {line}", file=sys.stderr, flush=True)
+    if record_file is not None:
+        record_file.write(line + "\n")
+        record_file.close()
+
+
 def main() -> int:
     argv = sys.argv[1:]
     if "--" not in argv:
         print("landlock_exec: usage: landlock_exec.py [--rw DIR]... "
               "[--ro DIR]... [--connect-port N]... [--bind-port N]... "
-              "-- ARGV...", file=sys.stderr)
+              "[--fail-closed] -- ARGV...", file=sys.stderr)
         return 2
     sep = argv.index("--")
     shim_argv, agent_argv = argv[:sep], argv[sep + 1:]
@@ -189,14 +215,62 @@ def main() -> int:
                         default=[], metavar="N")
     parser.add_argument("--bind-port", action="append", type=int,
                         default=[], metavar="N")
+    parser.add_argument("--fail-closed", action="store_true")
     args = parser.parse_args(shim_argv)
+    fail_closed = (args.fail_closed
+                   or os.environ.get("LINCE_LANDLOCK_FAIL_CLOSED") == "1")
 
     # Defaults mirror the design doc Q4.4: ro+execute on the whole ro-bound
     # system view; rw must be explicit (project dir + binds).
     ro_dirs = args.ro if args.ro else ["/"]
 
     abi = probe_abi()
+    forced = os.environ.get("LINCE_LANDLOCK_FORCE_ABI")
+    if forced is not None:
+        # Degraded-path demo: pretend the kernel is older than it is. Can
+        # only lower the probed ABI, never raise it.
+        abi = min(abi, int(forced))
+
+    # Effective-policy record (rpelevin, #211): requested vs enforced.
+    # Built BEFORE restriction (digest needs a file read; design doc Q4.3).
+    record = {
+        "backend": os.environ.get("LINCE_BACKEND", "bwrap"),
+        "requested_level": os.environ.get("LINCE_SANDBOX_LEVEL"),
+        "requested_fs": {"rw": args.rw, "ro": ro_dirs},
+        "requested_net": {"connect_ports": args.connect_port,
+                          "bind_ports": args.bind_port},
+        "landlock_abi": abi,
+        "fs_enforced": False,
+        "net_enforced": False,
+        # Landlock net rules (ABI >= 4) are TCP+port-based only — they can
+        # never express host allowlists; that stays the proxy's job.
+        "net_limitation": "unavailable",
+        "applied_before_exec": False,
+        # The shim cannot observe the agent after execvp; inheritance
+        # across fork+execve is a kernel property, verified empirically by
+        # demo.py / gate_check.py — stay honest about who verified what.
+        "inherited_by_subprocesses": "by-design; verified by gate_check",
+        "helper_digest": _self_digest(),
+        # Only the launcher (agent-sandbox build_bwrap_cmd) knows the bwrap
+        # argv; the in-sandbox shim never sees it. Production home for this
+        # field is #221, where agent-sandbox assembles the full record.
+        "bwrap_args_digest": None,
+        "degraded_reason": None,
+    }
+    # Open the optional record file BEFORE restriction: its parent dir may
+    # not be writable afterwards (the already-open fd still is).
+    record_path = os.environ.get("LINCE_POLICY_RECORD_PATH")
+    record_file = open(record_path, "w") if record_path else None
+
     if abi == 0:
+        record["degraded_reason"] = ("landlock unavailable (ABI 0 — kernel "
+                                     "without Landlock or LSM disabled)")
+        emit_record(record, record_file)
+        if fail_closed:
+            print("landlock_exec: FAIL-CLOSED — requested filesystem and "
+                  "network boundaries cannot be enforced (Landlock ABI 0); "
+                  "refusing to exec the agent", file=sys.stderr)
+            return 1
         print("landlock: not available — bwrap-only containment",
               file=sys.stderr)
         os.execvp(agent_argv[0], agent_argv)
@@ -207,8 +281,25 @@ def main() -> int:
                               connect_ports=args.connect_port,
                               bind_ports=args.bind_port)
 
+    record["fs_enforced"] = True
+    record["applied_before_exec"] = True
+    net_requested = bool(args.connect_port or args.bind_port)
+    if abi >= 4:
+        record["net_enforced"] = True
+        record["net_limitation"] = "port-only, host-unaware"
+    elif net_requested:
+        record["degraded_reason"] = (f"network rules not enforced "
+                                     f"(ABI {abi} < 4)")
+    emit_record(record, record_file)
+
+    if fail_closed and net_requested and not record["net_enforced"]:
+        print(f"landlock_exec: FAIL-CLOSED — requested network boundary "
+              f"cannot be enforced (ABI {abi} < 4); refusing to exec the "
+              f"agent", file=sys.stderr)
+        return 1
+
     enforced = "fs+net" if abi >= 4 else "fs only"
-    if abi < 4 and (args.connect_port or args.bind_port):
+    if abi < 4 and net_requested:
         print(f"landlock: network rules not enforced (ABI {abi} < 4)",
               file=sys.stderr)
     print(f"landlock: {enforced} (ABI {abi}) applied in {setup_us:.1f} us — "

--- a/sandbox/spikes/landlock/landlock_probe.py
+++ b/sandbox/spikes/landlock/landlock_probe.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Landlock ABI probe — stdlib-only (ctypes), no external deps.
+
+Queries the kernel for the supported Landlock ABI version via
+
+    landlock_create_ruleset(NULL, 0, LANDLOCK_CREATE_RULESET_VERSION)
+
+and prints the feature set that ABI level implies. Exit codes:
+
+    0  Landlock available (ABI printed)
+    1  Landlock not available (ENOSYS / EOPNOTSUPP / disabled LSM)
+    2  unexpected error
+
+This is the exact probe agent-sandbox would run at startup to decide
+what to enforce (graceful degradation: enforce only what the running
+kernel supports, log the rest as "not enforced").
+
+Spike: https://github.com/RisorseArtificiali/lince/issues/211
+"""
+
+import ctypes
+import errno
+import os
+import sys
+
+# x86_64 / aarch64 / riscv64 share these syscall numbers (asm-generic).
+SYS_LANDLOCK_CREATE_RULESET = 444
+
+LANDLOCK_CREATE_RULESET_VERSION = 1 << 0
+
+# ABI level -> (first kernel, feature added at this level)
+# Source: Documentation/userspace-api/landlock.rst (kernel docs),
+# include/uapi/linux/landlock.h changelog.
+ABI_TABLE = [
+    (1, "5.13", "filesystem access control (13 FS access rights, "
+                "execute/read/write/make_*)"),
+    (2, "5.19", "+ LANDLOCK_ACCESS_FS_REFER (file reparenting/linking "
+                "across directories)"),
+    (3, "6.2",  "+ LANDLOCK_ACCESS_FS_TRUNCATE (truncate(2)/O_TRUNC)"),
+    (4, "6.7",  "+ TCP network control: LANDLOCK_ACCESS_NET_BIND_TCP / "
+                "CONNECT_TCP (port-based)"),
+    (5, "6.10", "+ LANDLOCK_ACCESS_FS_IOCTL_DEV (ioctl on device files)"),
+    (6, "6.12", "+ scopes: LANDLOCK_SCOPE_ABSTRACT_UNIX_SOCKET, "
+                "LANDLOCK_SCOPE_SIGNAL (IPC isolation)"),
+    (7, "6.15", "+ audit support: LANDLOCK_RESTRICT_SELF_LOG_* flags "
+                "(denials visible in audit log)"),
+]
+
+
+def probe_abi() -> int:
+    """Return the Landlock ABI version, or raise OSError."""
+    libc = ctypes.CDLL(None, use_errno=True)
+    res = libc.syscall(
+        SYS_LANDLOCK_CREATE_RULESET,
+        None,                      # attr = NULL
+        ctypes.c_size_t(0),        # size = 0
+        ctypes.c_uint32(LANDLOCK_CREATE_RULESET_VERSION),
+    )
+    if res < 0:
+        err = ctypes.get_errno()
+        raise OSError(err, os.strerror(err))
+    return res
+
+
+def main() -> int:
+    try:
+        abi = probe_abi()
+    except OSError as exc:
+        if exc.errno == errno.ENOSYS:
+            print("Landlock: NOT available (ENOSYS — kernel < 5.13 or "
+                  "CONFIG_SECURITY_LANDLOCK not built)")
+        elif exc.errno == errno.EOPNOTSUPP:
+            print("Landlock: NOT available (EOPNOTSUPP — built but not "
+                  "enabled in the 'lsm=' boot parameter)")
+        else:
+            print(f"Landlock: unexpected error: {exc}")
+            return 2
+        print("agent-sandbox behaviour: skip Landlock layer, log a "
+              "warning, keep bwrap-only containment.")
+        return 1
+
+    print(f"Landlock ABI version: {abi}")
+    print(f"Kernel: {os.uname().release}")
+    print()
+    print("Feature set implied by this ABI:")
+    for level, kernel, feature in ABI_TABLE:
+        mark = "x" if abi >= level else " "
+        print(f"  [{mark}] v{level} (kernel >= {kernel}): {feature}")
+    if abi > ABI_TABLE[-1][0]:
+        print(f"  [?] v{abi} > v{ABI_TABLE[-1][0]}: newer than this "
+              f"probe's table — all listed features available, plus "
+              f"unknown newer ones")
+    print()
+    fs = "yes"
+    net = "yes (TCP bind/connect, port-based)" if abi >= 4 else "no"
+    scoped = "yes (signals + abstract unix sockets)" if abi >= 6 else "no"
+    print("Enforceable by agent-sandbox on this kernel:")
+    print(f"  filesystem rules : {fs}")
+    print(f"  network rules    : {net}")
+    print(f"  IPC scoping      : {scoped}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sandbox/spikes/landlock/paranoid_gate.sh
+++ b/sandbox/spikes/landlock/paranoid_gate.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Paranoid Landlock gate prototype (#211) — gates one agent at
+# `--sandbox-level paranoid` through the landlock_exec.py shim, using
+# ONLY existing agent-sandbox mechanisms (project-local config + custom
+# agent command). agent-sandbox itself is NOT modified.
+#
+# What it does:
+#   1. creates a throwaway project dir with a project-local
+#      .agent-sandbox/config.toml defining agent `landlock-demo` whose
+#      command IS the shim, plus a project-local paranoid fragment
+#      (credential_proxy + unshare_net, same [security] as shipped
+#      paranoid levels);
+#   2. runs `agent-sandbox run -a landlock-demo --sandbox-level paranoid`
+#      so the chain is exactly the design doc's Option B:
+#      unshare/socat wrapper -> bwrap <mounts> -> landlock_exec.py
+#      (rw=project, connect=8118) -> gate_check.py assertions;
+#   3. gate_check.py proves fs + net fences hold inside the real
+#      paranoid sandbox (see its docstring), exit 0 = all pass.
+#
+# Run from anywhere:  bash sandbox/spikes/landlock/paranoid_gate.sh
+set -euo pipefail
+
+SPIKE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$SPIKE_DIR/../../.." && pwd)"
+
+PROJ="$(mktemp -d /tmp/landlock_gate_XXXXXX)"
+trap 'rm -rf "$PROJ"' EXIT
+
+# The repo may live under $HOME, which paranoid covers with tmpfs — copy
+# the shim and the check payload into the project dir (bind-mounted rw
+# into the sandbox at the same path) so they are visible inside.
+cp "$SPIKE_DIR/landlock_exec.py" "$SPIKE_DIR/gate_check.py" "$PROJ/"
+chmod +x "$PROJ/landlock_exec.py"
+
+mkdir -p "$PROJ/.agent-sandbox/profiles" "$PROJ/.agent-sandbox/claude-config"
+cat > "$PROJ/.agent-sandbox/config.toml" <<EOF
+# Gate the landlock-demo agent through the Landlock shim (#211).
+[agents.landlock-demo]
+command = "$PROJ/landlock_exec.py"
+default_args = []
+
+[claude]
+# Keep the default ~/.agent-sandbox/claude-config bind out of the picture:
+# the gate must not depend on (or touch) the user's sandbox install.
+config_dir = "$PROJ/.agent-sandbox/claude-config"
+EOF
+cat > "$PROJ/.agent-sandbox/profiles/landlock-demo-paranoid.toml" <<'EOF'
+# Paranoid fragment for the gate prototype: same [security] semantics as
+# the shipped <agent>-paranoid levels (fresh netns + credential proxy
+# reached via the in-sandbox socat bridge on 127.0.0.1:8118).
+[security]
+credential_proxy = true
+unshare_net = true
+allow_domains = []
+
+[env.extra]
+# Dummy credential so the proxy has a rule and the socat bridge is live;
+# never sent anywhere (gate_check only TCP-connects to the bridge).
+ANTHROPIC_API_KEY = "sk-test-landlock-spike"
+EOF
+
+cd "$PROJ"
+python3 "$REPO/sandbox/agent-sandbox" run -a landlock-demo \
+  --sandbox-level paranoid -p "$PROJ" -- \
+  --rw "$PROJ" --connect-port 8118 -- \
+  python3 "$PROJ/gate_check.py" "$PROJ"

--- a/sandbox/spikes/landlock/paranoid_gate.sh
+++ b/sandbox/spikes/landlock/paranoid_gate.sh
@@ -15,7 +15,10 @@
 #      unshare/socat wrapper -> bwrap <mounts> -> landlock_exec.py
 #      (rw=project, connect=8118) -> gate_check.py assertions;
 #   3. gate_check.py proves fs + net fences hold inside the real
-#      paranoid sandbox (see its docstring), exit 0 = all pass.
+#      paranoid sandbox (see its docstring), exit 0 = all pass;
+#   4. captures the shim's LINCE_EFFECTIVE_POLICY record from the gated
+#      run and asserts fs_enforced=true, net_enforced=true,
+#      net_limitation="port-only, host-unaware" (#211, rpelevin).
 #
 # Run from anywhere:  bash sandbox/spikes/landlock/paranoid_gate.sh
 set -euo pipefail
@@ -57,10 +60,41 @@ allow_domains = []
 # Dummy credential so the proxy has a rule and the socat bridge is live;
 # never sent anywhere (gate_check only TCP-connects to the bridge).
 ANTHROPIC_API_KEY = "sk-test-landlock-spike"
+# Launch context for the shim's effective-policy record (#211): in
+# production agent-sandbox itself would export these (#221).
+LINCE_SANDBOX_LEVEL = "paranoid"
 EOF
 
 cd "$PROJ"
+LOG="$PROJ/gate.log"
 python3 "$REPO/sandbox/agent-sandbox" run -a landlock-demo \
   --sandbox-level paranoid -p "$PROJ" -- \
   --rw "$PROJ" --connect-port 8118 -- \
-  python3 "$PROJ/gate_check.py" "$PROJ"
+  python3 "$PROJ/gate_check.py" "$PROJ" 2>&1 | tee "$LOG"
+
+# --- Effective-policy record: capture + assert (#211, rpelevin) ----------
+RECORD_LINE="$(grep -m1 'LINCE_EFFECTIVE_POLICY: ' "$LOG" || true)"
+if [[ -z "$RECORD_LINE" ]]; then
+  echo "gate: FAIL — no LINCE_EFFECTIVE_POLICY record in gated run output" >&2
+  exit 1
+fi
+echo
+echo "gate: effective-policy record from the gated run:"
+echo "  $RECORD_LINE"
+python3 - "${RECORD_LINE#*LINCE_EFFECTIVE_POLICY: }" <<'PY'
+import json
+import sys
+
+rec = json.loads(sys.argv[1])
+want = {
+    "fs_enforced": True,
+    "net_enforced": True,
+    "net_limitation": "port-only, host-unaware",
+}
+bad = {k: rec.get(k) for k, v in want.items() if rec.get(k) != v}
+if bad:
+    print(f"gate: FAIL — record assertions: {bad}", file=sys.stderr)
+    sys.exit(1)
+print('gate: record asserts fs_enforced=true, net_enforced=true, '
+      'net_limitation="port-only, host-unaware" — OK')
+PY

--- a/sandbox/spikes/landlock/validate.sh
+++ b/sandbox/spikes/landlock/validate.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Landlock spike validation runner (#211 / #222).
+# Paste-proof wrapper around the four spike checks so a wrapping terminal
+# cannot split a long bwrap argv across newlines. Run from the repo root:
+#
+#   sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0   # Ubuntu 24.04+: unblock unpriv userns
+#   bash sandbox/spikes/landlock/validate.sh
+#
+# Writes a transcript to /tmp/landlock-validation.log. Never aborts on a
+# single failing step — each step's exit code is reported so a partial
+# environment still produces a useful record.
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOG=/tmp/landlock-validation.log
+
+run() {  # run "<label>" <cmd...>
+  local label="$1"; shift
+  echo "--- ${label}"
+  "$@"
+  echo "    rc=$?"
+  echo
+}
+
+{
+  echo "=== HOST: $(uname -r) | $( . /etc/os-release 2>/dev/null; echo "${PRETTY_NAME:-unknown}") ==="
+  echo "=== unpriv userns sysctl: $(sysctl -n kernel.apparmor_restrict_unprivileged_userns 2>/dev/null || echo n/a) (0 = allowed)"
+  echo
+
+  run "[1/5] probe"                  python3 "${HERE}/landlock_probe.py"
+  run "[2/5] demo (fs+net+inherit)"  python3 "${HERE}/demo.py"
+  run "[3/5] Q4: demo under bwrap"   bwrap --ro-bind / / --tmpfs /tmp --dev /dev --proc /proc -- python3 "${HERE}/demo.py"
+  run "[4/5] paranoid gate (native ABI)" bash "${HERE}/paranoid_gate.sh"
+  echo "--- [5/5] paranoid gate (FORCE_ABI=4 — exercises the v4 codepath)"
+  LINCE_LANDLOCK_FORCE_ABI=4 bash "${HERE}/paranoid_gate.sh"
+  echo "    rc=$?"
+  echo
+  echo "=== DONE — transcript at ${LOG} ==="
+} 2>&1 | tee "${LOG}"

--- a/sandbox/spikes/landlock/validate.sh
+++ b/sandbox/spikes/landlock/validate.sh
@@ -28,9 +28,9 @@ run() {  # run "<label>" <cmd...>
 
   run "[1/5] probe"                  python3 "${HERE}/landlock_probe.py"
   run "[2/5] demo (fs+net+inherit)"  python3 "${HERE}/demo.py"
-  # Bind the spike dir to a path outside /tmp so the fresh --tmpfs /tmp does
-  # not shadow it when the repo itself is cloned under /tmp.
-  run "[3/5] Q4: demo under bwrap"   bwrap --ro-bind / / --tmpfs /tmp --dev /dev --proc /proc --ro-bind "${HERE}" /opt/landlock-spike -- python3 /opt/landlock-spike/demo.py
+  # Re-bind the spike dir INTO the fresh tmpfs (writable, so bwrap can make the
+  # mountpoint) so --tmpfs /tmp does not shadow it when the repo is under /tmp.
+  run "[3/5] Q4: demo under bwrap"   bwrap --ro-bind / / --tmpfs /tmp --dev /dev --proc /proc --ro-bind "${HERE}" /tmp/spike -- python3 /tmp/spike/demo.py
   run "[4/5] paranoid gate (native ABI)" bash "${HERE}/paranoid_gate.sh"
   echo "--- [5/5] paranoid gate (FORCE_ABI=4 — exercises the v4 codepath)"
   LINCE_LANDLOCK_FORCE_ABI=4 bash "${HERE}/paranoid_gate.sh"

--- a/sandbox/spikes/landlock/validate.sh
+++ b/sandbox/spikes/landlock/validate.sh
@@ -28,7 +28,9 @@ run() {  # run "<label>" <cmd...>
 
   run "[1/5] probe"                  python3 "${HERE}/landlock_probe.py"
   run "[2/5] demo (fs+net+inherit)"  python3 "${HERE}/demo.py"
-  run "[3/5] Q4: demo under bwrap"   bwrap --ro-bind / / --tmpfs /tmp --dev /dev --proc /proc -- python3 "${HERE}/demo.py"
+  # Bind the spike dir to a path outside /tmp so the fresh --tmpfs /tmp does
+  # not shadow it when the repo itself is cloned under /tmp.
+  run "[3/5] Q4: demo under bwrap"   bwrap --ro-bind / / --tmpfs /tmp --dev /dev --proc /proc --ro-bind "${HERE}" /opt/landlock-spike -- python3 /opt/landlock-spike/demo.py
   run "[4/5] paranoid gate (native ABI)" bash "${HERE}/paranoid_gate.sh"
   echo "--- [5/5] paranoid gate (FORCE_ABI=4 — exercises the v4 codepath)"
   LINCE_LANDLOCK_FORCE_ABI=4 bash "${HERE}/paranoid_gate.sh"


### PR DESCRIPTION
## TLDR
Feasibility spike for Landlock as defense-in-depth inside the bwrap backend. **Verdict: GO.** All artifacts are new files (`sandbox/spikes/landlock/` + `docs/design/landlock-spike.md`) — `agent-sandbox` is untouched to stay conflict-free with the sibling security PRs.

All 5 spike questions answered **with live evidence on this box** (Fedora 44, kernel 6.19, Landlock ABI v7):
1. **ABI matrix**: distro floor across targets is ABI v4 (Ubuntu 24.04 GA 6.8) → fs + TCP-net rules enforceable everywhere we ship; live-probed v7 locally.
2. **Application point**: `preexec_fn` (restrict before bwrap) experimentally REJECTED — bwrap-created tmpfs isn't beneath host-opened rule FDs. Recommended and **prototyped**: in-sandbox launcher shim (`landlock_exec.py`, future `agent-sandbox __landlock-exec`) as last bwrap argv. Inheritance across fork+execve proven.
3. **Network**: Landlock is port-based — ports are Landlock's job (proxy bridge 8118 under unshare_net), hosts stay the credential proxy's; unix-socket bridge unaffected; UDP/QUIC not covered → complements, doesn't replace, `unshare -n`.
4. **bwrap composition**: TESTED, not just reasoned — `demo.py` inside a real bwrap mount namespace passes all 8 checks; full paranoid chain (unshare/socat → bwrap → shim → payload) gated via `paranoid_gate.sh` using only existing agent-sandbox mechanisms: **GATE RESULT: ALL CHECKS PASSED** (write to bwrap's own rw tmpfs → EACCES from Landlock; non-proxy port → EACCES in fresh netns; socat bridge 8118 reachable; bind denied; subprocess inheritance holds).
5. **Overhead**: ruleset build+apply measured at ~60-75 µs (shim: 47.5 µs in the gated run); est. 150-200 lines to integrate.

Recommendation for #201: paranoid = fs + net(connect→8118 only); normal = fs + net-when-proxy-active; permissive = off. Proposed policy keys: `[filesystem] write/read`, `[network] mode/allowed_hosts/allow_connect_ports/allow_bind_ports`.

## How to test it
- `python3 sandbox/spikes/landlock/landlock_probe.py` → ABI report.
- `python3 sandbox/spikes/landlock/demo.py` → 8/8 checks (graceful on old kernels: ENOSYS/EOPNOTSUPP handled).
- `bash sandbox/spikes/landlock/paranoid_gate.sh` → full paranoid-chain gate, 7/7 checks.
- `ruff check sandbox/spikes/landlock/` → clean. Captured outputs in the spike README.

Follow-up to file on merge: fold the shim into `agent-sandbox` as `__landlock-exec` + sandbox/tests check (the spike deliverable "gating one agent at paranoid" is met via the prototype chain; production integration is the next task).

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)