### PR TITLE
feat(lince-config): discovery helpers — lince-config discover (#208)

### DIFF
--- a/lince-config/README.md
+++ b/lince-config/README.md
@@ -33,6 +33,9 @@ lince-config unset <dotted.key>          [--target sandbox|dashboard] [-q]
 lince-config check    [--target sandbox|dashboard] [--json]
 lince-config validate [--target sandbox|dashboard|lince|registry] [--file PATH] [--overlay] [--json]
 
+# Discovery (#208) — detect installed agents/toolchains and propose apply lines
+lince-config discover [--json]
+
 # Guided configuration (#207) — compose policy bricks into ~/.config/lince/lince.toml
 lince-config templates [--json]                  # list agents / levels / providers
 lince-config apply <agent>[+<level>][+<provider>] [--project DIR] [--dry-run] [--force-v2]

--- a/lince-config/lince-config
+++ b/lince-config/lince-config
@@ -2573,6 +2573,139 @@ def cmd_apply(args) -> int:
     return 0
 
 
+# ── discover (#208 — propose instead of ask) ────────────────────────────
+
+# Preferred provider per agent binary for the suggested `apply` line — used
+# only when that provider's credentials are actually detected in the host
+# env. (mxc discovery-helpers precedent: suggestions, never silent writes.)
+_PREFERRED_PROVIDER = {
+    "claude": "anthropic",
+    "codex": "openai",
+    "gemini": "google",
+    "opencode": "anthropic",
+    "aider": "openai",
+    "amp": "anthropic",
+}
+
+# Toolchains whose presence is relevant to sandbox mounts/caches.
+_TOOLCHAIN_BINARIES = (
+    "node", "npm", "cargo", "rustc", "go", "python3", "uv", "pip",
+    "mvn", "gradle", "make", "gcc", "git",
+)
+
+
+def cmd_discover(args) -> int:
+    """`lince-config discover` — detect installed agents, toolchains, and
+    candidate paths; propose ready-made `apply` lines (#208). All emitted
+    paths are absolute and validated (the #125 relative-path bug class)."""
+    import os
+    import shutil
+
+    view, error = build_resolved_view()
+    if error is not None:
+        print(json.dumps({"error": error}, indent=2) if args.json
+              else f"Error: {error['message']}", file=sys.stderr)
+        return 1
+
+    agents: list[dict] = []
+    shells: list[dict] = []
+    for name, agent in sorted(view["agents"].items()):
+        binary_path = shutil.which(agent["binary"])
+        if not binary_path:
+            continue
+        resolved = str(Path(binary_path).resolve())
+        entry = {"name": name, "binary": agent["binary"], "path": resolved}
+        # Shells carry no providers in the registry — list them separately,
+        # never as agent-template suggestions (they would match on every box).
+        if not agent.get("providers"):
+            shells.append(entry)
+        else:
+            agents.append(entry)
+
+    providers_detected = [
+        {"name": name, "source": prov["source"]}
+        for name, prov in sorted(view["providers"].items())
+        if prov["available"]
+    ]
+    available_names = {p["name"] for p in providers_detected}
+
+    toolchains = []
+    for tool in _TOOLCHAIN_BINARIES:
+        path = shutil.which(tool)
+        if path:
+            toolchains.append({"name": tool, "path": str(Path(path).resolve())})
+
+    paths: dict[str, str] = {}
+    tmpdir = Path(os.environ.get("TMPDIR", "/tmp"))
+    if tmpdir.is_dir():
+        paths["tmp"] = str(tmpdir.resolve())
+    for label, candidate in (
+        ("local_share", Path.home() / ".local" / "share"),
+        ("cache", Path.home() / ".cache"),
+        ("project", Path.cwd()),
+    ):
+        if candidate.is_dir():
+            paths[label] = str(candidate.resolve())
+
+    suggestions: list[str] = []
+    for entry in agents:
+        combo = f"{entry['name']}+normal"
+        preferred = _PREFERRED_PROVIDER.get(entry["binary"])
+        if preferred in available_names:
+            combo += f"+{preferred}"
+        else:
+            user_provs = [
+                p for p in view["agents"][entry["name"]].get("providers_available", [])
+                if p in available_names
+            ]
+            if len(user_provs) == 1:
+                combo += f"+{user_provs[0]}"
+        suggestions.append(f"lince-config apply {combo}")
+
+    data = {
+        "agents": agents,
+        "shells": shells,
+        "providers": providers_detected,
+        "toolchains": toolchains,
+        "paths": paths,
+        "suggestions": suggestions,
+    }
+    if args.json:
+        print(json.dumps(data, indent=2, sort_keys=True))
+        return 0
+
+    if agents:
+        print("Installed agents:")
+        for entry in agents:
+            print(f"  {entry['name']:<10} {entry['path']}")
+    else:
+        print("Installed agents: none detected "
+              "(claude/codex/gemini/opencode/aider/amp/pi not on PATH)")
+    if shells:
+        print("Shells:")
+        for entry in shells:
+            print(f"  {entry['name']:<10} {entry['path']}")
+    if providers_detected:
+        print("Providers with credentials detected:")
+        for prov in providers_detected:
+            origin = "configured" if prov["source"] == "user" else "env key set"
+            print(f"  {prov['name']:<14} ({origin})")
+    if toolchains:
+        print("Toolchains on PATH: " + ", ".join(t["name"] for t in toolchains))
+    if paths:
+        print("Candidate paths:")
+        for label, path in paths.items():
+            print(f"  {label:<12} {path}")
+    print()
+    if suggestions:
+        print("Suggested setup (run any of):")
+        for line in suggestions:
+            print(f"  {line}")
+    else:
+        print("No agent suggestions — install an agent (e.g. claude) and re-run.")
+    return 0
+
+
 def cmd_resolve(args) -> int:
     """Emit the fully-resolved configuration view as JSON (#202, §4.3)."""
     view, error = build_resolved_view(
@@ -2743,6 +2876,14 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _add_json_flag(p_validate)
     p_validate.set_defaults(func=cmd_validate)
+
+    # ── discover ────────────────────────────────────────────────
+    p_discover = sub.add_parser(
+        "discover",
+        help="Detect installed agents/toolchains/paths and propose apply lines (#208)",
+    )
+    _add_json_flag(p_discover)
+    p_discover.set_defaults(func=cmd_discover)
 
     # ── apply ───────────────────────────────────────────────────
     p_apply = sub.add_parser(

--- a/scripts/tests/test_discover.py
+++ b/scripts/tests/test_discover.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Tests for `lince-config discover` (#208).
+
+Run with:
+    python3 scripts/tests/test_discover.py
+"""
+
+import contextlib
+import importlib.machinery
+import importlib.util
+import io
+import json
+import os
+import shutil
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def load_lince_config():
+    path = REPO_ROOT / "lince-config" / "lince-config"
+    spec = importlib.util.spec_from_loader(
+        "lince_config_discover_test",
+        importlib.machinery.SourceFileLoader("lince_config_discover_test", str(path)),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class DiscoverTestCase(unittest.TestCase):
+    def setUp(self):
+        self.lc = load_lince_config()
+        self.tmp = tempfile.TemporaryDirectory()
+        root = Path(self.tmp.name)
+        self.bin_dir = root / "bin"
+        self.bin_dir.mkdir()
+        self.lc.LINCE_REGISTRY_DIRS = [REPO_ROOT / "registry.d"]
+        self.lc.LINCE_CONFIG_PATH = root / "lince" / "lince.toml"
+        self.lc.SANDBOX_CONFIG_PATH = root / "sandbox-config.toml"
+        self.lc.DASHBOARD_CONFIG_PATH = root / "dashboard-config.toml"
+        self.lc.SANDBOX_PROFILES_DIR = root / "profiles"
+        self.lc.NONO_PROFILES_DIR = root / "nono-profiles"
+        self._old_which = shutil.which
+        self._old_env = dict(os.environ)
+        # Hermetic host: only the binaries we fake exist; no provider keys.
+        for var in list(os.environ):
+            if var.endswith(("_API_KEY", "_TOKEN")) or var.startswith("AWS_"):
+                os.environ.pop(var, None)
+
+    def tearDown(self):
+        shutil.which = self._old_which
+        os.environ.clear()
+        os.environ.update(self._old_env)
+        self.tmp.cleanup()
+
+    def fake_binaries(self, *names):
+        for name in names:
+            target = self.bin_dir / name
+            target.write_text("#!/bin/sh\n", encoding="utf-8")
+            target.chmod(0o755)
+
+        def which(cmd, *a, **kw):
+            candidate = self.bin_dir / cmd
+            return str(candidate) if candidate.is_file() else None
+
+        shutil.which = which
+
+    def discover(self):
+        args = types.SimpleNamespace(json=True)
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            rc = self.lc.cmd_discover(args)
+        self.assertEqual(rc, 0)
+        return json.loads(out.getvalue())
+
+    def test_exactly_installed_agents_proposed(self):
+        """Acceptance: claude + codex installed → exactly those two agent
+        templates, with valid absolute paths."""
+        self.fake_binaries("claude", "codex")
+        data = self.discover()
+        self.assertEqual([a["name"] for a in data["agents"]], ["claude", "codex"])
+        for agent in data["agents"]:
+            self.assertTrue(Path(agent["path"]).is_absolute())
+            self.assertTrue(Path(agent["path"]).is_file())
+        self.assertEqual(data["suggestions"], [
+            "lince-config apply claude+normal",
+            "lince-config apply codex+normal",
+        ])
+
+    def test_shells_never_suggested(self):
+        self.fake_binaries("bash", "zsh", "fish", "claude")
+        data = self.discover()
+        self.assertEqual([a["name"] for a in data["agents"]], ["claude"])
+        self.assertEqual([s["name"] for s in data["shells"]], ["bash", "fish", "zsh"])
+        self.assertEqual(len(data["suggestions"]), 1)
+
+    def test_provider_added_when_credentials_detected(self):
+        self.fake_binaries("claude")
+        os.environ["ANTHROPIC_API_KEY"] = "sk-ant-test"
+        data = self.discover()
+        self.assertIn("anthropic", {p["name"] for p in data["providers"]})
+        self.assertEqual(data["suggestions"],
+                         ["lince-config apply claude+normal+anthropic"])
+
+    def test_all_emitted_paths_are_absolute(self):
+        """The #125 bug class: discovery must never emit relative paths."""
+        self.fake_binaries("claude", "node", "cargo")
+        data = self.discover()
+        for agent in data["agents"]:
+            self.assertTrue(Path(agent["path"]).is_absolute())
+        for tool in data["toolchains"]:
+            self.assertTrue(Path(tool["path"]).is_absolute())
+        for path in data["paths"].values():
+            self.assertTrue(Path(path).is_absolute())
+            self.assertTrue(Path(path).is_dir())
+
+    def test_suggestions_apply_cleanly(self):
+        """Acceptance: suggestions always pass validation when applied."""
+        self.fake_binaries("claude", "codex")
+        os.environ["ANTHROPIC_API_KEY"] = "sk-ant-test"
+        data = self.discover()
+        for line in data["suggestions"]:
+            combo = line.split()[-1]
+            args = types.SimpleNamespace(combo=combo, project=None,
+                                         dry_run=False, force_v2=False)
+            out, err = io.StringIO(), io.StringIO()
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                rc = self.lc.cmd_apply(args)
+            self.assertEqual(rc, 0, f"{combo}: {err.getvalue()}")
+        # and the resulting file validates
+        issues = []
+        import tomllib
+        parsed = tomllib.loads(self.lc.LINCE_CONFIG_PATH.read_text())
+        self.lc.schema_validate(parsed, self.lc.LINCE_SCHEMA, "", issues)
+        self.assertEqual(issues, [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #208. m-17 guided-configuration epic; builds on #207 (`apply`) and #202 (resolver). Inspired by mxc's SDK discovery helpers — propose instead of ask.

## What

- **`lince-config discover [--json]`**: detects installed agent binaries (driven by the registry — any agent dropped into `registry.d/` is discovered automatically), toolchains on PATH relevant to mounts (node/cargo/python3/uv/…), candidate rw/ro paths (`$TMPDIR`, `~/.local/share`, `~/.cache`, project dir), and providers whose credentials are present in the host env (or configured) — then emits ready-made `lince-config apply <agent>+normal[+provider]` lines.
- Shells (registry agents with no providers) are listed separately and **never suggested** — they'd match on every machine.
- The preferred provider (claude→anthropic, codex→openai, …) is appended **only when its credentials are actually detected**; otherwise a uniquely-configured user provider; otherwise none.
- **#125 bug class fixed at the source**: every emitted path is absolute (`Path.resolve()`) and existence-validated.
- `--json` output is the machine surface for the #209 skill and the dashboard wizard, and for quickstart preselection (#41).

## How to test it

```
$ python3 scripts/tests/test_discover.py
Ran 5 tests in 0.054s
OK     # incl. both acceptance criteria:
       #  - claude+codex installed → exactly those two templates, valid absolute paths
       #  - every suggestion applies cleanly and the result passes schema validation

# On this machine (5 agents installed):
$ lince-config discover
Installed agents:
  claude     /home/maeste/.local/share/claude/versions/2.1.170
  codex      /usr/local/lib/node_modules/@openai/codex/bin/codex.js
  …
Suggested setup (run any of):
  lince-config apply claude+normal
  …

$ python3 scripts/tests/test_apply.py    # 14 tests OK (no regression)
$ ruff check lince-config/lince-config   # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)