### PR TITLE
feat(sandbox): effective-policy attestation record + dashboard badge (#221)

### DIFF
--- a/docs/design/config-v2-design.md
+++ b/docs/design/config-v2-design.md
@@ -464,11 +464,12 @@ spike shim.
 | Field | Meaning |
 |---|---|
 | `backend` | enforcing backend used for this launch (bwrap / seatbelt / nono / landlock) |
-| `requested` | isolation level + filesystem/network policy refs (the `<hash8>` slices, §4.2) |
+| `requested` | isolation level + filesystem/network policy refs (symbolic descriptions until the §4.2 generated-artifacts pipeline lands, then the `<hash8>` slices) |
 | `landlock_abi` | Landlock ABI detected at launch (0 = unavailable) |
 | `fs_enforced` / `net_enforced` | whether the requested fs / net rules were actually applied |
 | `net_limitation` | `"port-only"` \| `"host-unaware"` \| `"unavailable"` \| absent — what the net layer cannot express (e.g. ABI v4 must never pretend to enforce host allowlists, §2.2) |
 | `bwrap_args_digest` | digest of the `.args` artifact fed to bwrap |
+| `profile_digest` | digest of the backend profile content (Seatbelt runtime `.sb`), where the launch vector is a profile rather than args |
 | `helper_version` / `helper_digest` | Landlock helper version + binary digest |
 | `applied_before_exec` | rules in place before the agent process exec'd |
 | `inherited_by_subprocesses` | **verified** (child-process probe), not assumed |

--- a/lince-dashboard/plugin/src/agent.rs
+++ b/lince-dashboard/plugin/src/agent.rs
@@ -613,6 +613,7 @@ fn spawn_inner(
         sandbox_level: resolved_sandbox_level,
         sandbox_backend: resolved_sandbox_backend,
         transcript_path: None,
+        enforced: None,
         icon,
     })
 }
@@ -834,6 +835,7 @@ mod tests {
             sandbox_level: None,
             sandbox_backend: None,
             transcript_path: None,
+            enforced: None,
             icon: icon.to_string(),
         }
     }

--- a/lince-dashboard/plugin/src/config.rs
+++ b/lince-dashboard/plugin/src/config.rs
@@ -487,11 +487,18 @@ pub const CMD_POLL_STATUS: &str = "poll_status";
 /// `Event::RunCommandResult` with context `type=poll_status`.
 pub fn poll_status_files_async(status_dir: &str) {
     let dir = shell_escape(status_dir);
+    // Two line shapes share one poll (one fork per tick, not two):
+    //   `<basename>\t<event>`            — agent status from .state files
+    //   `POLICY\t<id>\t<json>`           — effective-policy record (#221)
+    //                                      from <id>.policy.json
     let script = format!(
-        "for f in '{}'/*.state; do [ -f \"$f\" ] || continue; \
+        "for f in '{dir}'/*.state; do [ -f \"$f\" ] || continue; \
          printf '%s\\t%s\\n' \"$(basename \"$f\" .state)\" \
+         \"$(tr -d '\\n' < \"$f\" 2>/dev/null)\"; done; \
+         for f in '{dir}'/*.policy.json; do [ -f \"$f\" ] || continue; \
+         printf 'POLICY\\t%s\\t%s\\n' \"$(basename \"$f\" .policy.json)\" \
          \"$(tr -d '\\n' < \"$f\" 2>/dev/null)\"; done",
-        dir
+        dir = dir
     );
     run_typed_command(&["sh", "-c", &script], CMD_POLL_STATUS);
 }

--- a/lince-dashboard/plugin/src/dashboard.rs
+++ b/lince-dashboard/plugin/src/dashboard.rs
@@ -523,7 +523,17 @@ fn render_agent_table(
                             pad_left("NOSB", col_sandbox)
                         } else {
                             let backend = agent.sandbox_backend.as_ref().unwrap_or(&cfg.sandbox_backend);
-                            pad_left(backend.display_name(), col_sandbox)
+                            // '!' = the effective-policy record (#221) says a
+                            // requested boundary was NOT enforced for this run.
+                            let degraded = agent
+                                .enforced
+                                .as_ref()
+                                .map_or(false, |p| !p.fully_enforced());
+                            if degraded {
+                                pad_left(&format!("{}!", backend.display_name()), col_sandbox)
+                            } else {
+                                pad_left(backend.display_name(), col_sandbox)
+                            }
                         }
                     } else {
                         pad_left("-", col_sandbox)
@@ -693,6 +703,28 @@ fn render_detail_panel(agent: &AgentInfo, cols: usize, max_rows: usize, agent_ty
         let profile = agent.sandbox_level.as_deref().unwrap_or("(default)");
         println!(" {}Profile:{} {}", CYAN, RESET, profile);
         row += 1;
+    }
+    // Effective-policy badge (#221): the boundary the kernel actually
+    // enforced for THIS run (requested view = `lince config resolve`).
+    if row < max_rows {
+        if let Some(ref p) = agent.enforced {
+            let color = if p.fully_enforced() { "\x1b[32m" } else { "\x1b[1;33m" };
+            let mut extra = String::new();
+            if let Some(ref lim) = p.net_limitation {
+                if lim != "unavailable" {
+                    extra.push_str(&format!(" net:{}", lim));
+                }
+            }
+            if let Some(ref reason) = p.degraded_reason {
+                extra.push_str(&format!(" \x1b[1;33m{}\x1b[0m", reason));
+            }
+            let line = format!(
+                " {}Enforced:{} {}{}{} [{}]{}",
+                CYAN, RESET, color, p.badge(), RESET, p.backend, extra,
+            );
+            println!("{}", truncate(&line, cols));
+            row += 1;
+        }
     }
     if row < max_rows {
         let provider = agent.provider.as_deref().unwrap_or("(default)");

--- a/lince-dashboard/plugin/src/main.rs
+++ b/lince-dashboard/plugin/src/main.rs
@@ -477,7 +477,18 @@ impl ZellijPlugin for State {
                         let output = String::from_utf8_lossy(&stdout);
                         let mut file_events: std::collections::HashMap<&str, &str> =
                             std::collections::HashMap::new();
+                        // Effective-policy records (#221): `POLICY\t<id>\t<json>`.
+                        let mut policy_records: std::collections::HashMap<&str, &str> =
+                            std::collections::HashMap::new();
                         for line in output.lines() {
+                            if let Some(rest) = line.strip_prefix("POLICY\t") {
+                                if let Some((id, json)) = rest.split_once('\t') {
+                                    if !json.trim().is_empty() {
+                                        policy_records.insert(id, json);
+                                    }
+                                }
+                                continue;
+                            }
                             if let Some((name, event)) = line.split_once('\t') {
                                 let event = event.trim();
                                 if !event.is_empty() {
@@ -487,6 +498,14 @@ impl ZellijPlugin for State {
                         }
                         let mut changed = false;
                         for agent in self.agents.iter_mut() {
+                            if let Some(json) = policy_records.get(agent.id.as_str()) {
+                                if let Ok(p) = serde_json::from_str::<types::EnforcedPolicy>(json) {
+                                    if agent.enforced.as_ref() != Some(&p) {
+                                        agent.enforced = Some(p);
+                                        changed = true;
+                                    }
+                                }
+                            }
                             let claude_key = format!("claude-{}", agent.id);
                             let event = file_events
                                 .get(claude_key.as_str())

--- a/lince-dashboard/plugin/src/types.rs
+++ b/lince-dashboard/plugin/src/types.rs
@@ -377,6 +377,36 @@ impl WizardState {
     }
 }
 
+/// Enforced-boundary summary from the per-launch effective-policy record
+/// (#221, design config-v2 §4.3.1): `lince config resolve --json` is the
+/// REQUESTED view; this is the ENFORCED view, parsed from the
+/// `<id>.policy.json` agent-sandbox writes next to the `.state` files.
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+pub struct EnforcedPolicy {
+    #[serde(default)]
+    pub backend: String,
+    #[serde(default)]
+    pub fs_enforced: bool,
+    #[serde(default)]
+    pub net_enforced: bool,
+    #[serde(default)]
+    pub net_limitation: Option<String>,
+    #[serde(default)]
+    pub degraded_reason: Option<String>,
+}
+
+impl EnforcedPolicy {
+    pub fn fully_enforced(&self) -> bool {
+        self.fs_enforced && self.net_enforced
+    }
+
+    /// Compact badge: which boundary the kernel actually enforced.
+    pub fn badge(&self) -> String {
+        let tick = |ok: bool| if ok { "\u{2713}" } else { "\u{2717}" };
+        format!("fs{} net{}", tick(self.fs_enforced), tick(self.net_enforced))
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct AgentInfo {
     pub id: String,
@@ -407,6 +437,10 @@ pub struct AgentInfo {
     /// empty. Runtime-only — not persisted to the state file (the spawn path
     /// re-derives it on restore).
     pub icon: String,
+    /// Effective-policy record for this launch (#221). None until the
+    /// `.policy.json` written by agent-sandbox is polled. Runtime-only —
+    /// re-read from disk after a restore.
+    pub enforced: Option<EnforcedPolicy>,
 }
 
 impl AgentInfo {
@@ -640,6 +674,32 @@ mod tests {
         assert_eq!(AgentStatus::Stopped.color(), "\x1b[2m");
     }
 
+    /// Effective-policy records (#221) arrive as single-line JSON written by
+    /// agent-sandbox; unknown fields must be ignored, badge must reflect the
+    /// enforced boundaries.
+    #[test]
+    fn enforced_policy_parses_record_json() {
+        let json = r#"{"schema":1,"agent":"claude","agent_id":"claude-1",
+            "backend":"bwrap","requested":{"level":"paranoid"},
+            "landlock_abi":7,"fs_enforced":true,"net_enforced":true,
+            "net_limitation":null,"bwrap_args_digest":"abc",
+            "degraded_reason":null,"written_at":"2026-06-10T10:00:00+02:00"}"#;
+        let p: EnforcedPolicy = serde_json::from_str(json).unwrap();
+        assert!(p.fully_enforced());
+        assert_eq!(p.backend, "bwrap");
+        assert_eq!(p.badge(), "fs\u{2713} net\u{2713}");
+    }
+
+    #[test]
+    fn enforced_policy_degraded_badge() {
+        let json = r#"{"backend":"nono","fs_enforced":false,"net_enforced":false,
+            "net_limitation":"unavailable","degraded_reason":"delegated to nono"}"#;
+        let p: EnforcedPolicy = serde_json::from_str(json).unwrap();
+        assert!(!p.fully_enforced());
+        assert_eq!(p.badge(), "fs\u{2717} net\u{2717}");
+        assert_eq!(p.degraded_reason.as_deref(), Some("delegated to nono"));
+    }
+
     fn make_agent(status: AgentStatus, exit_code: Option<i32>) -> AgentInfo {
         AgentInfo {
             id: "agent-1".to_string(),
@@ -657,6 +717,7 @@ mod tests {
             sandbox_level: None,
             sandbox_backend: None,
             transcript_path: None,
+            enforced: None,
             icon: String::new(),
         }
     }
@@ -717,6 +778,7 @@ mod tests {
             sandbox_level: Some("paranoid".to_string()),
             sandbox_backend: Some(crate::sandbox_backend::SandboxBackend::Nono),
             transcript_path: None,
+            enforced: None,
             icon: String::new(), // not persisted
         };
 

--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -3472,6 +3472,137 @@ def cmd_init(args) -> None:
     print("Run Claude in sandbox:\n  agent-sandbox run\n")
 
 
+# ---------------------------------------------------------------------------
+# Effective-policy attestation record (#221, design config-v2 §4.3.1)
+#
+# `lince config resolve --json` is the REQUESTED view; this record is the
+# ENFORCED view: per launch, which boundary the kernel actually enforced,
+# with which mechanism. Written next to the dashboard `.state` file so the
+# plugin can surface it as a badge. Best-effort: a record-write failure must
+# never break a launch — but a *degraded boundary at paranoid* must (I7).
+# ---------------------------------------------------------------------------
+
+_SYS_LANDLOCK_CREATE_RULESET = 444
+_LANDLOCK_CREATE_RULESET_VERSION = 1 << 0
+
+
+def probe_landlock_abi() -> int:
+    """Landlock ABI version supported by the running kernel (0 = unavailable).
+
+    Same probe as the #211 spike: landlock_create_ruleset(NULL, 0, VERSION).
+    """
+    if sys.platform != "linux":
+        return 0
+    try:
+        import ctypes
+        libc = ctypes.CDLL(None, use_errno=True)
+        res = libc.syscall(
+            _SYS_LANDLOCK_CREATE_RULESET,
+            None,
+            ctypes.c_size_t(0),
+            ctypes.c_uint32(_LANDLOCK_CREATE_RULESET_VERSION),
+        )
+        return int(res) if res > 0 else 0
+    except Exception:
+        return 0
+
+
+def policy_record_path(agent_id: str) -> Path:
+    """Record location: next to the dashboard `.state` files (same contract
+    as the status hooks: ${LINCE_STATUS_DIR:-/tmp/lince-dashboard})."""
+    status_dir = Path(os.environ.get("LINCE_STATUS_DIR", "/tmp/lince-dashboard"))
+    return status_dir / f"{agent_id}.policy.json"
+
+
+def build_policy_record(
+    *,
+    backend: str,
+    agent_name: str,
+    agent_id: str | None,
+    level: str | None,
+    requested_fs: str,
+    requested_net: str,
+    fs_enforced: bool,
+    net_enforced: bool,
+    net_limitation: str | None = None,
+    bwrap_args_digest: str | None = None,
+    profile_digest: str | None = None,
+    helper_version: str | None = None,
+    helper_digest: str | None = None,
+    applied_before_exec: bool = True,
+    inherited_by_subprocesses: str = "by-design (kernel namespaces)",
+    degraded_reason: str | None = None,
+) -> dict:
+    """Assemble the §4.3.1 record. degraded_reason is REQUIRED whenever any
+    *_enforced is false — asserted here so the degraded path can never be
+    silent (I7)."""
+    if (not fs_enforced or not net_enforced) and not degraded_reason:
+        raise ValueError("degraded_reason required when a boundary is not enforced (I7)")
+    return {
+        "schema": 1,
+        "agent": agent_name,
+        "agent_id": agent_id,
+        "backend": backend,
+        # Symbolic refs until the §4.2 generated-artifacts pipeline lands;
+        # then these become the <hash8> policy-slice references.
+        "requested": {
+            "level": level or "normal",
+            "filesystem": requested_fs,
+            "network": requested_net,
+        },
+        "landlock_abi": probe_landlock_abi(),
+        "fs_enforced": fs_enforced,
+        "net_enforced": net_enforced,
+        "net_limitation": net_limitation,
+        "bwrap_args_digest": bwrap_args_digest,
+        "profile_digest": profile_digest,
+        "helper_version": helper_version,
+        "helper_digest": helper_digest,
+        "applied_before_exec": applied_before_exec,
+        "inherited_by_subprocesses": inherited_by_subprocesses,
+        "degraded_reason": degraded_reason,
+        "written_at": datetime.now().astimezone().isoformat(timespec="seconds"),
+    }
+
+
+def write_policy_record(agent_id: str | None, record: dict) -> None:
+    """Write the record next to the dashboard .state file (best-effort)."""
+    if not agent_id:
+        return
+    try:
+        path = policy_record_path(agent_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(record, ensure_ascii=False) + "\n", encoding="utf-8")
+    except OSError as exc:
+        print(f"agent-sandbox: warning: could not write policy record: {exc}", file=sys.stderr)
+
+
+def enforce_paranoid_fail_closed(level: str | None, record: dict) -> None:
+    """I7: paranoid never degrades silently. If any requested boundary is not
+    enforced at level=paranoid, refuse to launch, naming the boundary."""
+    if level != "paranoid":
+        return
+    missing = [
+        name
+        for name, ok in (("filesystem", record["fs_enforced"]), ("network", record["net_enforced"]))
+        if not ok
+    ]
+    if missing:
+        print(
+            f"Error: sandbox level 'paranoid' requested but the "
+            f"{' and '.join(missing)} boundary cannot be enforced "
+            f"({record.get('degraded_reason') or 'no enforcing mechanism available'}). "
+            f"Refusing to launch (paranoid fails closed — design invariant I7). "
+            f"Pick --sandbox-level normal/permissive to opt into degraded operation.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def _argv_digest(cmd: list[str]) -> str:
+    return hashlib.sha256("\0".join(cmd).encode("utf-8", "replace")).hexdigest()
+
+
 def cmd_run(args, agent_extra: list[str]) -> None:
     config, config_path = load_config()
 
@@ -3620,6 +3751,34 @@ def cmd_run(args, agent_extra: list[str]) -> None:
             f"{'ask (safe mode)' if args.safe else 'per agent defaults'}"
         )
         print()
+
+        # Effective-policy record (#221). nono enforces via its own profiles;
+        # agent-sandbox cannot attest what it applied — recorded as such, and
+        # surfaced loudly at paranoid (the nono fail-closed gate per design
+        # §2.2 kernel checks lands with the Landlock backend work, #222).
+        nono_record = build_policy_record(
+            backend="nono",
+            agent_name=agent_name,
+            agent_id=args.id,
+            level=sandbox_level,
+            requested_fs=f"nono profile {nono_profile_name}",
+            requested_net=f"per nono profile {nono_profile_name}",
+            fs_enforced=False,
+            net_enforced=False,
+            net_limitation="unavailable",
+            applied_before_exec=False,
+            inherited_by_subprocesses="delegated to nono",
+            degraded_reason="enforcement delegated to the deprecated nono backend — "
+                            "not attested by agent-sandbox",
+        )
+        write_policy_record(args.id, nono_record)
+        if sandbox_level == "paranoid":
+            print(
+                "\033[33m⚠  paranoid on the deprecated nono backend: enforcement "
+                "is delegated to nono and not attested by agent-sandbox. "
+                "Prefer the bwrap (Linux) or seatbelt (macOS) backend.\033[0m",
+                file=sys.stderr,
+            )
 
         try:
             result = subprocess.run(cmd, cwd=str(project_dir))
@@ -3856,6 +4015,33 @@ def cmd_run(args, agent_extra: list[str]) -> None:
             f"{'ask (safe mode)' if args.safe else 'per agent defaults'}"
         )
         print()
+
+        # Effective-policy record (#221): Seatbelt applies the profile to the
+        # whole process tree before exec; the #196 pre-launch guard has
+        # already failed closed if paranoid's proxy precondition was missing.
+        try:
+            sb_profile_digest = hashlib.sha256(
+                Path(runtime_profile).read_bytes()
+            ).hexdigest()
+        except OSError:
+            sb_profile_digest = None
+        sb_record = build_policy_record(
+            backend="seatbelt",
+            agent_name=agent_name,
+            agent_id=args.id,
+            level=sandbox_level,
+            requested_fs=f"seatbelt profile {sb_profile_name}",
+            requested_net=(
+                "loopback-only (deny network* + loopback allows; egress via proxy)"
+                if sb_unshare_net else "shared (no kernel restriction requested)"
+            ),
+            fs_enforced=True,
+            net_enforced=True,
+            profile_digest=sb_profile_digest,
+            inherited_by_subprocesses="by-design (Seatbelt process tree)",
+        )
+        enforce_paranoid_fail_closed(sandbox_level, sb_record)
+        write_policy_record(args.id, sb_record)
 
         try:
             result = subprocess.run(cmd, cwd=str(project_dir))
@@ -4272,6 +4458,27 @@ def cmd_run(args, agent_extra: list[str]) -> None:
     _auto_snapshot(config, project_dir, agent_name)
 
     print()
+
+    # Effective-policy record (#221): bwrap applies mount + (optionally) net
+    # namespaces before exec'ing the agent; both are kernel-inherited by
+    # every subprocess.
+    bwrap_unshare_net = bool(sec.get("unshare_net", False))
+    bwrap_record = build_policy_record(
+        backend="bwrap",
+        agent_name=agent_name,
+        agent_id=args.id,
+        level=sandbox_level,
+        requested_fs="bwrap bind mounts (project rw, system ro, clearenv)",
+        requested_net=(
+            "loopback-only via credential proxy (netns --unshare-net)"
+            if bwrap_unshare_net else "shared (no kernel restriction requested)"
+        ),
+        fs_enforced=True,
+        net_enforced=True,
+        bwrap_args_digest=_argv_digest(cmd),
+    )
+    enforce_paranoid_fail_closed(sandbox_level, bwrap_record)
+    write_policy_record(args.id, bwrap_record)
 
     try:
         result = subprocess.run(cmd, cwd=str(project_dir))

--- a/scripts/tests/test_policy_record.py
+++ b/scripts/tests/test_policy_record.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Tests for the effective-policy attestation record (#221, design §4.3.1).
+
+Run with:
+    python3 scripts/tests/test_policy_record.py
+"""
+
+import importlib.machinery
+import importlib.util
+import io
+import json
+import contextlib
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def load_agent_sandbox():
+    path = REPO_ROOT / "sandbox" / "agent-sandbox"
+    spec = importlib.util.spec_from_loader(
+        "agent_sandbox_policy_test",
+        importlib.machinery.SourceFileLoader("agent_sandbox_policy_test", str(path)),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+MOD = load_agent_sandbox()
+
+
+class TestRecordShape(unittest.TestCase):
+    def record(self, **overrides):
+        kwargs = dict(
+            backend="bwrap",
+            agent_name="claude",
+            agent_id="claude-1",
+            level="paranoid",
+            requested_fs="bwrap bind mounts",
+            requested_net="loopback-only via credential proxy (netns --unshare-net)",
+            fs_enforced=True,
+            net_enforced=True,
+            bwrap_args_digest="abc123",
+        )
+        kwargs.update(overrides)
+        return MOD.build_policy_record(**kwargs)
+
+    def test_full_record_fields(self):
+        rec = self.record()
+        for field in (
+            "schema", "agent", "agent_id", "backend", "requested",
+            "landlock_abi", "fs_enforced", "net_enforced", "net_limitation",
+            "bwrap_args_digest", "profile_digest", "helper_version",
+            "helper_digest", "applied_before_exec",
+            "inherited_by_subprocesses", "degraded_reason", "written_at",
+        ):
+            self.assertIn(field, rec)
+        self.assertEqual(rec["requested"]["level"], "paranoid")
+        self.assertIsInstance(rec["landlock_abi"], int)
+        self.assertGreaterEqual(rec["landlock_abi"], 0)
+        json.dumps(rec)  # must be JSON-serializable
+
+    def test_degraded_requires_reason(self):
+        """I7: the degraded path can never be silent."""
+        with self.assertRaises(ValueError):
+            self.record(net_enforced=False)
+        rec = self.record(net_enforced=False, degraded_reason="ABI < 4")
+        self.assertEqual(rec["degraded_reason"], "ABI < 4")
+
+
+class TestParanoidFailClosed(unittest.TestCase):
+    def make(self, fs=True, net=True):
+        return {
+            "fs_enforced": fs,
+            "net_enforced": net,
+            "degraded_reason": None if (fs and net) else "test degradation",
+        }
+
+    def test_paranoid_with_full_enforcement_launches(self):
+        MOD.enforce_paranoid_fail_closed("paranoid", self.make())  # no exit
+
+    def test_paranoid_with_degraded_boundary_fails_closed(self):
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            with self.assertRaises(SystemExit) as ctx:
+                MOD.enforce_paranoid_fail_closed("paranoid", self.make(net=False))
+        self.assertEqual(ctx.exception.code, 1)
+        # the missing boundary is NAMED (I6/I7)
+        self.assertIn("network boundary", stderr.getvalue())
+        self.assertIn("fails closed", stderr.getvalue())
+
+    def test_normal_level_may_degrade(self):
+        MOD.enforce_paranoid_fail_closed("normal", self.make(net=False))  # no exit
+        MOD.enforce_paranoid_fail_closed(None, self.make(fs=False))  # no exit
+
+
+class TestRecordWrite(unittest.TestCase):
+    def test_write_next_to_state_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            old = os.environ.get("LINCE_STATUS_DIR")
+            os.environ["LINCE_STATUS_DIR"] = tmp
+            try:
+                rec = {"schema": 1, "fs_enforced": True}
+                MOD.write_policy_record("claude-7", rec)
+                path = Path(tmp) / "claude-7.policy.json"
+                self.assertTrue(path.is_file())
+                self.assertEqual(json.loads(path.read_text()), rec)
+                # single line (the dashboard poll cats it with tr -d '\n')
+                self.assertEqual(path.read_text().count("\n"), 1)
+            finally:
+                if old is None:
+                    del os.environ["LINCE_STATUS_DIR"]
+                else:
+                    os.environ["LINCE_STATUS_DIR"] = old
+
+    def test_no_agent_id_is_a_noop(self):
+        MOD.write_policy_record(None, {"schema": 1})  # must not raise
+
+
+class TestLandlockProbe(unittest.TestCase):
+    def test_probe_returns_nonnegative_int(self):
+        abi = MOD.probe_landlock_abi()
+        self.assertIsInstance(abi, int)
+        self.assertGreaterEqual(abi, 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #221. Part of epic #200 / m-16. Implements design `docs/design/config-v2-design.md` §4.3.1 (record contract) + invariant I7; folds in the #211 spike's record prototype (`sandbox/spikes/landlock/landlock_exec.py` stays untouched — the agent-sandbox `__landlock-exec` fold is #222, which will fill `helper_version`/`helper_digest` and the Landlock fs/net rows).

## What

**agent-sandbox** writes a per-launch JSON record next to the dashboard `.state` files (`${LINCE_STATUS_DIR:-/tmp/lince-dashboard}/<id>.policy.json`) — `lince config resolve --json` = requested view, this record = **enforced** view:

- Fields per §4.3.1: `backend`, `requested {level, filesystem, network}`, `landlock_abi` (stdlib ctypes probe from the spike), `fs_enforced`/`net_enforced`, `net_limitation`, `bwrap_args_digest`, `profile_digest` (new, documented in the design doc: Seatbelt's launch vector is a profile, not args), `helper_version`/`helper_digest` (filled by #222), `applied_before_exec`, `inherited_by_subprocesses`, `degraded_reason`.
- **I7 enforced twice**: `build_policy_record` *raises* if a boundary is unenforced without a `degraded_reason` (the degraded path can never be silent), and `enforce_paranoid_fail_closed()` exits 1 before launch naming the missing boundary when paranoid is requested — wired into the bwrap and seatbelt paths (complementing the #196 proxy pre-launch guard).
- Per backend: **bwrap** — namespaces applied before exec, argv sha256 recorded; **seatbelt** — runtime `.sb` digest recorded; **nono (deprecated)** — honestly recorded as `fs/net_enforced: false` + `degraded_reason: "enforcement delegated to the deprecated nono backend — not attested"`, with a visible warning at paranoid (its kernel≥6.6 fail-closed gate is the §2.2 item that lands with #222 — flagged here, not hidden).
- Record write is best-effort (a write failure warns, never breaks a launch) and a no-op without `--id`.

**Dashboard badge**: the existing `.state` poll also reads `.policy.json` (same single shell fork, `POLICY\t<id>\t<json>` lines); `AgentInfo.enforced` carries the parsed record; the detail panel shows `Enforced: fs✓ net✓ [bwrap]` (yellow + reason when degraded); the Sbox column gains a `!` marker for a degraded run — "the exact boundary the kernel actually enforced", not just "sandbox enabled".

## Deviations / notes
- `requested.*` refs are symbolic descriptions until the §4.2 generated-artifacts pipeline exists (then they become the `<hash8>` slices) — design doc updated in this PR.
- `inherited_by_subprocesses` is the spike's honest string form (`"by-design (kernel namespaces)"` / `"delegated to nono"`); the child-process *probe* form arrives with the Landlock shim (#222), which actually needs it.

## How to test it

```
$ python3 scripts/tests/test_policy_record.py
Ran 8 tests in 0.004s
OK                          # incl. I7: paranoid+degraded → SystemExit(1) naming the boundary

# Real end-to-end bwrap launch on this machine:
$ LINCE_STATUS_DIR=/tmp/s agent-sandbox run -p /tmp/proj --agent bash --id bash-42 -- -c 'echo ok'
$ python3 -m json.tool /tmp/s/bash-42.policy.json
  "backend": "bwrap", "landlock_abi": 7, "fs_enforced": true, "net_enforced": true,
  "bwrap_args_digest": "dc5ceb8f…", "applied_before_exec": true, …

# Rust (wasm test suite under wasmtime; host cargo test link failure pre-existing):
$ cargo test --target wasm32-wasip1 --no-run && wasmtime run --preload zellij=stub.wat <test>.wasm
test result: ok. 60 passed; 0 failed     # +2: EnforcedPolicy record parsing + degraded badge

$ cargo build --target wasm32-wasip1     # Finished, no warnings
$ python3 scripts/tests/test_default_config.py && python3 scripts/tests/test_registry_sync.py   # OK
$ ruff check sandbox/agent-sandbox       # 49 == main baseline (no new)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)