### PR TITLE
feat(config): lince config resolve --json; dashboard drops sandbox-TOML parsing (#202)

### DIFF
--- a/lince-config/lince-config
+++ b/lince-config/lince-config
@@ -1542,6 +1542,691 @@ def cmd_validate(args) -> int:
     return 1 if errors else 0
 
 
+# ── resolve --json (#202, design §4.3/§4.1/§5.2) ─────────────────────────
+#
+# The single resolution point. Consumed by the dashboard via run_command
+# (WASI plugins cannot read arbitrary files), by agent-sandbox, and by
+# skills. Provider/env-var NAMES only — never secret VALUES (I4): any
+# provider/agent env value that looks like a secret is redacted to its
+# "$NAME" self-reference form, which consumers treat as "inherit from the
+# host environment".
+
+RESOLVE_SCHEMA = 1
+SHIPPED_LEVELS = ["paranoid", "normal", "permissive"]
+
+SANDBOX_CONFIG_PATH = SANDBOX_DIR / "config.toml"
+DASHBOARD_CONFIG_PATH = DASHBOARD_DIR / "config.toml"
+SANDBOX_PROFILES_DIR = SANDBOX_DIR / "profiles"
+NONO_PROFILES_DIR = Path.home() / ".config" / "nono" / "profiles"
+
+# Registry [agent]-table keys lifted to the top level of [agents.<name>]
+# in lince.toml (§2.3 lifting rule).
+_LIFTED_AGENT_KEYS = ("binary", "display_name", "short_label", "color", "default_args")
+# Registry sub-tables that keep their table form under [agents.<name>].
+_AGENT_SUBTABLES = ("sandbox", "dashboard", "env", "event_map", "variants")
+# Policy-only keys (not part of the registry schema).
+_POLICY_AGENT_KEYS = ("level", "provider", "allowed_hosts")
+
+
+def _is_env_self_ref(key: str, value: str) -> bool:
+    return value in (f"${key}", f"${{{key}}}")
+
+
+def _redact_env(env: dict) -> dict:
+    """Redact secret-looking VALUES to their $NAME self-reference form (I4).
+
+    A value is a secret when its key matches the sensitive-keyword list or
+    the value matches a known credential pattern. $NAME / ${NAME} references
+    pass through (they are already names, not values).
+    """
+    out: dict = {}
+    for key, value in env.items():
+        sval = str(value)
+        if sval.startswith("$"):
+            out[key] = sval
+        elif any(kw in key.upper() for kw in _SENSITIVE_KEY_KEYWORDS) or any(
+            p.match(sval) for p in _SENSITIVE_VALUE_PATTERNS
+        ):
+            out[key] = f"${key}"
+        else:
+            out[key] = sval
+    return out
+
+
+def _env_available(name: str) -> bool:
+    import os
+    return bool(os.environ.get(name))
+
+
+def _load_toml_or_empty(path: Path, warnings: list | None = None) -> dict:
+    try:
+        with open(path, "rb") as fh:
+            return tomllib.load(fh)
+    except FileNotFoundError:
+        return {}
+    except (tomllib.TOMLDecodeError, OSError) as exc:
+        if warnings is not None:
+            warnings.append(f"{path}: {exc}")
+        return {}
+
+
+# List keys with ADDITIVE cross-layer semantics (LINCE-105 precedent; the
+# §4.1 "lists append" rule exists so an overlay can never silently drop
+# provider hosts or shipped mounts). Every other list REPLACES — launch
+# vectors like default_args must stay removable by an override (a user must
+# be able to drop --dangerously-skip-permissions, §3.5 security note).
+_ADDITIVE_LIST_KEYS = frozenset({
+    "allowed_hosts", "allow_domains", "blocked_hosts", "passthrough",
+    "home_ro_dirs", "home_rw_dirs", "scratch_home_dirs", "scratch_home_files",
+})
+
+
+def _deep_overlay(base: dict, overlay: dict) -> dict:
+    """§4.1 merge semantics: accumulation lists append (deduplicated), other
+    lists and scalars replace, tables deep-merge."""
+    result = dict(base)
+    for key, val in overlay.items():
+        if key in result and isinstance(result[key], dict) and isinstance(val, dict):
+            result[key] = _deep_overlay(result[key], val)
+        elif (
+            key in _ADDITIVE_LIST_KEYS
+            and key in result
+            and isinstance(result[key], list)
+            and isinstance(val, list)
+        ):
+            merged = list(result[key])
+            for item in val:
+                if item not in merged:
+                    merged.append(item)
+            result[key] = merged
+        else:
+            result[key] = val
+    return result
+
+
+def load_registry(registry_dir: Path, warnings: list) -> tuple[dict, dict]:
+    """Load registry.d → ({agent_name: registry_entry}, {provider: entry})."""
+    agents: dict = {}
+    providers: dict = {}
+    providers_path = registry_dir / "providers.toml"
+    if providers_path.is_file():
+        providers = _load_toml_or_empty(providers_path, warnings).get("providers", {})
+    for path in sorted(registry_dir.glob("*.toml")):
+        if path.name == "providers.toml":
+            continue
+        data = _load_toml_or_empty(path, warnings)
+        if not data:
+            continue
+        if not data.get("agent", {}).get("binary"):
+            warnings.append(f"{path.name}: missing [agent].binary — skipped")
+            continue
+        agents[data["agent"].get("name", path.stem)] = data
+    return agents, providers
+
+
+def _lince_agent_to_registry_shape(entry: dict) -> tuple[dict, dict]:
+    """Split a lince.toml [agents.<name>] entry (lifting rule, §2.3) into
+    (registry-shaped overlay, policy keys)."""
+    registry_shape: dict = {}
+    policy: dict = {}
+    agent_tbl: dict = {}
+    for key, val in entry.items():
+        if key in _LIFTED_AGENT_KEYS:
+            agent_tbl[key] = val
+        elif key in _POLICY_AGENT_KEYS:
+            policy[key] = val
+        elif key in _AGENT_SUBTABLES and isinstance(val, dict):
+            registry_shape[key] = val
+    if agent_tbl:
+        registry_shape["agent"] = agent_tbl
+    return registry_shape, policy
+
+
+def _discover_levels(base: str, allowed_levels: list) -> dict:
+    """Per-backend level lists: shipped trio + filesystem-discovered customs.
+
+    Mirrors the dashboard's (former) three globs and agent-sandbox's own
+    fragment lookup order. A non-empty allowed_levels pins the set and skips
+    discovery (shells, gh#91).
+    """
+    if allowed_levels:
+        return {"agent-sandbox": list(allowed_levels), "nono": list(allowed_levels)}
+    by_backend: dict = {}
+    for backend in ("agent-sandbox", "nono"):
+        levels = list(SHIPPED_LEVELS)
+        extras: set[str] = set()
+        if backend == "agent-sandbox" and SANDBOX_PROFILES_DIR.is_dir():
+            for p in SANDBOX_PROFILES_DIR.glob("*.toml"):
+                stem = p.stem
+                if stem.startswith(f"{base}-"):
+                    extras.add(stem[len(base) + 1:])
+                else:
+                    # agent-agnostic candidate; stems that are actually other
+                    # agents' fragments are dropped by _filter_agent_agnostic
+                    extras.add(stem)
+        if backend == "nono" and NONO_PROFILES_DIR.is_dir():
+            prefix = f"lince-{base}-"
+            for p in NONO_PROFILES_DIR.glob(f"lince-{base}-*.json"):
+                extras.add(p.name[len(prefix):-len(".json")])
+        for level in sorted(extras):
+            if level not in levels:
+                levels.append(level)
+        by_backend[backend] = levels
+    return by_backend
+
+
+def _filter_agent_agnostic(levels_by_backend: dict, all_bases: list[str], base: str) -> dict:
+    """Drop discovered 'levels' that are actually other agents' fragments
+    (e.g. codex-paranoid.toml must not register a 'codex-paranoid' level for
+    claude)."""
+    out: dict = {}
+    other_prefixes = tuple(f"{b}-" for b in all_bases if b != base)
+    for backend, levels in levels_by_backend.items():
+        out[backend] = [
+            lv for lv in levels
+            if not lv.startswith(other_prefixes)
+        ] if other_prefixes else list(levels)
+    return out
+
+
+_LEVEL_ORDER = {"permissive": 0, "normal": 1, "paranoid": 2}
+
+
+def _derive_unsandboxed(name: str, entry: dict, env: dict) -> dict:
+    """§3.5 variant derivation over a (merged) registry-shaped entry.
+    `env` is the base agent's already-expanded, already-redacted env table
+    (variants inherit it verbatim)."""
+    agent = entry.get("agent", {})
+    dashboard = entry.get("dashboard", {})
+    exc = entry.get("variants", {}).get("unsandboxed", {})
+    binary = agent.get("binary", name)
+    label = str(agent.get("short_label", name[:3].upper()))
+    return {
+        "command": list(exc.get("command", [binary])),
+        "pane_title_pattern": exc.get("pane_title_pattern", binary),
+        "status_pipe_name": dashboard.get("status_pipe_name", "lince-status"),
+        "display_name": exc.get(
+            "display_name", agent.get("display_name", name) + " (unsandboxed)"
+        ),
+        "short_label": exc.get("short_label", label[:2].strip() + "U"),
+        "color": exc.get("color", "red"),
+        "sandboxed": False,
+        "has_native_hooks": bool(dashboard.get("has_native_hooks", False)),
+        "providers": list(dashboard.get("providers", [])),
+        "env": dict(env),
+        "event_map": dict(entry.get("event_map", {})),
+        "bwrap_conflict": bool(
+            exc.get("bwrap_conflict", entry.get("sandbox", {}).get("bwrap_conflict", False))
+        ),
+    }
+
+
+def _expand_provider_env_all(env: dict, providers: dict) -> dict:
+    out = {k: v for k, v in env.items() if k != "provider_env"}
+    if env.get("provider_env") == "all":
+        for prov in providers.values():
+            for var in prov.get("env", []):
+                out.setdefault(var, f"${var}")
+    return out
+
+
+def build_resolved_view(
+    project_dir: Path | None = None,
+    agent_filter: str | None = None,
+    flag_level: str | None = None,
+    flag_provider: str | None = None,
+    flag_backend: str | None = None,
+    flag_allow_hosts: list[str] | None = None,
+) -> tuple[dict | None, dict | None]:
+    """Build the §4.3 resolved view. Returns (view, error) — exactly one set.
+
+    Layering (§4.1): registry.d → variant derivation → user policy
+    (lince.toml when present, else dual-read of the legacy files per §5.2)
+    → project overlay → CLI flags.
+    """
+    import platform
+
+    warnings: list[str] = []
+    registry_dir = find_registry_dir()
+    if registry_dir is None:
+        return None, {
+            "code": "no-registry",
+            "message": "No registry.d/ found. Run sandbox/install.sh (or update.sh) "
+                       "to install the agent registry.",
+        }
+    registry_agents, providers_tbl = load_registry(registry_dir, warnings)
+
+    lince_exists = LINCE_CONFIG_PATH.is_file()
+    config_version = f"{SCHEMA_VERSION_NATIVE[0]}.{SCHEMA_VERSION_NATIVE[1]}"
+    guarantee = "default-deny"
+    network: dict = {"default": "deny", "allowed_hosts": []}
+    agent_policy: dict[str, dict] = {}     # name -> policy keys (level/provider/allowed_hosts)
+    agent_origin: dict[str, dict] = {}     # name -> {key: origin}
+    user_provider_names_by_agent: dict[str, list] = {}
+    user_provider_details: dict[str, dict] = {}  # name -> {env, env_unset}
+    default_provider: str | None = None
+
+    if lince_exists:
+        # v2 is the ONLY source (§5.2 hard switch).
+        lince = _load_toml_or_empty(LINCE_CONFIG_PATH, warnings)
+        version_issues = check_version_contract(lince.get("version"), str(LINCE_CONFIG_PATH))
+        hard = [i for i in version_issues if i["level"] == "error"]
+        if hard:
+            return None, {"code": "version", "message": hard[0]["message"]}
+        for i in version_issues:
+            warnings.append(i["message"])
+        config_version = str(lince.get("version"))
+        net = lince.get("network", {})
+        network["default"] = net.get("default", "deny")
+        network["allowed_hosts"] = list(net.get("allowed_hosts", []))
+        for name, prov in lince.get("providers", {}).items():
+            providers_tbl = _deep_overlay(providers_tbl, {name: prov})
+        for name, entry in lince.get("agents", {}).items():
+            if not isinstance(entry, dict):
+                warnings.append(f"[agents.{name}]: not a table — skipped")
+                continue
+            registry_shape, policy = _lince_agent_to_registry_shape(entry)
+            if name in registry_agents:
+                registry_agents[name] = _deep_overlay(registry_agents[name], registry_shape)
+            else:
+                issues = schema_validate(entry, _LINCE_AGENT_SCHEMA, f"agents.{name}", [])
+                missing = [
+                    k for k in ("binary", "display_name", "short_label", "color")
+                    if k not in entry
+                ]
+                if missing:
+                    warnings.append(
+                        f"[agents.{name}]: custom agent missing required key(s) "
+                        f"{', '.join(missing)} — skipped"
+                    )
+                    continue
+                if any(i["level"] == "error" for i in issues):
+                    warnings.append(
+                        f"[agents.{name}]: {issues[0]['message']} — skipped"
+                    )
+                    continue
+                registry_agents[name] = registry_shape
+            agent_policy[name] = policy
+            agent_origin[name] = {k: "user" for k in policy}
+        experimental = lince.get("experimental", {})
+        active = [k for k, v in experimental.items() if v not in (False, "", [], {}, None)]
+        if active:
+            guarantee = f"void:{active[0]}"
+        sb = lince.get("sandbox", {})
+        default_provider = sb.get("default_provider") or None
+        legacy_present = [
+            str(p) for p in (SANDBOX_CONFIG_PATH, DASHBOARD_CONFIG_PATH)
+            if p.is_file()
+        ]
+        if legacy_present:
+            warnings.append(
+                "legacy config files still present (ignored): "
+                + ", ".join(legacy_present)
+                + " — run `lince config migrate --purge` to clean up"
+            )
+    else:
+        # DUAL-READ (§5.2): synthesize the v2 view in-memory from legacy files.
+        sandbox_cfg = _load_toml_or_empty(SANDBOX_CONFIG_PATH, warnings)
+        if project_dir is not None:
+            local = _load_toml_or_empty(
+                Path(project_dir) / ".agent-sandbox" / "config.toml", warnings
+            )
+            if local:
+                sandbox_cfg = _deep_overlay(sandbox_cfg, local)
+        dashboard_cfg = _load_toml_or_empty(DASHBOARD_CONFIG_PATH, warnings)
+
+        security = sandbox_cfg.get("security", {})
+        network["allowed_hosts"] = list(security.get("allow_domains", []))
+        sb = sandbox_cfg.get("sandbox", {})
+        default_provider = sb.get("default_provider") or sb.get("default_profile") or None
+
+        # Legacy providers, with v1 per-agent attribution (resolve_providers
+        # semantics: legacy [profiles.*] and top-level [providers.*] belong
+        # to claude; [<agent>.providers/profiles.*] to that agent).
+        def _collect_providers(agent: str) -> dict:
+            merged: dict = {}
+            if agent == "claude":
+                for key in ("profiles", "providers"):
+                    tbl = sandbox_cfg.get(key)
+                    if isinstance(tbl, dict):
+                        merged.update(tbl)
+            section = sandbox_cfg.get(agent, {})
+            if isinstance(section, dict):
+                for key in ("profiles", "providers"):
+                    tbl = section.get(key)
+                    if isinstance(tbl, dict):
+                        merged.update(tbl)
+            return merged
+
+        for base in list(registry_agents):
+            provs = _collect_providers(base)
+            if provs:
+                user_provider_names_by_agent[base] = sorted(provs)
+                for pname, ptbl in provs.items():
+                    if not isinstance(ptbl, dict):
+                        continue
+                    user_provider_details[pname] = {
+                        "env": _redact_env(ptbl.get("env", {}) or {}),
+                        "env_unset": list(ptbl.get("env_unset", []) or []),
+                    }
+
+        # User [agents.*] overrides: sandbox config first (jail keys), then
+        # dashboard config (UI keys), both as per-field overlays (§5.5 end
+        # state — the full-entry-replacement footgun dies here).
+        for name, entry in (sandbox_cfg.get("agents", {}) or {}).items():
+            if not isinstance(entry, dict):
+                continue
+            overlay: dict = {}
+            agent_tbl = {}
+            if "command" in entry:
+                agent_tbl["binary"] = entry["command"]
+            if "default_args" in entry:
+                agent_tbl["default_args"] = entry["default_args"]
+            if agent_tbl:
+                overlay["agent"] = agent_tbl
+            sandbox_tbl = {
+                k: entry[k]
+                for k in ("home_ro_dirs", "home_rw_dirs", "bwrap_conflict",
+                          "disable_inner_sandbox_args")
+                if k in entry
+            }
+            if sandbox_tbl:
+                overlay["sandbox"] = sandbox_tbl
+            if isinstance(entry.get("env"), dict):
+                overlay["env"] = entry["env"]
+            if name in registry_agents:
+                registry_agents[name] = _deep_overlay(registry_agents[name], overlay)
+            elif overlay.get("agent", {}).get("binary"):
+                overlay.setdefault("agent", {}).setdefault("name", name)
+                overlay["agent"].setdefault("display_name", name)
+                overlay["agent"].setdefault("short_label", name[:3].upper())
+                overlay["agent"].setdefault("color", "blue")
+                registry_agents[name] = overlay
+        for name, entry in (dashboard_cfg.get("agents", {}) or {}).items():
+            if not isinstance(entry, dict):
+                continue
+            if name.endswith("-unsandboxed"):
+                base = name[: -len("-unsandboxed")]
+                if base in registry_agents:
+                    variant = {
+                        k: entry[k]
+                        for k in ("command", "bwrap_conflict", "display_name",
+                                  "short_label", "color", "pane_title_pattern")
+                        if k in entry
+                    }
+                    if variant:
+                        registry_agents[base] = _deep_overlay(
+                            registry_agents[base],
+                            {"variants": {"unsandboxed": variant}},
+                        )
+                    continue
+            overlay = {}
+            agent_tbl = {
+                rk: entry[lk]
+                for lk, rk in (
+                    ("display_name", "display_name"), ("short_label", "short_label"),
+                    ("color", "color"),
+                )
+                if lk in entry
+            }
+            if isinstance(entry.get("command"), list) and entry["command"]:
+                agent_tbl.setdefault("binary", entry["command"][0])
+            if agent_tbl:
+                overlay["agent"] = agent_tbl
+            dash_tbl = {
+                k: entry[k]
+                for k in ("pane_title_pattern", "status_pipe_name",
+                          "has_native_hooks", "providers")
+                if k in entry
+            }
+            # pre-#81 alias
+            if "profiles" in entry and "providers" not in dash_tbl:
+                dash_tbl["providers"] = entry["profiles"]
+            if dash_tbl:
+                overlay["dashboard"] = dash_tbl
+            sandbox_tbl = {}
+            if "sandbox_level" in entry:
+                agent_policy.setdefault(name, {})["level"] = entry["sandbox_level"]
+                agent_origin.setdefault(name, {})["level"] = "user"
+            if "sandbox_levels" in entry:
+                sandbox_tbl["allowed_levels"] = entry["sandbox_levels"]
+            if "sandbox_backend" in entry:
+                sandbox_tbl["backend"] = entry["sandbox_backend"]
+            if "sandbox_home_subdir" in entry:
+                sandbox_tbl["home_subdir"] = entry["sandbox_home_subdir"]
+            for k in ("bwrap_conflict", "disable_inner_sandbox_args",
+                      "home_ro_dirs", "home_rw_dirs"):
+                if k in entry:
+                    sandbox_tbl[k] = entry[k]
+            if sandbox_tbl:
+                overlay["sandbox"] = sandbox_tbl
+            if isinstance(entry.get("env_vars"), dict):
+                overlay["env"] = entry["env_vars"]
+            if isinstance(entry.get("event_map"), dict):
+                overlay["event_map"] = entry["event_map"]
+            if name in registry_agents:
+                registry_agents[name] = _deep_overlay(registry_agents[name], overlay)
+            else:
+                if not overlay.get("agent", {}).get("binary"):
+                    warnings.append(
+                        f"[agents.{name}] (dashboard config): custom agent has no "
+                        f"usable command — skipped"
+                    )
+                    continue
+                overlay["agent"].setdefault("name", name)
+                overlay["agent"].setdefault("display_name", name)
+                overlay["agent"].setdefault("short_label", name[:3].upper())
+                overlay["agent"].setdefault("color", "blue")
+                registry_agents[name] = overlay
+
+    # Project overlay (<project>/.lince/lince.toml, §2.4 — clamped).
+    if project_dir is not None:
+        overlay_path = Path(project_dir) / ".lince" / "lince.toml"
+        if overlay_path.is_file():
+            overlay_cfg = _load_toml_or_empty(overlay_path, warnings)
+            trusted = False
+            if lince_exists:
+                lince = _load_toml_or_empty(LINCE_CONFIG_PATH, [])
+                trust = lince.get("trust", {}).get("projects", {})
+                entry = trust.get(str(Path(project_dir).resolve()), {})
+                trusted = bool(entry.get("allow_loosening"))
+            if "experimental" in overlay_cfg and not trusted:
+                warnings.append(
+                    f"{overlay_path}: [experimental] ignored (untrusted overlay). "
+                    f'To allow: add [trust.projects."{Path(project_dir).resolve()}"] '
+                    f"allow_loosening = true to {LINCE_CONFIG_PATH}"
+                )
+            extra_hosts = list(overlay_cfg.get("network", {}).get("allowed_hosts", []))
+            if extra_hosts:
+                if trusted:
+                    for h in extra_hosts:
+                        if h not in network["allowed_hosts"]:
+                            network["allowed_hosts"].append(h)
+                else:
+                    warnings.append(
+                        f"{overlay_path}: extra allowed_hosts ignored (untrusted overlay). "
+                        f'To allow: add [trust.projects."{Path(project_dir).resolve()}"] '
+                        f"allow_loosening = true to {LINCE_CONFIG_PATH}"
+                    )
+            for name, entry in (overlay_cfg.get("agents", {}) or {}).items():
+                if not isinstance(entry, dict) or name not in registry_agents:
+                    continue
+                lvl = entry.get("level")
+                if lvl is not None:
+                    # Clamp against the EFFECTIVE level (user policy, else the
+                    # registry default) — never against "unset".
+                    current = agent_policy.get(name, {}).get("level") or (
+                        registry_agents[name].get("sandbox", {}).get("default_level", "normal")
+                    )
+                    cur_rank = _LEVEL_ORDER.get(current, -1)
+                    new_rank = _LEVEL_ORDER.get(lvl, -1)
+                    if trusted or new_rank >= cur_rank:
+                        agent_policy.setdefault(name, {})["level"] = lvl
+                        agent_origin.setdefault(name, {})["level"] = "project"
+                    else:
+                        warnings.append(
+                            f"{overlay_path}: looser level '{lvl}' for {name} ignored "
+                            f"(untrusted overlay)"
+                        )
+
+    # Provider availability (env NAMES checked against the host env; a
+    # configured literal value also counts as available).
+    providers_out: dict = {}
+    for pname in sorted(set(providers_tbl) | set(user_provider_details)):
+        shipped = providers_tbl.get(pname, {})
+        details = user_provider_details.get(pname, {})
+        env_map = dict(details.get("env", {}))
+        env_keys = sorted(set(shipped.get("env", [])) | set(env_map))
+        available = any(_env_available(k) for k in env_keys) or any(
+            not _is_env_self_ref(k, str(v)) and not str(v).startswith("$")
+            for k, v in env_map.items()
+        )
+        providers_out[pname] = {
+            "env_keys": env_keys,
+            "hosts": list(shipped.get("hosts", [])),
+            "available": available,
+            "env": env_map,
+            "env_unset": list(details.get("env_unset", [])),
+            "source": "user" if pname in user_provider_details else "registry",
+        }
+
+    # Assemble agents.
+    is_macos = platform.system() == "Darwin"
+    all_bases = sorted(registry_agents)
+    agents_out: dict = {}
+    for name in all_bases:
+        if agent_filter and name != agent_filter:
+            continue
+        entry = registry_agents[name]
+        agent = entry.get("agent", {})
+        sandbox = entry.get("sandbox", {})
+        dashboard = entry.get("dashboard", {})
+        policy = agent_policy.get(name, {})
+        origin = agent_origin.get(name, {})
+
+        backend = flag_backend or sandbox.get("backend", "auto")
+        if backend == "auto":
+            backend = "seatbelt" if is_macos else "bwrap"
+        level = flag_level or policy.get("level") or sandbox.get("default_level", "normal")
+        if flag_level:
+            origin = {**origin, "level": "flag"}
+        elif "level" not in origin:
+            origin = {**origin, "level": "registry"}
+        provider = flag_provider or policy.get("provider") or default_provider
+        if flag_provider:
+            origin = {**origin, "provider": "flag"}
+        elif "provider" not in origin:
+            origin = {**origin, "provider": "user" if policy.get("provider") or default_provider else "registry"}
+
+        env = _redact_env(_expand_provider_env_all(entry.get("env", {}), providers_tbl))
+        levels_by_backend = _filter_agent_agnostic(
+            _discover_levels(name, list(sandbox.get("allowed_levels", []))),
+            all_bases, name,
+        )
+        backend_key = "agent-sandbox" if backend in ("bwrap", "agent-sandbox") else backend
+        levels = levels_by_backend.get(backend_key) or list(SHIPPED_LEVELS)
+
+        # Per-agent provider list (window semantics: user-configured only, so
+        # every offered name resolves inside agent-sandbox's own config).
+        raw_providers = list(dashboard.get("providers", ["__discover__"]))
+        if raw_providers == ["__discover__"]:
+            providers_available = list(user_provider_names_by_agent.get(name, []))
+        else:
+            providers_available = [
+                p for p in raw_providers if p in providers_out
+            ] if raw_providers else []
+
+        allowed_hosts = list(network["allowed_hosts"])
+        for h in policy.get("allowed_hosts", []):
+            if h not in allowed_hosts:
+                allowed_hosts.append(h)
+        if flag_allow_hosts:
+            for h in flag_allow_hosts:
+                if h not in allowed_hosts:
+                    allowed_hosts.append(h)
+        if provider and provider in providers_out:
+            for h in providers_out[provider]["hosts"]:
+                if h not in allowed_hosts:
+                    allowed_hosts.insert(0, h)
+
+        agents_out[name] = {
+            "display_name": agent.get("display_name", name),
+            "short_label": agent.get("short_label", name[:3].upper()),
+            "color": agent.get("color", "blue"),
+            "binary": agent.get("binary", name),
+            "default_args": list(agent.get("default_args", [])),
+            "backend": backend,
+            "level": level,
+            "levels": levels,
+            "levels_by_backend": levels_by_backend,
+            "allowed_levels": list(sandbox.get("allowed_levels", [])),
+            "provider": provider,
+            "providers": raw_providers,
+            "providers_available": providers_available,
+            "command": [
+                "agent-sandbox", "run", "-p", "{project_dir}",
+                "--id", "{agent_id}", "--agent", name,
+            ],
+            "env": env,
+            "env_keys": sorted(env),
+            "event_map": dict(entry.get("event_map", {})),
+            "bwrap_conflict": bool(sandbox.get("bwrap_conflict", False)),
+            "disable_inner_sandbox_args": list(sandbox.get("disable_inner_sandbox_args", [])),
+            "home_subdir": sandbox.get("home_subdir", ""),
+            "dashboard": {
+                "pane_title_pattern": dashboard.get("pane_title_pattern", "agent-sandbox"),
+                "status_pipe_name": dashboard.get("status_pipe_name", "lince-status"),
+                "has_native_hooks": bool(dashboard.get("has_native_hooks", False)),
+                "sandboxed": True,
+            },
+            "variants": {"unsandboxed": _derive_unsandboxed(name, entry, env)},
+            "allowed_hosts_effective": allowed_hosts,
+            "origin": origin,
+        }
+
+    view = {
+        "schema": RESOLVE_SCHEMA,
+        "config_version": config_version,
+        "guarantee": guarantee,
+        "sources": {
+            "registry": [str(registry_dir)],
+            "user": str(LINCE_CONFIG_PATH) if lince_exists else None,
+            "legacy": None if lince_exists else [
+                str(p) for p in (SANDBOX_CONFIG_PATH, DASHBOARD_CONFIG_PATH) if p.is_file()
+            ],
+            "project": str(project_dir) if project_dir else None,
+        },
+        "network": network,
+        "providers": providers_out,
+        "agents": agents_out,
+        "warnings": warnings,
+    }
+    return view, None
+
+
+def cmd_resolve(args) -> int:
+    """Emit the fully-resolved configuration view as JSON (#202, §4.3)."""
+    view, error = build_resolved_view(
+        project_dir=Path(args.project).expanduser() if args.project else None,
+        agent_filter=args.agent,
+        flag_level=args.level,
+        flag_provider=args.provider,
+        flag_backend=args.backend,
+        flag_allow_hosts=args.allow_host or None,
+    )
+    if error is not None:
+        print(json.dumps({"error": error}, indent=2, sort_keys=True))
+        return 1
+    if args.agent and args.agent not in view["agents"]:
+        print(json.dumps({"error": {
+            "code": "unknown-agent",
+            "message": f"agent '{args.agent}' not found in the registry or user config",
+        }}, indent=2, sort_keys=True))
+        return 1
+    print(json.dumps(view, indent=2, sort_keys=True))
+    return 0
+
+
 def cmd_schema(args) -> int:
     """Print or write the published JSON Schemas (#203)."""
     if args.write:
@@ -1685,6 +2370,22 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _add_json_flag(p_validate)
     p_validate.set_defaults(func=cmd_validate)
+
+    # ── resolve ─────────────────────────────────────────────────
+    p_resolve = sub.add_parser(
+        "resolve",
+        help="Emit the fully-resolved configuration view as JSON (#202)",
+    )
+    p_resolve.add_argument("--json", "-j", action="store_true", default=True,
+                           help="JSON output (the only format; flag kept for clarity)")
+    p_resolve.add_argument("--agent", "-a", help="Restrict output to one agent")
+    p_resolve.add_argument("--project", "-p", help="Project directory (applies project overlays)")
+    p_resolve.add_argument("--level", help="Override isolation level (never persisted)")
+    p_resolve.add_argument("--provider", "-P", help="Override provider (never persisted)")
+    p_resolve.add_argument("--backend", help="Override backend (never persisted)")
+    p_resolve.add_argument("--allow-host", action="append", metavar="HOST",
+                           help="Extra allowed host (repeatable, never persisted)")
+    p_resolve.set_defaults(func=cmd_resolve)
 
     # ── schema ──────────────────────────────────────────────────
     p_schema = sub.add_parser("schema", help="Print or write the published JSON Schemas")

--- a/lince-dashboard/install.sh
+++ b/lince-dashboard/install.sh
@@ -336,6 +336,22 @@ AGENTS_TEMPLATE_SRC="$SCRIPT_DIR/agents-template.toml"
 AGENTS_TEMPLATE_DST="$CONFIG_DIR/agents-template.toml"
 USER_CONFIG="$CONFIG_DIR/config.toml"
 
+# lince-config is a runtime dependency since #202: the plugin obtains agent
+# types / providers / sandbox levels from `lince-config resolve --json`.
+# Install it from the sibling module when missing (idempotent); without it
+# the dashboard falls back to compiled-in shipped defaults.
+if ! command -v lince-config >/dev/null 2>&1 && [ ! -x "$HOME/.local/bin/lince-config" ]; then
+    if [ -x "$SCRIPT_DIR/../lince-config/install.sh" ]; then
+        echo -e "${YELLOW}  lince-config not found — installing from ../lince-config${NC}"
+        bash "$SCRIPT_DIR/../lince-config/install.sh" >/dev/null \
+            && echo -e "${GREEN}  ✓ lince-config installed${NC}" \
+            || echo -e "${YELLOW}  ⚠ lince-config install failed — dashboard will use built-in agent defaults${NC}"
+    else
+        echo -e "${YELLOW}  ⚠ lince-config not installed — dashboard will use built-in agent defaults.${NC}"
+        echo -e "${YELLOW}    Install it: cd ../lince-config && ./install.sh${NC}"
+    fi
+fi
+
 # Unified agent registry (Config v2, #204). Shipped data — always overwritten
 # (#199); custom agents never live here. Also installed by sandbox/install.sh
 # (same files, idempotent) so either module works standalone.

--- a/lince-dashboard/plugin/src/config.rs
+++ b/lince-dashboard/plugin/src/config.rs
@@ -273,9 +273,11 @@ pub struct DashboardConfig {
     /// then provider name.
     #[serde(skip)]
     pub provider_details_by_agent: HashMap<String, HashMap<String, ProviderDetails>>,
-    /// Path to sandbox config for provider auto-discovery.
-    /// Defaults to `~/.agent-sandbox/config.toml`.
+    /// Path to the sandbox config. Since #202 provider discovery happens in
+    /// `lince-config resolve` (which reads the canonical locations itself);
+    /// the key is kept so existing configs keep validating.
     #[serde(default)]
+    #[allow(dead_code)]
     pub sandbox_config_path: Option<String>,
     #[serde(default)]
     pub default_project_dir: Option<String>,
@@ -336,9 +338,9 @@ pub struct DashboardConfig {
     pub instance_icons: Vec<String>,
     /// Custom sandbox levels discovered from the filesystem, keyed by
     /// `<backend>:<base>` (e.g. `"nono:claude"` or `"agent-sandbox:claude"`).
-    /// Populated asynchronously by `discover_sandbox_levels_async()` reading
-    /// profile files matching `~/.config/nono/profiles/lince-<base>-*.json` and
-    /// `~/.agent-sandbox/profiles/<base>-*.toml`. Combined with the shipped
+    /// Populated from the `levels_by_backend` field of `lince-config
+    /// resolve --json` (#202; the resolver does the filesystem discovery
+    /// the plugin's shell globs used to do). Combined with the shipped
     /// `paranoid`/`normal`/`permissive` defaults by `supported_sandbox_levels()`.
     #[serde(skip)]
     pub discovered_sandbox_levels: HashMap<String, Vec<String>>,
@@ -443,11 +445,11 @@ pub fn common_prefix(items: &[String]) -> String {
 
 /// Context key for identifying RunCommandResult callbacks (shared with state_file).
 pub const CMD_TYPE_KEY: &str = "type";
-/// Command type for async provider discovery via `run_command` (was
-/// `CMD_DISCOVER_PROFILES` pre-#81).
-pub const CMD_DISCOVER_PROVIDERS: &str = "discover_providers";
-/// Command type for async loading of agent type defaults via `run_command`.
-pub const CMD_LOAD_AGENT_DEFAULTS: &str = "load_agent_defaults";
+/// Command type for the async `lince-config resolve --json` call (#202) —
+/// the single source for agent types, providers, and sandbox levels.
+/// Replaces the former `discover_providers` / `load_agent_defaults` /
+/// `discover_sandbox_levels` TOML-parsing pipeline.
+pub const CMD_RESOLVE_CONFIG: &str = "resolve_config";
 
 /// Run a command with a typed context map. Wraps the common
 /// BTreeMap + `run_command` boilerplate used across modules.
@@ -493,11 +495,6 @@ pub fn poll_status_files_async(status_dir: &str) {
     );
     run_typed_command(&["sh", "-c", &script], CMD_POLL_STATUS);
 }
-
-/// Command type for async discovery of custom sandbox-level profiles.
-/// Output format: lines of `<backend>:<base>:<level>` (or `<backend>:<base>:` for the
-/// suffix-less "normal" profile). See `discover_sandbox_levels_async()`.
-pub const CMD_DISCOVER_SANDBOX_LEVELS: &str = "discover_sandbox_levels";
 
 /// Command type for async transcript extraction for the relay feature.
 pub const CMD_EXTRACT_TRANSCRIPT: &str = "extract_transcript";
@@ -548,251 +545,265 @@ for m in msgs[-{count}:]:
     );
 }
 
-/// Extract provider details from a TOML table (the value side of a
-/// `[*.providers.<name>]` / `[*.profiles.<name>]` entry).
-fn parse_provider_details(table: &toml::Table) -> ProviderDetails {
-    let mut pd = ProviderDetails::default();
-    // Parse env vars to set
-    if let Some(env_table) = table.get("env").and_then(|v| v.as_table()) {
-        for (k, v) in env_table {
-            if let Some(s) = v.as_str() {
-                pd.env.insert(k.clone(), s.to_string());
-            }
-        }
-    }
-    // Parse env vars to unset
-    if let Some(unset_arr) = table.get("env_unset").and_then(|v| v.as_array()) {
-        for v in unset_arr {
-            if let Some(s) = v.as_str() {
-                pd.env_unset.push(s.to_string());
-            }
-        }
-    }
-    pd
-}
-
-/// Parse providers (env-var bundles) from sandbox config TOML content,
-/// returning per-agent-type maps.
-///
-/// Recognises four formats — canonical first, legacy second:
-///   - `[providers.<name>]`              → attributed to agent base "claude"
-///   - `[<agent>.providers.<name>]`      → attributed to `<agent>`
-///   - Legacy `[profiles.<name>]`        → attributed to "claude"
-///   - Legacy `[<agent>.profiles.<name>]` → attributed to `<agent>`
-///
-/// When both forms exist for the same agent + name, the canonical entry wins.
-/// Returns `(providers_by_agent, details_by_agent)`.
-pub fn parse_providers_from_toml(
-    content: &str,
-) -> (HashMap<String, Vec<String>>, HashMap<String, HashMap<String, ProviderDetails>>) {
-    let table: toml::Table = match toml::from_str(content) {
-        Ok(t) => t,
-        Err(_) => return (HashMap::new(), HashMap::new()),
-    };
-
-    let mut by_agent: HashMap<String, Vec<String>> = HashMap::new();
-    let mut details_by_agent: HashMap<String, HashMap<String, ProviderDetails>> = HashMap::new();
-
-    fn push_one(
-        agent: &str,
-        name: &str,
-        detail_table: Option<&toml::Table>,
-        by_agent: &mut HashMap<String, Vec<String>>,
-        details_by_agent: &mut HashMap<String, HashMap<String, ProviderDetails>>,
-    ) {
-        let names = by_agent.entry(agent.to_string()).or_default();
-        if !names.iter().any(|n| n == name) {
-            names.push(name.to_string());
-        }
-        // Last-wins semantics: a later (higher-precedence) call OVERWRITES the
-        // previous detail for the same agent + name. Match the Python reader's
-        // dict.update() behaviour so the same config produces the same env-var
-        // bundle on both sides — see the precedence comment below.
-        if let Some(t) = detail_table {
-            details_by_agent
-                .entry(agent.to_string())
-                .or_default()
-                .insert(name.to_string(), parse_provider_details(t));
-        }
-    }
-
-    // Process from LOWEST to HIGHEST precedence so the last write wins
-    // (matches `resolve_providers` in sandbox/agent-sandbox: legacy top →
-    // legacy ns → canonical top → canonical ns, with later layers replacing
-    // earlier ones for any colliding agent + name pair).
-    //
-    // 1) Legacy top-level [profiles.*]      → "claude"
-    // 2) Canonical top-level [providers.*]  → "claude"
-    for top_key in ["profiles", "providers"] {
-        if let Some(top) = table.get(top_key).and_then(|v| v.as_table()) {
-            for (name, value) in top {
-                push_one("claude", name, value.as_table(), &mut by_agent, &mut details_by_agent);
-            }
-        }
-    }
-    // 3) Legacy namespaced [<agent>.profiles.*]
-    // 4) Canonical namespaced [<agent>.providers.*] — highest precedence
-    for (agent_key, agent_value) in &table {
-        if agent_key == "providers" || agent_key == "profiles" {
-            continue;
-        }
-        let Some(agent_section) = agent_value.as_table() else { continue };
-        for sub_key in ["profiles", "providers"] {
-            if let Some(provs) = agent_section.get(sub_key).and_then(|v| v.as_table()) {
-                for (name, val) in provs {
-                    push_one(agent_key, name, val.as_table(), &mut by_agent, &mut details_by_agent);
-                }
-            }
-        }
-    }
-
-    // Sort each agent's provider names
-    for names in by_agent.values_mut() {
-        names.sort();
-    }
-
-    (by_agent, details_by_agent)
-}
-
 /// Escape a string for use inside single quotes in a shell command.
 pub fn shell_escape(s: &str) -> String {
     s.replace('\'', "'\\''")
 }
 
-/// Kick off async discovery of providers (env-var bundles) by reading sandbox
-/// config files via `run_command`. Results arrive in `Event::RunCommandResult`
-/// with context `type=discover_providers`. Was `discover_profiles_async`
-/// pre-#81 — see issue for naming rationale.
+/// Kick off the async `lince-config resolve --json` call (#202).
 ///
-/// Reads the global config and optionally a project-local config. Each file
-/// is cat'd separately and their outputs are joined by a NUL byte so the
-/// handler can parse them independently (avoiding invalid TOML from
-/// concatenating files with duplicate `[providers]` headers).
-pub fn discover_providers_async(sandbox_config_path: Option<&str>, launch_dir: Option<&str>) {
-    // Build the global config path for the shell script.
-    // IMPORTANT: We must NOT quote paths that start with `~` because the shell
-    // only performs tilde expansion on unquoted tildes.  `expand_tilde()` uses
-    // `std::env::var("HOME")` which is unavailable inside the WASI sandbox, so
-    // the tilde would be passed through literally.  Instead we let the shell
-    // handle `~` expansion by using `$HOME` in the script.
-    let raw_path = sandbox_config_path.unwrap_or("~/.agent-sandbox/config.toml");
-    let global_expr = shell_path_expr(raw_path);
-
-    // Output each file separated by NUL so the handler can split and parse independently.
-    let mut script = format!("cat {} 2>/dev/null", global_expr);
-
+/// The resolver is the single resolution point (design config-v2 §4.3): it
+/// merges registry.d, the legacy sandbox/dashboard user configs (dual-read
+/// window) or `~/.config/lince/lince.toml`, the project overlay, and the
+/// filesystem-discovered custom sandbox levels — so this plugin no longer
+/// parses any sandbox-owned TOML. Result arrives in
+/// `Event::RunCommandResult` with context `type=resolve_config` and is
+/// applied by `apply_resolved_view`.
+pub fn resolve_config_async(launch_dir: Option<&str>) {
+    // PATH inside the Zellij host shell may not include ~/.local/bin —
+    // prefer the PATH lookup, fall back to the canonical install location.
+    let mut script = String::from(
+        "LC=\"$(command -v lince-config || echo \"$HOME/.local/bin/lince-config\")\"; \
+         \"$LC\" resolve --json",
+    );
     if let Some(dir) = launch_dir {
-        let local_path = format!(
-            "{}/.agent-sandbox/config.toml",
-            dir.trim_end_matches('/')
-        );
-        script = format!(
-            "{} ; printf '\\0' ; cat '{}' 2>/dev/null",
-            script,
-            shell_escape(&local_path)
-        );
+        script.push_str(&format!(" --project '{}'", shell_escape(dir)));
     }
-
-    run_typed_command(&["sh", "-c", &script], CMD_DISCOVER_PROVIDERS);
+    run_typed_command(&["sh", "-c", &script], CMD_RESOLVE_CONFIG);
 }
 
-/// Kick off async discovery of custom sandbox-level profile files.
-///
-/// Globs:
-/// - `~/.config/nono/profiles/lince-<base>-*.json` (nono: per-agent only)
-/// - `~/.agent-sandbox/profiles/<base>-<level>.toml` (agent-sandbox: per-agent)
-/// - `~/.agent-sandbox/profiles/<level>.toml` (agent-sandbox: agent-agnostic,
-///   matches agent-sandbox's own resolution order — see its source for the
-///   comment "tried as <agent>-<level>.toml then <level>.toml"). Agent-agnostic
-///   levels are emitted once per known base so the cache is populated uniformly.
-///
-/// Filenames are emitted as `<backend>:<base>:<level>` lines on stdout.
-/// Result arrives in `Event::RunCommandResult` with context
-/// `type=discover_sandbox_levels`; the handler parses and populates
-/// `DashboardConfig.discovered_sandbox_levels`.
-pub fn discover_sandbox_levels_async(bases: &[String]) {
-    if bases.is_empty() {
-        return;
-    }
-    let mut script = String::new();
-    // Per-base globs: nono (always per-agent) + agent-sandbox <base>-<level>.toml.
-    for base in bases {
-        let b = shell_escape(base);
-        script.push_str(&format!(
-            "find \"$HOME/.config/nono/profiles\" -maxdepth 1 -type f \
-                -name 'lince-{base}-*.json' 2>/dev/null \
-                | sed -n 's|.*/lince-{base}-\\(.*\\)\\.json$|nono:{base}:\\1|p';\n",
-            base = b,
-        ));
-        script.push_str(&format!(
-            "find \"$HOME/.agent-sandbox/profiles\" -maxdepth 1 -type f \
-                -name '{base}-*.toml' 2>/dev/null \
-                | sed -n 's|.*/{base}-\\(.*\\)\\.toml$|agent-sandbox:{base}:\\1|p';\n",
-            base = b,
-        ));
-    }
-    // Agent-agnostic agent-sandbox profiles: any *.toml whose stem doesn't start
-    // with `<known-base>-`. Each such level applies to ALL bases, so we emit one
-    // line per base. Skip-patterns are quoted shell `case` patterns built from
-    // the same base list to avoid double-counting per-base files.
-    let bases_quoted: Vec<String> = bases.iter().map(|b| format!("'{}'", shell_escape(b))).collect();
-    let skip_patterns: Vec<String> = bases.iter().map(|b| format!("{}-*", shell_escape(b))).collect();
-    script.push_str(&format!(
-        "find \"$HOME/.agent-sandbox/profiles\" -maxdepth 1 -type f -name '*.toml' 2>/dev/null \
-         | while IFS= read -r f; do \
-             name=$(basename \"$f\" .toml); \
-             case \"$name\" in {skip}) continue;; esac; \
-             for base in {bases}; do \
-                 printf 'agent-sandbox:%s:%s\\n' \"$base\" \"$name\"; \
-             done; \
-         done\n",
-        skip = skip_patterns.join("|"),
-        bases = bases_quoted.join(" "),
-    ));
-    run_typed_command(&["sh", "-c", &script], CMD_DISCOVER_SANDBOX_LEVELS);
+/// The resolve --json contract (design config-v2 §4.3), reduced to the fields
+/// this plugin consumes. Unknown fields are ignored (forward compat); every
+/// field is defaulted so partial output degrades instead of failing.
+#[derive(Deserialize)]
+pub struct ResolvedView {
+    /// "default-deny", or "void:<key>" when an [experimental] hatch is
+    /// active (I5). Not yet rendered — the #221 effective-policy badge
+    /// consumes it.
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub guarantee: String,
+    #[serde(default)]
+    pub providers: HashMap<String, ResolvedProvider>,
+    #[serde(default)]
+    pub agents: HashMap<String, ResolvedAgent>,
+    #[serde(default)]
+    pub warnings: Vec<String>,
 }
 
-/// Parse the stdout of `discover_sandbox_levels_async()` into a
-/// `<backend>:<base> -> [level, ...]` map. Empty / malformed lines are skipped.
-pub fn parse_discovered_sandbox_levels(stdout: &[u8]) -> HashMap<String, Vec<String>> {
-    let output = String::from_utf8_lossy(stdout);
-    let mut out: HashMap<String, Vec<String>> = HashMap::new();
-    for line in output.lines() {
-        // Format: backend:base:level — parse from the right so base names with
-        // `-` (none today, future-proofing) survive.
-        let mut parts = line.splitn(3, ':');
-        let backend = match parts.next() { Some(s) if !s.is_empty() => s, _ => continue };
-        let base = match parts.next() { Some(s) if !s.is_empty() => s, _ => continue };
-        let level = match parts.next() { Some(s) if !s.is_empty() => s, _ => continue };
-        let key = format!("{}:{}", backend, base);
-        let bucket = out.entry(key).or_default();
-        if !bucket.iter().any(|l| l == level) {
-            bucket.push(level.to_string());
+/// Provider entry: env-var NAMES (secret values are redacted to `$NAME`
+/// self-references by the resolver — I4; the spawn path skips those and the
+/// value is inherited from the host environment).
+#[derive(Deserialize, Default)]
+pub struct ResolvedProvider {
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+    #[serde(default)]
+    pub env_unset: Vec<String>,
+    /// Whether any of the provider's env names is set in the host env.
+    /// Informational for now (wizard filtering is a follow-up).
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub available: bool,
+}
+
+#[derive(Deserialize, Default)]
+pub struct ResolvedAgentDashboard {
+    #[serde(default)]
+    pub pane_title_pattern: String,
+    #[serde(default)]
+    pub status_pipe_name: String,
+    #[serde(default)]
+    pub has_native_hooks: bool,
+}
+
+#[derive(Deserialize, Default)]
+pub struct ResolvedVariant {
+    #[serde(default)]
+    pub command: Vec<String>,
+    #[serde(default)]
+    pub pane_title_pattern: String,
+    #[serde(default)]
+    pub status_pipe_name: String,
+    #[serde(default)]
+    pub display_name: String,
+    #[serde(default)]
+    pub short_label: String,
+    #[serde(default)]
+    pub color: String,
+    #[serde(default)]
+    pub has_native_hooks: bool,
+    #[serde(default)]
+    pub providers: Vec<String>,
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+    #[serde(default)]
+    pub event_map: HashMap<String, String>,
+    #[serde(default)]
+    pub bwrap_conflict: bool,
+}
+
+#[derive(Deserialize)]
+pub struct ResolvedAgent {
+    #[serde(default)]
+    pub display_name: String,
+    #[serde(default)]
+    pub short_label: String,
+    #[serde(default)]
+    pub color: String,
+    #[serde(default)]
+    pub backend: String,
+    #[serde(default)]
+    pub level: Option<String>,
+    #[serde(default)]
+    pub levels_by_backend: HashMap<String, Vec<String>>,
+    #[serde(default)]
+    pub allowed_levels: Vec<String>,
+    #[serde(default)]
+    pub providers: Vec<String>,
+    #[serde(default)]
+    pub providers_available: Vec<String>,
+    #[serde(default)]
+    pub command: Vec<String>,
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+    #[serde(default)]
+    pub event_map: HashMap<String, String>,
+    #[serde(default)]
+    pub bwrap_conflict: bool,
+    #[serde(default)]
+    pub disable_inner_sandbox_args: Vec<String>,
+    #[serde(default)]
+    pub home_subdir: String,
+    #[serde(default)]
+    pub dashboard: ResolvedAgentDashboard,
+    #[serde(default)]
+    pub variants: HashMap<String, ResolvedVariant>,
+}
+
+fn backend_from_str(s: &str) -> SandboxBackend {
+    match s {
+        "seatbelt" | "sandbox-exec" => SandboxBackend::Seatbelt,
+        "nono" => SandboxBackend::Nono,
+        // "bwrap" / "agent-sandbox" / "auto" / anything unknown
+        _ => SandboxBackend::AgentSandbox,
+    }
+}
+
+const SHIPPED_LEVELS: [&str; 3] = ["paranoid", "normal", "permissive"];
+
+/// Apply a `lince-config resolve --json` payload to the dashboard config:
+/// agent types (base + derived variants), per-agent providers + details,
+/// and the per-backend custom sandbox-level cache. Returns the resolver
+/// warnings on success.
+pub fn apply_resolved_view(
+    config: &mut DashboardConfig,
+    json_text: &str,
+) -> Result<Vec<String>, String> {
+    let view: ResolvedView = serde_json::from_str(json_text.trim())
+        .map_err(|e| format!("resolve JSON parse error: {}", e))?;
+    if view.agents.is_empty() {
+        return Err("resolve returned no agents".to_string());
+    }
+
+    let mut agent_types: HashMap<String, AgentTypeConfig> = HashMap::new();
+    let mut providers_by_agent: HashMap<String, Vec<String>> = HashMap::new();
+    let mut details_by_agent: HashMap<String, HashMap<String, ProviderDetails>> = HashMap::new();
+    let mut discovered: HashMap<String, Vec<String>> = HashMap::new();
+
+    for (name, agent) in &view.agents {
+        agent_types.insert(
+            name.clone(),
+            AgentTypeConfig {
+                command: agent.command.clone(),
+                pane_title_pattern: if agent.dashboard.pane_title_pattern.is_empty() {
+                    DEFAULT_SANDBOX_COMMAND.to_string()
+                } else {
+                    agent.dashboard.pane_title_pattern.clone()
+                },
+                status_pipe_name: agent.dashboard.status_pipe_name.clone(),
+                display_name: agent.display_name.clone(),
+                short_label: agent.short_label.clone(),
+                color: agent.color.clone(),
+                sandboxed: true,
+                env_vars: agent.env.clone(),
+                has_native_hooks: agent.dashboard.has_native_hooks,
+                home_ro_dirs: Vec::new(),
+                home_rw_dirs: Vec::new(),
+                bwrap_conflict: agent.bwrap_conflict,
+                disable_inner_sandbox_args: agent.disable_inner_sandbox_args.clone(),
+                event_map: agent.event_map.clone(),
+                providers: agent.providers.clone(),
+                sandbox_backend: backend_from_str(&agent.backend),
+                sandbox_level: agent.level.clone(),
+                sandbox_levels: agent.allowed_levels.clone(),
+                sandbox_home_subdir: if agent.home_subdir.is_empty() {
+                    None
+                } else {
+                    Some(agent.home_subdir.clone())
+                },
+            },
+        );
+        for (variant, v) in &agent.variants {
+            agent_types.insert(
+                format!("{}-{}", name, variant),
+                AgentTypeConfig {
+                    command: v.command.clone(),
+                    pane_title_pattern: v.pane_title_pattern.clone(),
+                    status_pipe_name: v.status_pipe_name.clone(),
+                    display_name: v.display_name.clone(),
+                    short_label: v.short_label.clone(),
+                    color: v.color.clone(),
+                    sandboxed: false,
+                    env_vars: v.env.clone(),
+                    has_native_hooks: v.has_native_hooks,
+                    home_ro_dirs: Vec::new(),
+                    home_rw_dirs: Vec::new(),
+                    bwrap_conflict: v.bwrap_conflict,
+                    disable_inner_sandbox_args: Vec::new(),
+                    event_map: v.event_map.clone(),
+                    providers: v.providers.clone(),
+                    sandbox_backend: SandboxBackend::None,
+                    sandbox_level: None,
+                    sandbox_levels: Vec::new(),
+                    sandbox_home_subdir: None,
+                },
+            );
+        }
+        if !agent.providers_available.is_empty() {
+            providers_by_agent.insert(name.clone(), agent.providers_available.clone());
+            let details = details_by_agent.entry(name.clone()).or_default();
+            for pname in &agent.providers_available {
+                if let Some(p) = view.providers.get(pname) {
+                    details.insert(
+                        pname.clone(),
+                        ProviderDetails {
+                            env: p.env.clone(),
+                            env_unset: p.env_unset.clone(),
+                        },
+                    );
+                }
+            }
+        }
+        // Per-backend custom levels (extras beyond the shipped trio) feed the
+        // same cache the filesystem globs used to populate.
+        for (backend_key, levels) in &agent.levels_by_backend {
+            let extras: Vec<String> = levels
+                .iter()
+                .filter(|l| !SHIPPED_LEVELS.contains(&l.as_str()))
+                .cloned()
+                .collect();
+            if !extras.is_empty() {
+                discovered.insert(format!("{}:{}", backend_key, name), extras);
+            }
         }
     }
-    out
-}
 
-/// Kick off async loading of agent type defaults from
-/// `~/.config/lince-dashboard/agents-defaults.toml` via `run_command`.
-/// Results arrive in `Event::RunCommandResult` with context
-/// `type=load_agent_defaults`.
-///
-/// The shell reads the defaults file first, then (separated by NUL) any
-/// `[agents.*]` sections from the user's dashboard config.toml so they can
-/// be merged.  User entries override defaults (full replacement per key).
-pub fn load_agent_defaults_async(_sandbox_config_path: Option<&str>) {
-    let defaults_path = "\"$HOME/.config/lince-dashboard/agents-defaults.toml\"";
-    let user_cfg_path = "\"$HOME/.config/lince-dashboard/config.toml\"";
-
-    // Output defaults first, then NUL, then user dashboard config (which may
-    // contain [agents.*]).
-    let script = format!(
-        "cat {} 2>/dev/null ; printf '\\0' ; cat {} 2>/dev/null",
-        defaults_path, user_cfg_path
-    );
-
-    run_typed_command(&["sh", "-c", &script], CMD_LOAD_AGENT_DEFAULTS);
+    config.agent_types = agent_types;
+    config.providers_by_agent = providers_by_agent;
+    config.provider_details_by_agent = details_by_agent;
+    config.discovered_sandbox_levels = discovered;
+    Ok(view.warnings)
 }
 
 /// TOML wrapper for user config.toml `[agents.<name>]` sections.
@@ -802,13 +813,13 @@ struct UserAgentsSection {
     agents: HashMap<String, AgentTypeConfig>,
 }
 
-/// Parse agent type defaults from the stdout of `load_agent_defaults_async`.
+/// Parse agent type definitions from `[agents.<name>]` TOML content.
 ///
-/// The output consists of two NUL-separated chunks:
-///   1. Contents of `agents-defaults.toml` (`[agents.<name>]` tables)
-///   2. Contents of user `config.toml` (may contain `[agents.<name>]` tables)
-///
-/// User entries override defaults (full replacement per agent type key).
+/// Since #202 the live agent types come from `lince-config resolve --json`
+/// (`apply_resolved_view`); this parser remains only for the compiled-in
+/// shipped defaults (`embedded_agent_types` / `embedded_event_maps` fallback,
+/// #198) and tests. Input is up to two NUL-separated chunks; entries in the
+/// second chunk fully replace same-named entries from the first.
 pub fn parse_agent_defaults(stdout: &[u8]) -> HashMap<String, AgentTypeConfig> {
     let chunks: Vec<&[u8]> = stdout.split(|&b| b == 0).collect();
 
@@ -916,8 +927,9 @@ impl DashboardConfig {
     /// Returns `(config, error)` where `error` is `Some(msg)` if reading or
     /// parsing failed (in which case `config` holds all defaults).
     ///
-    /// Provider auto-discovery happens asynchronously via `discover_providers_async()`
-    /// after the plugin has permissions and knows the launch directory.
+    /// Agent types and providers arrive asynchronously via
+    /// `resolve_config_async()` (#202) after the plugin has permissions and
+    /// knows the launch directory.
     ///
     /// # Manual testing
     ///
@@ -939,29 +951,6 @@ impl DashboardConfig {
         }
     }
 
-
-    /// Merge discovered per-agent-type providers, deduplicating.
-    pub fn merge_providers(
-        &mut self,
-        by_agent: &HashMap<String, Vec<String>>,
-        details_by_agent: &HashMap<String, HashMap<String, ProviderDetails>>,
-    ) {
-        for (agent, names) in by_agent {
-            let existing = self.providers_by_agent.entry(agent.clone()).or_default();
-            for name in names {
-                if !existing.contains(name) {
-                    existing.push(name.clone());
-                }
-            }
-            existing.sort();
-        }
-        for (agent, details) in details_by_agent {
-            let existing = self.provider_details_by_agent.entry(agent.clone()).or_default();
-            for (name, detail) in details {
-                existing.entry(name.clone()).or_insert_with(|| detail.clone());
-            }
-        }
-    }
 
     /// Resolve the effective provider list for a given agent type.
     ///
@@ -995,8 +984,8 @@ impl DashboardConfig {
     /// Return the supported sandbox levels for a given agent type and backend.
     ///
     /// Combines the shipped defaults (`paranoid`, `normal`, `permissive`) with
-    /// custom levels discovered from the filesystem (see
-    /// `discover_sandbox_levels_async()`). The standard order is preserved;
+    /// custom levels discovered by the resolver (see
+    /// `resolve_config_async()` / `apply_resolved_view()`). The standard order is preserved;
     /// custom levels are appended in alphabetical order. Duplicates are
     /// removed.
     ///
@@ -1029,8 +1018,8 @@ impl DashboardConfig {
             "permissive".to_string(),
         ];
         if let Some(b) = backend {
-            // Cache key MUST match the prefix that `discover_sandbox_levels_async`
-            // emits ("agent-sandbox:" / "nono:") — NOT `display_name()`, which
+            // Cache key MUST match the backend key that `apply_resolved_view`
+            // stores ("agent-sandbox:" / "nono:") — NOT `display_name()`, which
             // returns "bwrap" for AgentSandbox and would silently miss the cache.
             // `None` has no custom-profile concept (no fs lookup), so skip.
             use crate::sandbox_backend::SandboxBackend;
@@ -1188,6 +1177,20 @@ impl DashboardConfig {
     }
 }
 
+/// Full agent-type definitions for the built-in agents, parsed once from the
+/// shipped `agents-defaults.toml` baked into the binary at compile time.
+/// Last-resort fallback (#198 precedent) when `lince-config resolve --json`
+/// is unavailable or fails — the dashboard stays usable with shipped
+/// defaults instead of an empty agent picker.
+pub fn embedded_agent_types() -> &'static HashMap<String, AgentTypeConfig> {
+    static TYPES: std::sync::OnceLock<HashMap<String, AgentTypeConfig>> =
+        std::sync::OnceLock::new();
+    TYPES.get_or_init(|| {
+        const SHIPPED: &str = include_str!("../../agents-defaults.toml");
+        parse_agent_defaults(SHIPPED.as_bytes())
+    })
+}
+
 /// Event maps for the built-in agents, parsed once from the shipped
 /// `agents-defaults.toml` baked into the binary at compile time. Used as a
 /// fallback by `event_map_for` so a stale or partial on-disk config can't
@@ -1233,31 +1236,112 @@ mod tests {
         assert_eq!(claude.providers, vec!["__discover__"]);
     }
 
-    /// Sandbox config dual-read: namespaced canonical `[<agent>.providers.X]`
-    /// must beat top-level legacy `[profiles.X]` for the same name. Matches
-    /// the precedence implemented by `resolve_providers` in
-    /// `sandbox/agent-sandbox` (legacy → canonical, last wins).
+    /// A full resolve --json payload maps onto the plugin structures: base +
+    /// variant agent types, per-agent providers with details, and the
+    /// per-backend custom-level cache. (Provider precedence itself is the
+    /// Python resolver's job now — covered by scripts/tests/test_resolve.py.)
     #[test]
-    fn namespaced_canonical_overrides_top_level_legacy() {
-        let toml_text = r#"
-            [profiles.zai]
-            description = "from-legacy-top"
-            [profiles.zai.env]
-            ANTHROPIC_BASE_URL = "https://legacy.example.com"
-
-            [claude.providers.zai]
-            description = "from-canonical-ns"
-            [claude.providers.zai.env]
-            ANTHROPIC_BASE_URL = "https://canonical.example.com"
-        "#;
-        let (_names, details) = parse_providers_from_toml(toml_text);
-        let claude = details.get("claude").expect("claude bucket");
-        let zai = claude.get("zai").expect("zai entry");
+    fn apply_resolved_view_populates_config() {
+        let json = r#"{
+            "guarantee": "default-deny",
+            "providers": {
+                "zai": {
+                    "env": {"ANTHROPIC_BASE_URL": "https://api.z.ai/api/anthropic",
+                             "ANTHROPIC_API_KEY": "$ANTHROPIC_API_KEY"},
+                    "env_unset": ["CLAUDE_CODE_OAUTH_TOKEN"],
+                    "available": true
+                }
+            },
+            "agents": {
+                "claude": {
+                    "display_name": "Claude Code",
+                    "short_label": "CLA",
+                    "color": "blue",
+                    "backend": "bwrap",
+                    "level": "paranoid",
+                    "levels_by_backend": {
+                        "agent-sandbox": ["paranoid", "normal", "permissive", "strict"],
+                        "nono": ["paranoid", "normal", "permissive"]
+                    },
+                    "allowed_levels": [],
+                    "providers": ["__discover__"],
+                    "providers_available": ["zai"],
+                    "command": ["agent-sandbox", "run", "-p", "{project_dir}",
+                                 "--id", "{agent_id}", "--agent", "claude"],
+                    "env": {},
+                    "event_map": {"Stop": "input"},
+                    "bwrap_conflict": false,
+                    "disable_inner_sandbox_args": [],
+                    "home_subdir": ".claude",
+                    "dashboard": {"pane_title_pattern": "agent-sandbox",
+                                   "status_pipe_name": "claude-status",
+                                   "has_native_hooks": true},
+                    "variants": {
+                        "unsandboxed": {
+                            "command": ["claude"],
+                            "pane_title_pattern": "claude",
+                            "status_pipe_name": "claude-status",
+                            "display_name": "Claude Code (unsandboxed)",
+                            "short_label": "CLU",
+                            "color": "red",
+                            "has_native_hooks": true,
+                            "providers": ["__discover__"],
+                            "env": {},
+                            "event_map": {"Stop": "input"},
+                            "bwrap_conflict": false
+                        }
+                    }
+                }
+            },
+            "warnings": []
+        }"#;
+        let mut cfg = DashboardConfig::parse_toml("[dashboard]\n").0;
+        let warnings = apply_resolved_view(&mut cfg, json).expect("apply should succeed");
+        assert!(warnings.is_empty());
+        let claude = cfg.agent_types.get("claude").expect("claude type");
+        assert!(claude.sandboxed);
+        assert_eq!(claude.sandbox_level.as_deref(), Some("paranoid"));
+        assert_eq!(claude.status_pipe_name, "claude-status");
+        assert_eq!(claude.sandbox_home_subdir.as_deref(), Some(".claude"));
+        assert!(matches!(claude.sandbox_backend, SandboxBackend::AgentSandbox));
+        let clu = cfg.agent_types.get("claude-unsandboxed").expect("variant type");
+        assert!(!clu.sandboxed);
+        assert_eq!(clu.command, vec!["claude"]);
+        assert_eq!(clu.short_label, "CLU");
+        // provider plumbing
+        assert_eq!(cfg.providers_by_agent.get("claude").unwrap(), &vec!["zai".to_string()]);
+        let details = cfg.provider_details_by_agent.get("claude").unwrap();
+        assert_eq!(details.get("zai").unwrap().env_unset, vec!["CLAUDE_CODE_OAUTH_TOKEN"]);
+        // secrets arrive as $NAME self-refs only (I4) — spawn path skips them
         assert_eq!(
-            zai.env.get("ANTHROPIC_BASE_URL").map(String::as_str),
-            Some("https://canonical.example.com"),
-            "namespaced canonical must replace top-level legacy",
+            details.get("zai").unwrap().env.get("ANTHROPIC_API_KEY").map(String::as_str),
+            Some("$ANTHROPIC_API_KEY"),
         );
+        // custom-level cache: only the extras beyond the shipped trio
+        assert_eq!(
+            cfg.discovered_sandbox_levels.get("agent-sandbox:claude").unwrap(),
+            &vec!["strict".to_string()],
+        );
+        assert!(cfg.discovered_sandbox_levels.get("nono:claude").is_none());
+    }
+
+    /// An empty / malformed resolve payload must fail loudly so the caller
+    /// can fall back to the embedded shipped defaults.
+    #[test]
+    fn apply_resolved_view_rejects_empty_and_malformed() {
+        let mut cfg = DashboardConfig::parse_toml("[dashboard]\n").0;
+        assert!(apply_resolved_view(&mut cfg, "{}").is_err());
+        assert!(apply_resolved_view(&mut cfg, "not json").is_err());
+    }
+
+    /// The compiled-in fallback parses to a non-empty agent set with event
+    /// maps (the dashboard must stay usable without lince-config installed).
+    #[test]
+    fn embedded_agent_types_nonempty() {
+        let types = embedded_agent_types();
+        assert!(types.contains_key("claude"));
+        assert!(types.contains_key("claude-unsandboxed"));
+        assert!(!types.get("claude").unwrap().event_map.is_empty());
     }
 
     /// `default_agent_type` (gh#62) round-trips through TOML so the `n`
@@ -1280,26 +1364,6 @@ mod tests {
         let (cfg, err) = DashboardConfig::parse_toml("[dashboard]\n");
         assert!(err.is_none(), "parse error: {err:?}");
         assert!(cfg.default_agent_type.is_none());
-    }
-
-    /// Both forms in the same file must each contribute their distinct
-    /// providers without dropping anything. Uses an explicit name list assert
-    /// so a regression in iteration order would still surface a missing entry.
-    #[test]
-    fn legacy_and_canonical_coexist() {
-        let toml_text = r#"
-            [profiles.legacyOnly]
-            [profiles.legacyOnly.env]
-            X = "1"
-
-            [claude.providers.canonicalOnly]
-            [claude.providers.canonicalOnly.env]
-            Y = "2"
-        "#;
-        let (names, _details) = parse_providers_from_toml(toml_text);
-        let mut claude = names.get("claude").cloned().unwrap_or_default();
-        claude.sort();
-        assert_eq!(claude, vec!["canonicalOnly", "legacyOnly"]);
     }
 
     /// Verify that an unknown agent type (e.g. "zai") parses with

--- a/lince-dashboard/plugin/src/main.rs
+++ b/lince-dashboard/plugin/src/main.rs
@@ -293,15 +293,10 @@ impl ZellijPlugin for State {
                     Some(CMD_GET_CWD) if exit_code == Some(0) => {
                         let dir = String::from_utf8_lossy(&stdout).trim().to_string();
                         if !dir.is_empty() {
-                            // Kick off async provider discovery (reads sandbox config via shell).
-                            config::discover_providers_async(
-                                self.config.sandbox_config_path.as_deref(),
-                                Some(&dir),
-                            );
-                            // Kick off async load of agent type defaults.
-                            config::load_agent_defaults_async(
-                                self.config.sandbox_config_path.as_deref(),
-                            );
+                            // Kick off the single async resolution call (#202):
+                            // agent types + providers + sandbox levels all come
+                            // from `lince-config resolve --json`.
+                            config::resolve_config_async(Some(&dir));
                             // Kick off async load of saved state.
                             state_file::load_state_async(&dir);
                             self.launch_dir = Some(dir);
@@ -345,48 +340,51 @@ impl ZellijPlugin for State {
                         // Nothing to do, just acknowledge.
                         false
                     }
-                    Some(config::CMD_DISCOVER_PROVIDERS) => {
-                        // Each config file's output is separated by NUL.
-                        // Parse each independently to avoid duplicate-section TOML errors.
-                        for chunk in stdout.split(|&b| b == 0) {
-                            if chunk.is_empty() { continue; }
-                            let content = String::from_utf8_lossy(chunk);
-                            let (by_agent, details_by_agent) = config::parse_providers_from_toml(&content);
-                            self.config.merge_providers(&by_agent, &details_by_agent);
+                    Some(config::CMD_RESOLVE_CONFIG) => {
+                        // Single resolution point (#202): agent types, providers,
+                        // and custom sandbox levels all arrive in one JSON payload
+                        // from `lince-config resolve --json`.
+                        let mut applied = false;
+                        if exit_code == Some(0) && !stdout.is_empty() {
+                            let content = String::from_utf8_lossy(&stdout);
+                            match config::apply_resolved_view(&mut self.config, &content) {
+                                Ok(warnings) => {
+                                    applied = true;
+                                    if let Some(w) = warnings.first() {
+                                        self.config_error =
+                                            Some(format!("config: {}", w));
+                                    }
+                                }
+                                Err(e) => {
+                                    self.config_error = Some(format!(
+                                        "lince-config resolve: {} — using built-in defaults",
+                                        e
+                                    ));
+                                }
+                            }
+                        } else {
+                            let err = String::from_utf8_lossy(&stderr);
+                            self.config_error = Some(format!(
+                                "lince-config resolve failed ({}) — using built-in defaults. \
+                                 Install it: lince-config/install.sh",
+                                err.trim().lines().last().unwrap_or("not found")
+                            ));
                         }
-                        true
-                    }
-                    Some(config::CMD_LOAD_AGENT_DEFAULTS) => {
-                        let agent_types = config::parse_agent_defaults(&stdout);
-                        if !agent_types.is_empty() {
-                            self.config.agent_types = agent_types;
+                        if !applied && self.config.agent_types.is_empty() {
+                            // Last-resort fallback (#198 precedent): compiled-in
+                            // shipped defaults keep the dashboard usable.
+                            self.config.agent_types = config::embedded_agent_types().clone();
                         }
                         self.agent_types_loaded = true;
-                        // Pre-warm the custom sandbox-level cache now that we know the
-                        // bases. Discovery is async and idempotent — the wizard re-fires
-                        // it on open as a refresh, but doing it here means the cache is
-                        // usually populated before the user ever presses N.
-                        let bases: Vec<String> = self.config.base_agents()
-                            .into_iter().map(|(b, _)| b).collect();
-                        config::discover_sandbox_levels_async(&bases);
                         // Flush any buffered restore that was waiting for agent types.
                         if let Some(saved_agents) = self.pending_restore.take() {
                             self.restore_agents(saved_agents);
                         }
-                        true
-                    }
-                    Some(config::CMD_DISCOVER_SANDBOX_LEVELS) => {
-                        if exit_code == Some(0) {
-                            // Replace entire cache: each discovery call covers all
-                            // bases × both backends atomically. A profile removed
-                            // since the last run won't appear in the new map and
-                            // would otherwise stick around as a stale level.
-                            self.config.discovered_sandbox_levels =
-                                config::parse_discovered_sandbox_levels(&stdout);
-                            // Refresh the wizard's level list ONLY if the user hasn't
-                            // moved past SandboxLevel yet — otherwise we'd risk
-                            // clobbering an already-confirmed choice if discovery
-                            // shifted the list (e.g., file removed mid-wizard).
+                        // Refresh the wizard's level list ONLY if the user hasn't
+                        // moved past SandboxLevel yet — otherwise we'd risk
+                        // clobbering an already-confirmed choice if resolution
+                        // shifted the list (e.g., profile file removed mid-wizard).
+                        if applied {
                             if let Some(ref mut wizard) = self.wizard {
                                 let on_or_before_level = matches!(
                                     wizard.step,
@@ -825,10 +823,10 @@ impl State {
                     .and_then(|dp| available_providers.iter().position(|p| p == dp))
                     .unwrap_or(0);
                 // Sandbox levels follow the canonical sandboxed entry (skipped when backend = None).
-                // Levels are backend-aware: discovered custom levels from
-                // `~/.config/nono/profiles/` and `~/.agent-sandbox/profiles/` are merged with
-                // the standard 3. Discovery is async — the cache may be empty at this point;
-                // CMD_DISCOVER_SANDBOX_LEVELS handler refreshes the wizard when results arrive.
+                // Levels are backend-aware: custom levels discovered by the resolver
+                // (lince-config resolve --json) are merged with the standard 3.
+                // Resolution is async — the cache may be empty at this point;
+                // the CMD_RESOLVE_CONFIG handler refreshes the wizard when results arrive.
                 let default_backend = available_sandbox_backends.get(sandbox_backend_index);
                 let available_sandbox_levels = self.config.supported_sandbox_levels(default_base, default_backend);
                 let sandbox_level_index = {
@@ -838,10 +836,8 @@ impl State {
                         .and_then(|p| available_sandbox_levels.iter().position(|l| l == p))
                         .unwrap_or(0)
                 };
-                // Kick off async discovery for ALL bases (cache covers any future wizard moves).
-                let discover_bases: Vec<String> = self.config.base_agents()
-                    .into_iter().map(|(b, _)| b).collect();
-                config::discover_sandbox_levels_async(&discover_bases);
+                // Re-run resolution as a refresh (covers custom levels added since boot).
+                config::resolve_config_async(self.launch_dir.as_deref());
                 // #167: seed the default name from the (possibly pre-filled)
                 // project dir basename. Recomputed when the user changes the
                 // ProjectDir field (which now precedes the Name step).

--- a/lince-dashboard/update.sh
+++ b/lince-dashboard/update.sh
@@ -119,6 +119,20 @@ echo -e "${GREEN}[7/8] Updating agent defaults...${NC}"
 AGENTS_DEFAULTS_SRC="$SCRIPT_DIR/agents-defaults.toml"
 AGENTS_DEFAULTS_DST="$CONFIG_DIR/agents-defaults.toml"
 
+# lince-config is a runtime dependency since #202 (resolve --json). Refresh
+# it from the sibling module so the plugin and resolver stay in step.
+if [ -x "$SCRIPT_DIR/../lince-config/update.sh" ] && \
+   { command -v lince-config >/dev/null 2>&1 || [ -x "$HOME/.local/bin/lince-config" ]; }; then
+    bash "$SCRIPT_DIR/../lince-config/update.sh" >/dev/null \
+        && echo -e "${GREEN}  ✓ lince-config updated${NC}" \
+        || echo -e "${YELLOW}  ⚠ lince-config update failed — run ../lince-config/update.sh manually${NC}"
+elif [ -x "$SCRIPT_DIR/../lince-config/install.sh" ]; then
+    echo -e "${YELLOW}  lince-config not found — installing from ../lince-config${NC}"
+    bash "$SCRIPT_DIR/../lince-config/install.sh" >/dev/null \
+        && echo -e "${GREEN}  ✓ lince-config installed${NC}" \
+        || echo -e "${YELLOW}  ⚠ lince-config install failed — dashboard will use built-in agent defaults${NC}"
+fi
+
 # Unified agent registry (Config v2, #204). Shipped data — always overwritten
 # (#199); custom agents never live here. Also updated by sandbox/update.sh.
 REGISTRY_SRC="$SCRIPT_DIR/../registry.d"

--- a/scripts/tests/test_resolve.py
+++ b/scripts/tests/test_resolve.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Tests for `lince-config resolve --json` (#202, design §4.3).
+
+Run with:
+    python3 scripts/tests/test_resolve.py
+"""
+
+import importlib.machinery
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def load_lince_config_module():
+    path = REPO_ROOT / "lince-config" / "lince-config"
+    spec = importlib.util.spec_from_loader(
+        "lince_config_resolve_test",
+        importlib.machinery.SourceFileLoader("lince_config_resolve_test", str(path)),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class ResolveTestCase(unittest.TestCase):
+    """Each test runs against the repo registry.d plus a scratch fake $HOME."""
+
+    def setUp(self):
+        self.lc = load_lince_config_module()
+        self.tmp = tempfile.TemporaryDirectory()
+        root = Path(self.tmp.name)
+        self.sandbox_cfg = root / "agent-sandbox-config.toml"
+        self.dashboard_cfg = root / "dashboard-config.toml"
+        self.lince_cfg = root / "lince" / "lince.toml"
+        self.profiles_dir = root / "profiles"
+        self.nono_dir = root / "nono-profiles"
+        # Redirect every filesystem touchpoint into the scratch dir.
+        self.lc.LINCE_REGISTRY_DIRS = [REPO_ROOT / "registry.d"]
+        self.lc.LINCE_CONFIG_PATH = self.lince_cfg
+        self.lc.SANDBOX_CONFIG_PATH = self.sandbox_cfg
+        self.lc.DASHBOARD_CONFIG_PATH = self.dashboard_cfg
+        self.lc.SANDBOX_PROFILES_DIR = self.profiles_dir
+        self.lc.NONO_PROFILES_DIR = self.nono_dir
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def resolve(self, **kwargs):
+        view, error = self.lc.build_resolved_view(**kwargs)
+        self.assertIsNone(error, f"unexpected resolve error: {error}")
+        return view
+
+    # ── dual-read: registry only ────────────────────────────────────────
+
+    def test_registry_only_view(self):
+        view = self.resolve()
+        self.assertEqual(view["guarantee"], "default-deny")
+        self.assertIsNone(view["sources"]["user"])
+        # all 10 shipped agents present
+        self.assertIn("claude", view["agents"])
+        self.assertIn("aider", view["agents"])
+        claude = view["agents"]["claude"]
+        self.assertEqual(claude["binary"], "claude")
+        self.assertEqual(claude["level"], "normal")
+        self.assertEqual(claude["origin"]["level"], "registry")
+        self.assertEqual(claude["event_map"]["Stop"], "input")
+        self.assertEqual(claude["dashboard"]["status_pipe_name"], "claude-status")
+        # variant derivation incl. the codex exception
+        self.assertEqual(view["agents"]["codex"]["variants"]["unsandboxed"]["command"],
+                         ["codex", "--full-auto"])
+        self.assertFalse(view["agents"]["codex"]["variants"]["unsandboxed"]["bwrap_conflict"])
+        self.assertEqual(claude["variants"]["unsandboxed"]["command"], ["claude"])
+        self.assertEqual(claude["variants"]["unsandboxed"]["short_label"], "CLU")
+        # pi: provider_env = "all" expanded to $NAME self-refs (names only)
+        pi_env = view["agents"]["pi"]["env"]
+        self.assertEqual(pi_env.get("ANTHROPIC_API_KEY"), "$ANTHROPIC_API_KEY")
+        self.assertNotIn("provider_env", pi_env)
+        self.assertEqual(view["agents"]["pi"]["variants"]["unsandboxed"]["env"], pi_env)
+        # shells pin their level set
+        self.assertEqual(view["agents"]["bash"]["levels"], ["normal"])
+
+    # ── dual-read: legacy user configs ──────────────────────────────────
+
+    def test_legacy_sandbox_overrides_and_providers(self):
+        self.sandbox_cfg.write_text(
+            '[sandbox]\ndefault_provider = "vertex"\n'
+            '[security]\nallow_domains = ["pypi.org"]\n'
+            '[agents.claude]\ndefault_args = ["--continue"]\n'
+            '[providers.vertex]\n'
+            'env = { CLOUD_ML_REGION = "us-east5", ANTHROPIC_API_KEY = "sk-ant-LITERALSECRET123456" }\n'
+            '[codex.providers.work]\nenv = { OPENAI_API_KEY = "$OPENAI_API_KEY" }\n',
+            encoding="utf-8",
+        )
+        view = self.resolve()
+        claude = view["agents"]["claude"]
+        # per-field overlay: default_args replaced, everything else intact
+        self.assertEqual(claude["default_args"], ["--continue"])
+        self.assertEqual(claude["display_name"], "Claude Code")
+        # provider attribution: vertex → claude, work → codex
+        self.assertEqual(claude["providers_available"], ["vertex"])
+        self.assertEqual(view["agents"]["codex"]["providers_available"], ["work"])
+        # default provider + allowed hosts
+        self.assertEqual(claude["provider"], "vertex")
+        self.assertIn("pypi.org", claude["allowed_hosts_effective"])
+        # secrets never cross (I4): the literal key is redacted to $NAME
+        vertex = view["providers"]["vertex"]
+        self.assertEqual(vertex["env"]["ANTHROPIC_API_KEY"], "$ANTHROPIC_API_KEY")
+        self.assertEqual(vertex["env"]["CLOUD_ML_REGION"], "us-east5")
+        self.assertTrue(vertex["available"])  # literal non-secret value configured
+        self.assertNotIn("LITERALSECRET", json.dumps(view))
+
+    def test_legacy_dashboard_custom_agent_and_level(self):
+        self.dashboard_cfg.write_text(
+            '[agents.claude]\nsandbox_level = "paranoid"\n'
+            '[agents.bob]\n'
+            'command = ["bob", "--go"]\n'
+            'display_name = "Bob CLI"\nshort_label = "BOB"\ncolor = "magenta"\n'
+            'pane_title_pattern = "bob"\nstatus_pipe_name = "lince-status"\n'
+            'sandboxed = true\n'
+            '[agents.bob.event_map]\nturn_end = "input"\n',
+            encoding="utf-8",
+        )
+        view = self.resolve()
+        self.assertEqual(view["agents"]["claude"]["level"], "paranoid")
+        self.assertEqual(view["agents"]["claude"]["origin"]["level"], "user")
+        bob = view["agents"]["bob"]
+        self.assertEqual(bob["binary"], "bob")
+        self.assertEqual(bob["display_name"], "Bob CLI")
+        self.assertEqual(bob["event_map"], {"turn_end": "input"})
+        # derived variant for free
+        self.assertEqual(bob["variants"]["unsandboxed"]["short_label"], "BOU")
+        self.assertEqual(bob["variants"]["unsandboxed"]["color"], "red")
+
+    def test_malformed_custom_agent_fails_that_agent_only(self):
+        self.dashboard_cfg.write_text(
+            '[agents.broken]\ndisplay_name = "No Command"\n'
+            '[agents.claude]\nsandbox_level = "paranoid"\n',
+            encoding="utf-8",
+        )
+        view = self.resolve()
+        self.assertNotIn("broken", view["agents"])
+        self.assertIn("claude", view["agents"])
+        self.assertTrue(any("broken" in w for w in view["warnings"]))
+
+    def test_custom_level_discovery(self):
+        self.profiles_dir.mkdir(parents=True)
+        (self.profiles_dir / "claude-strict.toml").write_text("[security]\n", encoding="utf-8")
+        (self.profiles_dir / "relaxed.toml").write_text("[security]\n", encoding="utf-8")
+        (self.profiles_dir / "codex-hard.toml").write_text("[security]\n", encoding="utf-8")
+        self.nono_dir.mkdir(parents=True)
+        (self.nono_dir / "lince-claude-nstrict.json").write_text("{}", encoding="utf-8")
+        view = self.resolve()
+        claude = view["agents"]["claude"]
+        self.assertEqual(
+            claude["levels_by_backend"]["agent-sandbox"],
+            ["paranoid", "normal", "permissive", "relaxed", "strict"],
+        )
+        self.assertIn("nstrict", claude["levels_by_backend"]["nono"])
+        # codex-hard is codex's fragment, not an agnostic level for claude
+        self.assertNotIn("codex-hard", claude["levels_by_backend"]["agent-sandbox"])
+        self.assertIn("hard", view["agents"]["codex"]["levels_by_backend"]["agent-sandbox"])
+        # shells keep their pin regardless of discovery
+        self.assertEqual(view["agents"]["bash"]["levels"], ["normal"])
+
+    # ── v2 path: lince.toml ─────────────────────────────────────────────
+
+    def write_lince(self, content: str):
+        self.lince_cfg.parent.mkdir(parents=True, exist_ok=True)
+        self.lince_cfg.write_text(content, encoding="utf-8")
+
+    def test_lince_toml_is_the_only_source(self):
+        self.sandbox_cfg.write_text(
+            '[agents.claude]\ndefault_args = ["--legacy-should-be-ignored"]\n',
+            encoding="utf-8",
+        )
+        self.write_lince(
+            'version = "2.0"\n'
+            '[network]\nallowed_hosts = ["pypi.org"]\n'
+            '[agents.claude]\nlevel = "paranoid"\nprovider = "anthropic"\n'
+            'allowed_hosts = ["github.com"]\n'
+        )
+        view = self.resolve()
+        claude = view["agents"]["claude"]
+        # legacy file ignored entirely (§5.2 hard switch) + notice emitted
+        self.assertEqual(claude["default_args"], ["--dangerously-skip-permissions"])
+        self.assertTrue(any("migrate" in w for w in view["warnings"]))
+        self.assertEqual(claude["level"], "paranoid")
+        self.assertEqual(claude["origin"]["level"], "user")
+        self.assertEqual(claude["provider"], "anthropic")
+        hosts = claude["allowed_hosts_effective"]
+        self.assertIn("pypi.org", hosts)
+        self.assertIn("github.com", hosts)
+        # provider hosts auto-added when selected
+        self.assertIn("api.anthropic.com", hosts)
+
+    def test_lince_toml_version_contract_fails_closed(self):
+        self.write_lince('version = "2.9"\n')
+        view, error = self.lc.build_resolved_view()
+        self.assertIsNone(view)
+        self.assertEqual(error["code"], "version")
+        self.assertIn("newer lince", error["message"])
+
+    def test_lince_missing_version_is_hard_error(self):
+        self.write_lince('[network]\ndefault = "deny"\n')
+        view, error = self.lc.build_resolved_view()
+        self.assertIsNone(view)
+        self.assertIn('Add: version = "2.0"', error["message"])
+
+    def test_experimental_voids_guarantee(self):
+        self.write_lince('version = "2.0"\n[experimental]\npermissive_network = true\n')
+        view = self.resolve()
+        self.assertEqual(view["guarantee"], "void:permissive_network")
+
+    def test_custom_agent_in_lince_toml(self):
+        self.write_lince(
+            'version = "2.0"\n'
+            '[agents.bob]\n'
+            'binary = "bob"\ndisplay_name = "Bob CLI"\nshort_label = "BOB"\n'
+            'color = "magenta"\nprovider = "openai"\nlevel = "normal"\n'
+            '[agents.bob.dashboard]\nhas_native_hooks = false\n'
+            '[agents.bob.event_map]\nturn_end = "input"\n'
+        )
+        view = self.resolve()
+        bob = view["agents"]["bob"]
+        self.assertEqual(bob["display_name"], "Bob CLI")
+        self.assertEqual(bob["event_map"], {"turn_end": "input"})
+        self.assertEqual(bob["variants"]["unsandboxed"]["short_label"], "BOU")
+
+    def test_malformed_lince_custom_agent_fails_that_agent_only(self):
+        self.write_lince(
+            'version = "2.0"\n'
+            '[agents.broken]\ncolor = "red"\n'   # missing binary/display/label
+            '[agents.claude]\nlevel = "paranoid"\n'
+        )
+        view = self.resolve()
+        self.assertNotIn("broken", view["agents"])
+        self.assertEqual(view["agents"]["claude"]["level"], "paranoid")
+        self.assertTrue(any("broken" in w for w in view["warnings"]))
+
+    # ── project overlay clamp (§2.4) ────────────────────────────────────
+
+    def test_project_overlay_tighten_applies_loosen_clamped(self):
+        self.write_lince('version = "2.0"\n[agents.claude]\nlevel = "normal"\n')
+        project = Path(self.tmp.name) / "proj"
+        (project / ".lince").mkdir(parents=True)
+        (project / ".lince" / "lince.toml").write_text(
+            '[agents.claude]\nlevel = "paranoid"\n'
+            '[agents.codex]\nlevel = "permissive"\n'
+            '[network]\nallowed_hosts = ["sketchy.example"]\n',
+            encoding="utf-8",
+        )
+        view = self.resolve(project_dir=project)
+        # tighten (normal → paranoid): applied silently
+        self.assertEqual(view["agents"]["claude"]["level"], "paranoid")
+        self.assertEqual(view["agents"]["claude"]["origin"]["level"], "project")
+        # loosen (normal → permissive): ignored with a notice
+        self.assertEqual(view["agents"]["codex"]["level"], "normal")
+        self.assertNotIn("sketchy.example",
+                         view["agents"]["claude"]["allowed_hosts_effective"])
+        self.assertTrue(any("allow_loosening" in w for w in view["warnings"]))
+
+    # ── misc contract ───────────────────────────────────────────────────
+
+    def test_agent_filter(self):
+        view = self.resolve(agent_filter="gemini")
+        self.assertEqual(list(view["agents"]), ["gemini"])
+
+    def test_cli_flags_override(self):
+        view = self.resolve(flag_level="paranoid", flag_allow_hosts=["crates.io"])
+        self.assertEqual(view["agents"]["claude"]["level"], "paranoid")
+        self.assertEqual(view["agents"]["claude"]["origin"]["level"], "flag")
+        self.assertIn("crates.io", view["agents"]["claude"]["allowed_hosts_effective"])
+
+    def test_output_is_json_serializable_and_deterministic(self):
+        a = json.dumps(self.resolve(), sort_keys=True)
+        b = json.dumps(self.resolve(), sort_keys=True)
+        self.assertEqual(a, b)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #202. Part of epic #200 / m-16. Implements design `docs/design/config-v2-design.md` §4.3 (resolve contract), §4.1 (layering), §5.2 (dual-read), §2.4 (clamped project overlay). Builds on #204 (registry) and #203 (version contract).

## Python — `lince-config resolve --json`

The single resolution point, consumed by the dashboard via `run_command` (WASI: no direct fs reads):

- **Layering (§4.1)**: `registry.d` → §3.5 variant derivation → `~/.config/lince/lince.toml` when it exists (**hard switch**, legacy ignored with a migrate notice; version contract enforced — structured `{"error":{...}}` + exit 1 on violation) **or** dual-read of the legacy files (sandbox global + project config incl. `[profiles.*]`/`[<agent>.providers.*]` attribution, dashboard `[agents.*]`) → project overlay → CLI flags (`--level/--provider/--backend/--allow-host`, never persisted).
- **User `[agents.<shipped>]` entries are per-field overlays** — the `config.rs:829` full-entry-replacement footgun is fixed by centralizing resolution here (§5.5 end state). A malformed custom agent fails *that agent only* with a named warning.
- **Secrets never cross (I4)**: providers carry env-var **names**; any secret-looking *value* (key-name keywords or credential patterns) is redacted to its `$NAME` self-reference — which the dashboard spawn path already skips, so the value is inherited from the host env. Non-secret literals (base URLs, regions) still flow, keeping zai-style providers working unsandboxed. Asserted by test (`LITERALSECRET` never appears in the JSON).
- **Level discovery** moves here: shipped trio + customs from `~/.agent-sandbox/profiles/` (per-agent and agent-agnostic, cross-agent stems excluded) and `~/.config/nono/profiles/lince-<base>-*.json`, per backend.
- **Project overlay clamped (§2.4)**: tighten applies silently; looser level / extra hosts / `[experimental]` ignored with the exact `[trust.projects."<path>"] allow_loosening = true` line named.
- Additive fields vs the §4.3 example (documented): `providers_available` (per-agent resolved list — **user-configured providers only** during the window, so every name offered by the wizard resolves inside agent-sandbox's `-P`), `levels_by_backend`, `allowed_levels`, provider `env`/`env_unset` (redacted), `env` on agents.
- Merge semantics note: lists append **only** for accumulation keys (`allowed_hosts`, `home_*_dirs`, `passthrough`, …); launch vectors like `default_args` replace — otherwise an override could never *remove* `--dangerously-skip-permissions`.

## Rust — the plugin no longer parses sandbox-owned TOML

- Deleted: `parse_providers_from_toml`, `parse_provider_details`, `discover_providers_async` (config cat'ing), `discover_sandbox_levels_async` + `parse_discovered_sandbox_levels` (the three shell globs), `load_agent_defaults_async`, `merge_providers`.
- One `resolve_config_async()` call (boot + wizard-open refresh) → `apply_resolved_view()` populates `agent_types` (base + variants), `providers_by_agent` + details, and the per-backend custom-level cache. The wizard/spawn/status code is untouched.
- **Resilience**: compiled-in shipped defaults (`embedded_agent_types`, extending the #198 embedded event_map fallback) keep the dashboard usable if `lince-config` is missing/fails, with a status warning naming the fix.
- `install.sh`/`update.sh`: lince-config is now a runtime dependency — installed/refreshed from the sibling module (idempotent), warn-and-degrade otherwise.

## How to test it

```
$ python3 scripts/tests/test_resolve.py            → Ran 15 tests … OK
$ python3 scripts/tests/test_schemas.py            → Ran 17 tests … OK
$ python3 scripts/tests/test_registry_sync.py      → Ran 7 tests … OK
$ python3 scripts/tests/test_config_merge.py       → Ran 14 tests … OK
$ ruff check lince-config/lince-config scripts/tests/test_resolve.py → All checks passed!

$ lince-config resolve --json | python3 -c "<contract check>"
contract OK: 10 agents, 19 providers, guarantee = default-deny

# WASM build (per CLAUDE.md):
$ cargo build --target wasm32-wasip1               → Finished, 0 warnings

# Plugin unit tests (NOTE: `cargo test` on the host target fails to link
# zellij host imports on main too — pre-existing. Ran the suite under
# wasmtime with a host-fn stub instead):
$ cargo test --target wasm32-wasip1 --no-run
$ wasmtime run --preload zellij=stub.wat …lince_dashboard….wasm
test result: ok. 58 passed; 0 failed   (includes new apply_resolved_view tests)

$ lince-dashboard/tests/event-map-coverage.sh      → All event_map entries are canonical…
$ lince-dashboard/tests/hook-contract.sh           → All hook contract checks passed.
$ bash -n lince-dashboard/{install,update}.sh      → OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)