### PR TITLE
feat(lince-config): template composition — apply / templates (#207)

### DIFF
--- a/lince-config/README.md
+++ b/lince-config/README.md
@@ -33,10 +33,30 @@ lince-config unset <dotted.key>          [--target sandbox|dashboard] [-q]
 lince-config check    [--target sandbox|dashboard] [--json]
 lince-config validate [--target sandbox|dashboard|lince|registry] [--file PATH] [--overlay] [--json]
 
+# Guided configuration (#207) — compose policy bricks into ~/.config/lince/lince.toml
+lince-config templates [--json]                  # list agents / levels / providers
+lince-config apply <agent>[+<level>][+<provider>] [--project DIR] [--dry-run] [--force-v2]
+
+# Resolution (#202) — the single resolved view (consumed by the dashboard)
+lince-config resolve [--agent NAME] [--project DIR] [--level L] [--provider P]
+
 # JSON Schemas (Taplo-compatible — see schemas/ in the repo)
 lince-config schema <lince|registry-agent|registry-providers|sandbox-config|dashboard-config>
 lince-config schema --write schemas/
 ```
+
+`apply` writes ONLY the v2 policy file (never registry.d, never generated
+files), validates the composed result before writing, is idempotent, and
+shows a diff with `--dry-run`. Example — a working sandboxed Claude in one
+command:
+
+```bash
+lince-config apply claude+normal+anthropic
+```
+
+Creating `lince.toml` switches resolution to v2-only; when legacy
+customizations exist (`[providers.*]`, `[agents.*]` in the old config
+files), `apply` refuses until they are migrated (or `--force-v2`).
 
 `validate` is schema-driven (#203): type mismatches and missing required keys
 are errors; unknown keys under known tables are warnings (forward-compat).

--- a/lince-config/lince-config
+++ b/lince-config/lince-config
@@ -59,6 +59,10 @@ CONFIG_FILES = {
     "dashboard": [
         DASHBOARD_DIR / "config.toml",
     ],
+    # Config v2 policy file (#207): the write surface for apply/set/skills.
+    "lince": [
+        Path.home() / ".config" / "lince" / "lince.toml",
+    ],
 }
 
 AGENTS_DEFAULTS_SEARCH = [
@@ -1091,11 +1095,21 @@ def cmd_set(args) -> int:
                     file=sys.stderr,
                 )
                 return 1
+        elif target == "lince":
+            # Writes create the v2 policy file (§5.3: v2 tools write only
+            # lince.toml). The §5.2 v2 switch is guarded like `apply`.
+            config_path = LINCE_CONFIG_PATH
+            blockers = describe_legacy_intent()
+            if blockers and not getattr(args, "force_v2", False):
+                _print_v2_switch_refusal(blockers)
+                return 1
         else:
             print(f"Error: no {target} config file found.", file=sys.stderr)
             return 1
 
-    doc = _load_tomlkit(config_path)
+    doc = _load_tomlkit(config_path) if config_path.is_file() else tomlkit.document()
+    if target == "lince" and "version" not in doc:
+        doc["version"] = f"{SCHEMA_VERSION_NATIVE[0]}.{SCHEMA_VERSION_NATIVE[1]}"
     _dotted_set(doc, key, value)
     _save_tomlkit(doc, config_path)
 
@@ -1916,6 +1930,7 @@ def build_resolved_view(
     user_provider_names_by_agent: dict[str, list] = {}
     user_provider_details: dict[str, dict] = {}  # name -> {env, env_unset}
     default_provider: str | None = None
+    enabled_agents: set[str] | None = None  # [dashboard].enabled_agents (v2)
 
     if lince_exists:
         # v2 is the ONLY source (§5.2 hard switch).
@@ -1965,6 +1980,9 @@ def build_resolved_view(
             guarantee = f"void:{active[0]}"
         sb = lince.get("sandbox", {})
         default_provider = sb.get("default_provider") or None
+        enabled = lince.get("dashboard", {}).get("enabled_agents")
+        if isinstance(enabled, list) and enabled:
+            enabled_agents = set(enabled)
         legacy_present = [
             str(p) for p in (SANDBOX_CONFIG_PATH, DASHBOARD_CONFIG_PATH)
             if p.is_file()
@@ -2208,6 +2226,14 @@ def build_resolved_view(
     for name in all_bases:
         if agent_filter and name != agent_filter:
             continue
+        # [dashboard].enabled_agents (§2): absent = all registry agents;
+        # custom agents defined in lince.toml are always shown.
+        if (
+            enabled_agents is not None
+            and name not in enabled_agents
+            and name not in agent_policy
+        ):
+            continue
         entry = registry_agents[name]
         agent = entry.get("agent", {})
         sandbox = entry.get("sandbox", {})
@@ -2315,6 +2341,238 @@ def build_resolved_view(
     return view, None
 
 
+# ── apply / templates (#207 — guided configuration over the policy layer) ──
+
+def describe_legacy_intent() -> list[str]:
+    """User intent living in the legacy v1 files that the §5.2 v2 hard switch
+    would silently stop reading. Empty list = safe to create lince.toml."""
+    findings: list[str] = []
+    sandbox_cfg = _load_toml_or_empty(SANDBOX_CONFIG_PATH, None)
+    provider_sections = []
+    for key in ("providers", "profiles"):
+        if isinstance(sandbox_cfg.get(key), dict) and sandbox_cfg[key]:
+            provider_sections.append(f"[{key}.*]")
+    for top, val in sandbox_cfg.items():
+        if isinstance(val, dict):
+            for key in ("providers", "profiles"):
+                if isinstance(val.get(key), dict) and val[key]:
+                    provider_sections.append(f"[{top}.{key}.*]")
+    if provider_sections:
+        findings.append(
+            f"{SANDBOX_CONFIG_PATH}: provider definitions "
+            f"({', '.join(sorted(set(provider_sections)))})"
+        )
+    if isinstance(sandbox_cfg.get("agents"), dict) and sandbox_cfg["agents"]:
+        findings.append(
+            f"{SANDBOX_CONFIG_PATH}: [agents.*] overrides "
+            f"({', '.join(sorted(sandbox_cfg['agents']))})"
+        )
+    dashboard_cfg = _load_toml_or_empty(DASHBOARD_CONFIG_PATH, None)
+    if isinstance(dashboard_cfg.get("agents"), dict) and dashboard_cfg["agents"]:
+        findings.append(
+            f"{DASHBOARD_CONFIG_PATH}: [agents.*] overrides "
+            f"({', '.join(sorted(dashboard_cfg['agents']))})"
+        )
+    return findings
+
+
+def _print_v2_switch_refusal(blockers: list[str]) -> None:
+    print(
+        "Error: creating ~/.config/lince/lince.toml switches resolution to "
+        "v2-only (§5.2 hard switch) — the following legacy customizations "
+        "would stop being read:",
+        file=sys.stderr,
+    )
+    for b in blockers:
+        print(f"  - {b}", file=sys.stderr)
+    print(
+        "Migrate them into lince.toml first (see docs/migration-v2-users.md), "
+        "or pass --force-v2 to proceed anyway.",
+        file=sys.stderr,
+    )
+
+
+def cmd_templates(args) -> int:
+    """List the composition bricks for `apply` (#207): agents from registry.d,
+    isolation levels (shipped + discovered customs), providers."""
+    view, error = build_resolved_view()
+    if error is not None:
+        print(json.dumps({"error": error}, indent=2) if args.json
+              else f"Error: {error['message']}", file=sys.stderr)
+        return 1
+
+    levels: dict[str, str] = {
+        "paranoid": "kernel isolation + ephemeral FS + credential proxy (keys never enter the sandbox)",
+        "normal": "read-only system, writable project, shared network",
+        "permissive": "adds gh/github access, direct network, keys in env",
+    }
+    for agent in view["agents"].values():
+        for backend_levels in agent.get("levels_by_backend", {}).values():
+            for lv in backend_levels:
+                levels.setdefault(lv, "custom level (discovered from profiles)")
+
+    data = {
+        "agents": [
+            {"name": name, "description": a["display_name"]}
+            for name, a in sorted(view["agents"].items())
+        ],
+        "levels": [
+            {"name": name, "description": desc} for name, desc in levels.items()
+        ],
+        "providers": [
+            {
+                "name": name,
+                "available": prov["available"],
+                "source": prov["source"],
+                "description": ", ".join(prov["env_keys"][:3])
+                               + ("…" if len(prov["env_keys"]) > 3 else ""),
+            }
+            for name, prov in sorted(view["providers"].items())
+        ],
+    }
+    if args.json:
+        print(json.dumps(data, indent=2, sort_keys=True))
+        return 0
+    print("Compose with:  lince-config apply <agent>[+<level>][+<provider>]\n")
+    for kind in ("agents", "levels", "providers"):
+        print(f"{kind.capitalize()}:")
+        for item in data[kind]:
+            extra = ""
+            if kind == "providers":
+                extra = "  [configured]" if item["source"] == "user" else (
+                    "  [key detected]" if item["available"] else "")
+            print(f"  {item['name']:<14} {item['description']}{extra}")
+        print()
+    return 0
+
+
+def cmd_apply(args) -> int:
+    """`lince-config apply <agent>[+<level>][+<provider>]` — compose policy
+    bricks into lince.toml (#207). Never touches registry.d or generated
+    files; the result must validate before anything is written."""
+    parts = [tok.strip() for tok in args.combo.split("+") if tok.strip()]
+    if not parts:
+        print("Error: empty combination. Usage: lince-config apply "
+              "<agent>[+<level>][+<provider>]", file=sys.stderr)
+        return 1
+
+    project_dir = Path(args.project).expanduser() if args.project else None
+    view, error = build_resolved_view(project_dir=project_dir)
+    if error is not None:
+        print(f"Error: {error['message']}", file=sys.stderr)
+        return 1
+
+    agent = parts[0]
+    if agent not in view["agents"]:
+        avail = ", ".join(sorted(view["agents"]))
+        print(f"Error: unknown agent '{agent}'. Available: {avail}", file=sys.stderr)
+        return 1
+
+    known_levels = set(SHIPPED_LEVELS)
+    for backend_levels in view["agents"][agent].get("levels_by_backend", {}).values():
+        known_levels.update(backend_levels)
+    level = provider = None
+    for tok in parts[1:]:
+        if tok in known_levels:
+            if level is not None:
+                print(f"Error: two isolation levels given ('{level}' and '{tok}').",
+                      file=sys.stderr)
+                return 1
+            level = tok
+        elif tok in view["providers"]:
+            if provider is not None:
+                print(f"Error: two providers given ('{provider}' and '{tok}').",
+                      file=sys.stderr)
+                return 1
+            provider = tok
+        else:
+            print(
+                f"Error: '{tok}' is neither an isolation level "
+                f"({', '.join(sorted(known_levels))}) nor a known provider "
+                f"({', '.join(sorted(view['providers'])) or 'none configured'}).",
+                file=sys.stderr,
+            )
+            return 1
+    if level is not None and view["agents"][agent].get("allowed_levels") and \
+            level not in view["agents"][agent]["allowed_levels"]:
+        allowed = ", ".join(view["agents"][agent]["allowed_levels"])
+        print(f"Error: agent '{agent}' only supports level(s): {allowed}.",
+              file=sys.stderr)
+        return 1
+
+    # Target file: user policy, or the clamped project overlay (§2.4).
+    if project_dir is not None:
+        target_path = project_dir / ".lince" / "lince.toml"
+        is_user_file = False
+    else:
+        target_path = LINCE_CONFIG_PATH
+        is_user_file = True
+
+    if is_user_file and not target_path.is_file():
+        blockers = describe_legacy_intent()
+        if blockers and not args.force_v2:
+            _print_v2_switch_refusal(blockers)
+            return 1
+
+    doc = _load_tomlkit(target_path) if target_path.is_file() else tomlkit.document()
+    before = tomlkit.dumps(doc)
+    if is_user_file and "version" not in doc:
+        doc["version"] = f"{SCHEMA_VERSION_NATIVE[0]}.{SCHEMA_VERSION_NATIVE[1]}"
+    if "agents" not in doc:
+        doc["agents"] = tomlkit.table()
+    if agent not in doc["agents"]:
+        doc["agents"][agent] = tomlkit.table()
+    if level is not None:
+        doc["agents"][agent]["level"] = level
+    if provider is not None:
+        doc["agents"][agent]["provider"] = provider
+    after = tomlkit.dumps(doc)
+
+    # The composed result must validate BEFORE anything is written.
+    issues: list[dict] = []
+    parsed = tomllib.loads(after)
+    issues.extend(check_version_contract(parsed.get("version"), str(target_path),
+                                         required=is_user_file))
+    # project overlays carry no version key (§2.4)
+    schema = LINCE_SCHEMA if is_user_file else {**LINCE_SCHEMA, "required": []}
+    schema_validate(parsed, schema, "", issues)
+    errors = [i for i in issues if i["level"] == "error"]
+    if errors:
+        print("Error: the composed configuration does not validate — nothing "
+              "was written:", file=sys.stderr)
+        for i in errors:
+            print(f"  ✗ {i['message']}", file=sys.stderr)
+        return 1
+
+    if before == after:
+        print(f"Already applied — {target_path} unchanged (no-op).")
+        return 0
+
+    if args.dry_run:
+        import difflib
+        diff = difflib.unified_diff(
+            before.splitlines(keepends=True), after.splitlines(keepends=True),
+            fromfile=str(target_path), tofile=f"{target_path} (after apply)",
+        )
+        sys.stdout.writelines(diff)
+        print("\n(dry-run — nothing written)")
+        return 0
+
+    created = not target_path.is_file()
+    _save_tomlkit(doc, target_path)
+    summary = " + ".join(x for x in (agent, level, provider) if x)
+    print(f"Applied {summary} → {target_path}")
+    if created and is_user_file:
+        print(
+            "Note: this created your v2 policy file — resolution now reads "
+            "lince.toml (legacy config.toml files are no longer consulted "
+            "for agents/providers)."
+        )
+    print("Verify with:  lince-config validate --target lince  &&  "
+          "lince-config resolve --agent " + agent)
+    return 0
+
+
 def cmd_resolve(args) -> int:
     """Emit the fully-resolved configuration view as JSON (#202, §4.3)."""
     view, error = build_resolved_view(
@@ -2374,9 +2632,10 @@ def _check_permissions(path: Path, quiet: bool = False) -> None:
 def _add_target_flag(p: argparse.ArgumentParser) -> None:
     p.add_argument(
         "--target", "-t",
-        choices=["sandbox", "dashboard"],
+        choices=["sandbox", "dashboard", "lince"],
         default="sandbox",
-        help="Which config to operate on (default: sandbox)",
+        help="Which config to operate on (default: sandbox; "
+             "lince = the v2 policy file ~/.config/lince/lince.toml)",
     )
 
 
@@ -2419,6 +2678,9 @@ def build_parser() -> argparse.ArgumentParser:
     p_set = sub.add_parser("set", help="Set a config value")
     p_set.add_argument("key", help="Dotted key path (e.g. providers.vertex.description)")
     p_set.add_argument("value", help="Value to set (auto-coerced: bool, int, list, string)")
+    p_set.add_argument("--force-v2", action="store_true",
+                       help="With --target lince: create lince.toml even when legacy "
+                            "files carry unmigrated customizations")
     _add_target_flag(p_set)
     _add_quiet_flag(p_set)
     p_set.set_defaults(func=cmd_set)
@@ -2481,6 +2743,28 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _add_json_flag(p_validate)
     p_validate.set_defaults(func=cmd_validate)
+
+    # ── apply ───────────────────────────────────────────────────
+    p_apply = sub.add_parser(
+        "apply",
+        help="Compose policy bricks into lince.toml: <agent>[+<level>][+<provider>] (#207)",
+    )
+    p_apply.add_argument("combo", help="e.g. claude+normal+anthropic")
+    p_apply.add_argument("--project", "-p",
+                         help="Write the project overlay (<dir>/.lince/lince.toml) instead")
+    p_apply.add_argument("--dry-run", action="store_true",
+                         help="Show the resulting diff without writing")
+    p_apply.add_argument("--force-v2", action="store_true",
+                         help="Create lince.toml even when legacy files carry "
+                              "unmigrated customizations")
+    p_apply.set_defaults(func=cmd_apply)
+
+    # ── templates ───────────────────────────────────────────────
+    p_templates = sub.add_parser(
+        "templates", help="List the composition bricks for apply (agents/levels/providers)",
+    )
+    _add_json_flag(p_templates)
+    p_templates.set_defaults(func=cmd_templates)
 
     # ── resolve ─────────────────────────────────────────────────
     p_resolve = sub.add_parser(

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -514,7 +514,7 @@ select_shells() {
         fi
     done
 
-    # Append to SELECTED_AGENTS so generate_agent_defaults / generate_sandbox_defaults
+    # Append to SELECTED_AGENTS so configure_agent_selection
     # emit their TOML blocks. De-dup in case the user runs interactively twice.
     for sh in "${SELECTED_SHELLS[@]}"; do
         local already=0
@@ -715,98 +715,6 @@ confirm_installation() {
     fi
 }
 
-# ── Generate filtered agents-defaults.toml ───────────────────────────
-#
-# Schema note: since the SandboxBackend wizard step shipped, agents-defaults.toml
-# has ONE canonical sandboxed entry per agent (e.g. `[agents.claude]`) plus an
-# optional `[agents.<agent>-unsandboxed]` sibling. The runtime backend (bwrap vs
-# nono) is picked by the user at spawn time in the N wizard, so install-time no
-# longer needs separate `<agent>-bwrap` / `<agent>-nono` entries — they don't
-# exist in the source file.
-#
-# The user's backend selection in quickstart therefore boils down to:
-#   - any sandboxed backend (bwrap or nono) → emit the canonical `[agents.<x>]`
-#   - "unsandboxed" → emit the `[agents.<x>-unsandboxed]` sibling
-# Picking both bwrap AND nono produces a single canonical entry (no dupe).
-generate_agent_defaults() {
-    local src="$SCRIPT_DIR/lince-dashboard/agents-defaults.toml"
-    local dst="$1"
-
-    if [ ! -f "$src" ]; then
-        echo -e "  ${YELLOW}⚠ agents-defaults.toml not found — using empty config${NC}"
-        echo "# No agent types configured. Add agents via /lince-add-supported-agent or edit this file." > "$dst"
-        return
-    fi
-
-    # Start with header
-    head -13 "$src" > "$dst"
-
-    # Decide once which entry types we need from the user's backend selection.
-    local need_sandboxed=false
-    local need_unsandboxed=false
-    for backend in "${SELECTED_BACKENDS[@]}"; do
-        case "$backend" in
-            bwrap|nono) need_sandboxed=true ;;
-            unsandboxed) need_unsandboxed=true ;;
-        esac
-    done
-
-    for agent in "${SELECTED_AGENTS[@]}"; do
-        if [ "$need_sandboxed" = true ]; then
-            echo "" >> "$dst"
-            extract_agent_block "$src" "agents.${agent}" >> "$dst"
-        fi
-        if [ "$need_unsandboxed" = true ]; then
-            echo "" >> "$dst"
-            extract_agent_block "$src" "agents.${agent}-unsandboxed" >> "$dst"
-        fi
-    done
-}
-
-# Extract a TOML block from [agents.X] to the next TOML section or EOF.
-#
-# Captures the matched [agents.X] header plus any of its sub-tables
-# (e.g. [agents.X.env_vars]). Trailing blank lines and standalone `#`
-# comments after the section's last in-section line are buffered and
-# dropped on the next section boundary — without that, a freestanding
-# comment block before the *next* [agents.Y] would leak into this
-# extraction (see gh#91 regression).
-extract_agent_block() {
-    local file="$1"
-    local section="$2"
-
-    awk -v sec="[$section]" -v secpfx="[$section." '
-        BEGIN { printing=0; buf="" }
-        # Any TOML section header is a potential boundary — not just [agents.*],
-        # so future top-level sections (e.g. [providers]) cant slip through.
-        /^\[/ {
-            if ($0 == sec || (printing && index($0, secpfx) == 1)) {
-                # Flush buffered blanks/comments (they belong inside the section
-                # since real content followed them).
-                if (buf != "") { printf "%s", buf; buf="" }
-                printing=1
-            } else if (printing) {
-                # Crossed into a different section. Discard the trailing buffer
-                # — those blanks/comments belong to whatever comes next.
-                printing=0
-                buf=""
-            }
-        }
-        printing {
-            if ($0 ~ /^[[:space:]]*$/ || $0 ~ /^[[:space:]]*#/) {
-                # Buffer; emit only if more in-section content follows.
-                buf = buf $0 "\n"
-            } else {
-                if (buf != "") { printf "%s", buf; buf="" }
-                print
-            }
-        }
-        # Intentionally no END flush: a section that runs to EOF with only
-        # trailing blanks/comments still drops them, which is what we want
-        # for clean output.
-    ' "$file"
-}
-
 # ── Install VoxCode ──────────────────────────────────────────────────
 do_install_voxcode() {
     if [ "$INSTALL_VOXCODE" = false ]; then
@@ -845,35 +753,6 @@ do_install_voxcode() {
     fi
 }
 
-# Filter sandbox/agents-defaults.toml the same way we filter the dashboard's,
-# so `agent-sandbox run --agent <x>` only resolves the agents the user picked.
-# Sandbox schema is one block per agent (no `-unsandboxed` siblings) so this is
-# simpler than generate_agent_defaults — we just emit each [agents.<name>]
-# block. install.sh writes the file to two locations; we overwrite both.
-generate_sandbox_defaults() {
-    local src="$SCRIPT_DIR/sandbox/agents-defaults.toml"
-    local dst="$1"
-
-    if [ ! -f "$src" ]; then
-        return
-    fi
-
-    # Preserve the file header (top comment block) so the schema docs survive.
-    # The header runs from line 1 until the first [agents.*] line.
-    local header_end
-    header_end=$(grep -n '^\[agents\.' "$src" | head -1 | cut -d: -f1)
-    if [ -z "$header_end" ]; then
-        # No agent blocks in source — nothing to filter, leave file alone.
-        return
-    fi
-    head -n $((header_end - 1)) "$src" > "$dst"
-
-    for agent in "${SELECTED_AGENTS[@]}"; do
-        echo "" >> "$dst"
-        extract_agent_block "$src" "agents.${agent}" >> "$dst"
-    done
-}
-
 # ── Install sandbox ─────────────────────────────────────────────────
 do_install_sandbox() {
     # Only install agent-sandbox if bwrap backend is selected
@@ -894,21 +773,6 @@ do_install_sandbox() {
         if ! confirm "Continue anyway?"; then exit 1; fi
     fi
 
-    # Overwrite both copies install.sh wrote with a SELECTED_AGENTS-filtered
-    # version. Without this, the sandbox would happily resolve agents the
-    # user explicitly opted out of (e.g. zsh on a bash-only Linux setup).
-    if [ ${#SELECTED_AGENTS[@]} -gt 0 ]; then
-        local sandbox_targets=(
-            "$HOME/.agent-sandbox/agents-defaults.toml"
-            "$HOME/.local/bin/agents-defaults.toml"
-        )
-        for target in "${sandbox_targets[@]}"; do
-            if [ -f "$target" ]; then
-                generate_sandbox_defaults "$target"
-            fi
-        done
-        echo -e "  ${GREEN}✓ Sandbox agents filtered: ${SELECTED_AGENTS[*]}${NC}"
-    fi
 }
 
 # ── Install lince-config CLI ────────────────────────────────────────
@@ -928,6 +792,55 @@ do_install_lince_config() {
     fi
 }
 
+# ── Agent selection → lince.toml (#207) ─────────────────────────────
+#
+# Selection used to be implemented by awk-filtering COPIES of the shipped
+# agents-defaults files — installed files then differed from shipped ones in
+# ways that were not user customization (#199/#204). Selection is now DATA:
+# `lince-config apply <agent>+<level>` per picked agent plus
+# [dashboard].enabled_agents in ~/.config/lince/lince.toml. The shipped
+# registry/defaults stay complete; the dashboard picker reads the policy.
+configure_agent_selection() {
+    if [ ${#SELECTED_AGENTS[@]} -eq 0 ]; then
+        return
+    fi
+    local LC="$HOME/.local/bin/lince-config"
+    command -v lince-config >/dev/null 2>&1 && LC="lince-config"
+    if ! "$LC" --version >/dev/null 2>&1; then
+        echo -e "  ${YELLOW}⚠ lince-config unavailable — agent selection not persisted"
+        echo -e "    (all registry agents will appear in the dashboard picker)${NC}"
+        return
+    fi
+
+    echo ""
+    echo -e "${CYAN}Persisting agent selection to ~/.config/lince/lince.toml...${NC}"
+    local ok=true
+    for agent in "${SELECTED_AGENTS[@]}"; do
+        if ! "$LC" apply "${agent}+normal" >/dev/null 2>&1; then
+            ok=false
+        fi
+    done
+    # Restrict the dashboard picker to the selection (absent = all agents).
+    local json="["
+    local first=true
+    for agent in "${SELECTED_AGENTS[@]}"; do
+        if [ "$first" = true ]; then first=false; else json="$json, "; fi
+        json="$json\"$agent\""
+    done
+    json="$json]"
+    if ! "$LC" set dashboard.enabled_agents "$json" --target lince --quiet >/dev/null 2>&1; then
+        ok=false
+    fi
+    if [ "$ok" = true ]; then
+        echo -e "${GREEN}✓ Agents enabled: ${SELECTED_AGENTS[*]}${NC}"
+    else
+        echo -e "  ${YELLOW}⚠ Could not persist the agent selection (existing legacy"
+        echo -e "    customizations detected?). All registry agents stay available;"
+        echo -e "    run 'lince-config apply <agent>+<level>' manually after migrating"
+        echo -e "    (see docs/migration-v2-users.md).${NC}"
+    fi
+}
+
 # ── Install dashboard ───────────────────────────────────────────────
 do_install_dashboard() {
     echo ""
@@ -943,16 +856,6 @@ do_install_dashboard() {
     else
         echo -e "${RED}✗ lince-dashboard installation failed${NC}"
         if ! confirm "Continue anyway?"; then exit 1; fi
-    fi
-
-    # Overwrite agents-defaults.toml with filtered version
-    local defaults_dst="$HOME/.config/lince-dashboard/agents-defaults.toml"
-    if [ ${#SELECTED_AGENTS[@]} -gt 0 ]; then
-        echo ""
-        echo -e "${CYAN}Configuring selected agents...${NC}"
-        generate_agent_defaults "$defaults_dst"
-        echo -e "${GREEN}✓ Agent defaults written: $defaults_dst${NC}"
-        echo -e "  ${DIM}Configured: ${SELECTED_AGENTS[*]}${NC}"
     fi
 
     # Hardcode the chosen default shell into lince-viewport-placeholder.
@@ -1272,4 +1175,5 @@ do_install_sandbox
 do_install_voxcode        # before dashboard so step 14 detects voxcode
 do_install_dashboard
 do_install_lince_config   # CLI required by the lince-configure skill
+configure_agent_selection # selection becomes data in lince.toml (#207)
 print_summary

--- a/scripts/tests/test_apply.py
+++ b/scripts/tests/test_apply.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Tests for `lince-config apply` / `templates` (#207).
+
+Run with:
+    python3 scripts/tests/test_apply.py
+"""
+
+import contextlib
+import importlib.machinery
+import importlib.util
+import io
+import tempfile
+import tomllib
+import types
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def load_lince_config():
+    path = REPO_ROOT / "lince-config" / "lince-config"
+    spec = importlib.util.spec_from_loader(
+        "lince_config_apply_test",
+        importlib.machinery.SourceFileLoader("lince_config_apply_test", str(path)),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class ApplyTestCase(unittest.TestCase):
+    def setUp(self):
+        self.lc = load_lince_config()
+        self.tmp = tempfile.TemporaryDirectory()
+        root = Path(self.tmp.name)
+        self.lince_cfg = root / "lince" / "lince.toml"
+        self.lc.LINCE_REGISTRY_DIRS = [REPO_ROOT / "registry.d"]
+        self.lc.LINCE_CONFIG_PATH = self.lince_cfg
+        self.lc.SANDBOX_CONFIG_PATH = root / "sandbox-config.toml"
+        self.lc.DASHBOARD_CONFIG_PATH = root / "dashboard-config.toml"
+        self.lc.SANDBOX_PROFILES_DIR = root / "profiles"
+        self.lc.NONO_PROFILES_DIR = root / "nono-profiles"
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def apply(self, combo, project=None, dry_run=False, force_v2=False):
+        args = types.SimpleNamespace(
+            combo=combo, project=str(project) if project else None,
+            dry_run=dry_run, force_v2=force_v2,
+        )
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            rc = self.lc.cmd_apply(args)
+        return rc, out.getvalue(), err.getvalue()
+
+    # ── happy path ───────────────────────────────────────────────────────
+
+    def test_fresh_machine_one_command(self):
+        rc, out, err = self.apply("claude+normal+anthropic")
+        self.assertEqual(rc, 0, err)
+        parsed = tomllib.loads(self.lince_cfg.read_text())
+        self.assertEqual(parsed["version"], "2.0")
+        self.assertEqual(parsed["agents"]["claude"]["level"], "normal")
+        self.assertEqual(parsed["agents"]["claude"]["provider"], "anthropic")
+        # the result resolves: level/provider visible, origin = user
+        view, error = self.lc.build_resolved_view()
+        self.assertIsNone(error)
+        self.assertEqual(view["agents"]["claude"]["level"], "normal")
+        self.assertEqual(view["agents"]["claude"]["provider"], "anthropic")
+        # the written file passes the validator with zero issues
+        issues = []
+        self.lc.schema_validate(parsed, self.lc.LINCE_SCHEMA, "", issues)
+        self.assertEqual(issues, [])
+
+    def test_reapply_is_noop(self):
+        self.apply("claude+paranoid")
+        before = self.lince_cfg.read_text()
+        rc, out, _ = self.apply("claude+paranoid")
+        self.assertEqual(rc, 0)
+        self.assertIn("no-op", out)
+        self.assertEqual(self.lince_cfg.read_text(), before)
+
+    def test_order_of_level_and_provider_is_free(self):
+        rc, _, err = self.apply("codex+openai+permissive")
+        self.assertEqual(rc, 0, err)
+        parsed = tomllib.loads(self.lince_cfg.read_text())
+        self.assertEqual(parsed["agents"]["codex"]["level"], "permissive")
+        self.assertEqual(parsed["agents"]["codex"]["provider"], "openai")
+
+    def test_dry_run_writes_nothing(self):
+        rc, out, _ = self.apply("claude+paranoid", dry_run=True)
+        self.assertEqual(rc, 0)
+        self.assertIn("+level = \"paranoid\"", out)
+        self.assertFalse(self.lince_cfg.exists())
+
+    def test_project_overlay(self):
+        project = Path(self.tmp.name) / "proj"
+        project.mkdir()
+        rc, _, err = self.apply("claude+paranoid", project=project)
+        self.assertEqual(rc, 0, err)
+        overlay = project / ".lince" / "lince.toml"
+        parsed = tomllib.loads(overlay.read_text())
+        self.assertEqual(parsed["agents"]["claude"]["level"], "paranoid")
+        # overlays carry no version key (§2.4)
+        self.assertNotIn("version", parsed)
+        self.assertFalse(self.lince_cfg.exists())
+
+    # ── failure modes (nothing written) ──────────────────────────────────
+
+    def test_unknown_agent_fails_before_writing(self):
+        rc, _, err = self.apply("nosuch+normal")
+        self.assertEqual(rc, 1)
+        self.assertIn("unknown agent", err)
+        self.assertFalse(self.lince_cfg.exists())
+
+    def test_unknown_token_fails_with_both_lists(self):
+        rc, _, err = self.apply("claude+warpspeed")
+        self.assertEqual(rc, 1)
+        self.assertIn("neither an isolation level", err)
+        self.assertFalse(self.lince_cfg.exists())
+
+    def test_level_pin_respected(self):
+        rc, _, err = self.apply("bash+paranoid")
+        self.assertEqual(rc, 1)
+        self.assertIn("only supports level(s): normal", err)
+
+    def test_double_level_fails(self):
+        rc, _, err = self.apply("claude+normal+paranoid")
+        self.assertEqual(rc, 1)
+        self.assertIn("two isolation levels", err)
+
+    # ── the §5.2 v2-switch guard ─────────────────────────────────────────
+
+    def test_legacy_intent_blocks_v2_switch(self):
+        self.lc.SANDBOX_CONFIG_PATH.write_text(
+            '[providers.vertex]\nenv = { CLOUD_ML_REGION = "us-east5" }\n',
+            encoding="utf-8",
+        )
+        rc, _, err = self.apply("claude+normal")
+        self.assertEqual(rc, 1)
+        self.assertIn("force-v2", err)
+        self.assertIn("vertex" if "vertex" in err else "providers", err)
+        self.assertFalse(self.lince_cfg.exists())
+        # explicit opt-in proceeds
+        rc, _, err = self.apply("claude+normal", force_v2=True)
+        self.assertEqual(rc, 0, err)
+        self.assertTrue(self.lince_cfg.exists())
+
+    def test_fresh_init_config_does_not_block(self):
+        """A fresh `agent-sandbox init` config has no providers/agent
+        overrides — apply must not demand --force-v2."""
+        example = (REPO_ROOT / "sandbox" / "config.toml.example").read_text()
+        self.lc.SANDBOX_CONFIG_PATH.write_text(example, encoding="utf-8")
+        rc, _, err = self.apply("claude+normal")
+        self.assertEqual(rc, 0, err)
+
+    # ── enabled_agents (the quickstart selection mechanism) ─────────────
+
+    def test_enabled_agents_filters_resolve(self):
+        self.lince_cfg.parent.mkdir(parents=True)
+        self.lince_cfg.write_text(
+            'version = "2.0"\n[dashboard]\nenabled_agents = ["claude", "bash"]\n',
+            encoding="utf-8",
+        )
+        view, error = self.lc.build_resolved_view()
+        self.assertIsNone(error)
+        self.assertEqual(sorted(view["agents"]), ["bash", "claude"])
+
+    def test_custom_agents_always_visible(self):
+        self.lince_cfg.parent.mkdir(parents=True)
+        self.lince_cfg.write_text(
+            'version = "2.0"\n'
+            '[dashboard]\nenabled_agents = ["claude"]\n'
+            '[agents.bob]\nbinary = "bob"\ndisplay_name = "Bob"\n'
+            'short_label = "BOB"\ncolor = "magenta"\n',
+            encoding="utf-8",
+        )
+        view, _ = self.lc.build_resolved_view()
+        self.assertEqual(sorted(view["agents"]), ["bob", "claude"])
+
+
+class TemplatesTestCase(unittest.TestCase):
+    def test_templates_json(self):
+        lc = load_lince_config()
+        lc.LINCE_REGISTRY_DIRS = [REPO_ROOT / "registry.d"]
+        args = types.SimpleNamespace(json=True)
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            rc = lc.cmd_templates(args)
+        self.assertEqual(rc, 0)
+        import json
+        data = json.loads(out.getvalue())
+        names = {a["name"] for a in data["agents"]}
+        self.assertIn("claude", names)
+        self.assertEqual(
+            {lv["name"] for lv in data["levels"]} >= {"paranoid", "normal", "permissive"},
+            True,
+        )
+        self.assertIn("anthropic", {p["name"] for p in data["providers"]})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #207. First m-17 item (guided-configuration epic #206); builds on #204 (registry bricks), #203 (validation), #202 (resolver). Note: per the m-16 plan the `lince` CLI does not exist yet, so the commands live in `lince-config` (`lince config apply` ⇢ `lince-config apply`).

## What

- **`lince-config apply <agent>[+<level>][+<provider>]`** — composes schema-validated bricks into `~/.config/lince/lince.toml` policy entries (never registry.d, never generated files):
  - Bricks resolved through `build_resolved_view`: agents = registry ∪ custom; levels = shipped trio ∪ filesystem-discovered customs (per-agent pins like the shells' `["normal"]` enforced); providers = registry ∪ user-configured. Token order free (`codex+openai+permissive` works).
  - The composed result must pass the schema **and** version contract before anything is written; invalid combinations fail with both candidate lists named (I6).
  - Idempotent (`Already applied — no-op`), `--dry-run` prints the unified diff, `--project DIR` writes the §2.4 overlay (no `version` key).
  - **§5.2 v2-switch guard**: creating `lince.toml` makes resolution v2-only, so on installs whose legacy files carry real intent (`[providers.*]`/`[agents.*]`) `apply` refuses, listing exactly what would stop being read + the fix (`migrate` per the user guide, or `--force-v2`). A fresh `agent-sandbox init` config does **not** trip the guard (tested against the shipped example).
- **`lince-config templates [--json]`** — lists the bricks with one-line descriptions and provider availability; the dashboard wizard can reuse the JSON.
- **`--target lince`** for `get/set/append/remove/unset/list` (the v2 write surface for skills, #209); `set` creates the file (version stamped) behind the same guard.
- **`resolve` honors `[dashboard].enabled_agents`** (§2): absent = all registry agents; custom agents always visible.
- **quickstart.sh**: the awk-filtered rewrites of copied agents-defaults files are gone (`generate_agent_defaults`, `generate_sandbox_defaults`, `extract_agent_block` — the #204 issue's "installed files differ from shipped ones" root cause). Selection is now data: `apply <agent>+normal` per picked agent + `dashboard.enabled_agents`, with graceful degradation when legacy customizations block the v2 switch (everything stays available, migration pointer printed).

## How to test it

```
$ python3 scripts/tests/test_apply.py
Ran 14 tests in 0.081s
OK

# Acceptance: fresh machine → working sandboxed Claude in one command
$ lince-config apply claude+normal+anthropic
Applied claude + normal + anthropic → ~/.config/lince/lince.toml
$ lince-config apply claude+normal+anthropic
Already applied — ~/.config/lince/lince.toml unchanged (no-op).
$ lince-config apply claude+warpspeed
Error: 'warpspeed' is neither an isolation level (normal, paranoid, permissive) nor a known provider (…)
  → exit 1, nothing written

$ lince-config templates | head            # agents/levels/providers listing
$ python3 scripts/tests/test_resolve.py && python3 scripts/tests/test_schemas.py \
  && python3 scripts/tests/test_config_reference.py    # all OK
$ bash -n quickstart.sh && ruff check lince-config/lince-config   # OK / clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)