### PR TITLE
docs: Config v2 migration guides — users + developers (#213)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Structured CLI for reading and editing LINCE configuration files (`~/.agent-sand
 
 Also powers the **`/lince-configure` skill** — a natural-language interface that lets any AI coding agent read and modify its own configuration interactively (conversational or guided-menu mode). Installed automatically by `quickstart.sh` or `lince-dashboard/install.sh`.
 
+**Config v2**: configuration is converging on a single versioned policy file (`~/.config/lince/lince.toml`) + a shipped agent registry. Get started with `lince-config discover` / `lince-config apply <agent>+<level>+<provider>`; existing installs keep working unchanged — see the [user migration guide](docs/migration-v2-users.md) and the [developer migration guide](docs/migration-v2-developers.md).
+
 ### [sandbox/](sandbox/)
 
 Bubblewrap-based sandbox for running AI coding agents safely. Restricts filesystem access, blocks git push, isolates environment variables, and hides host processes — with near-zero overhead. Supports any agent via `--agent` flag (`agent-sandbox run -a codex`, `-a gemini`, etc.). Used by the dashboard to spawn every agent.

--- a/docs/documentation/_sidebar.md
+++ b/docs/documentation/_sidebar.md
@@ -2,6 +2,8 @@
   - [Overview](/)
   - [Configuration Keys (generated)](configuration-keys.md)
   - [Docs Inventory](docs-inventory.md)
+  - [Migrating to Config v2 — users](https://github.com/RisorseArtificiali/lince/blob/main/docs/migration-v2-users.md)
+  - [Migrating to Config v2 — developers](https://github.com/RisorseArtificiali/lince/blob/main/docs/migration-v2-developers.md)
 
 - **Sandbox (agent-sandbox)**
   - [CLI Reference](sandbox/cli-reference.md)

--- a/docs/migration-v2-developers.md
+++ b/docs/migration-v2-developers.md
@@ -1,0 +1,71 @@
+# Migrating to Config v2 (developers)
+
+For contributors, skill authors, and integrators. Rationale and full
+contracts: [design doc](design/config-v2-design.md). Key tables:
+[generated configuration reference](documentation/configuration-keys.md).
+
+## The contracts at a glance
+
+| Artifact | Owner | Contract |
+|---|---|---|
+| `registry.d/<agent>.toml` + `providers.toml` | **shipped** | One file per agent; always overwritten on update; generated from the legacy agents-defaults files by `scripts/gen_registry.py` until those are deleted (diff-guard: `scripts/tests/test_registry_sync.py`) |
+| `~/.config/lince/lince.toml` | **user** | Versioned (`version = "2.0"`, §2.1 contract), default-deny, never touched by update |
+| `<project>/.lince/lince.toml` | **project** | Same schema, no `version`, security keys clamped (loosening needs `[trust.projects."…"]`) |
+| `lince-config resolve --json` | **the only read API** | Requested view; secrets never cross (env-var names only) |
+| `<id>.policy.json` (next to `.state`) | runner | **Enforced** view, per launch (§4.3.1) — paranoid fails closed on degradation (I7) |
+
+## Adding an agent: before → after
+
+| | Before | After (#204) |
+|---|---|---|
+| Files to edit | 4 (two agents-defaults, profiles fragment, nono profile) | **1** registry file (+ optional hook) |
+| Pi-style env bundle | copy-pasted 4× | `provider_env = "all"` (expands from `providers.toml`) |
+| `-unsandboxed` variant | duplicated entry incl. event_map | derived (§3.5); exceptions in `[variants.unsandboxed]` |
+| Until legacy files are deleted | — | edit the legacy files and run `python3 scripts/gen_registry.py` (the diff-guard enforces sync) |
+
+## What is removed, and when
+
+| Legacy surface | Replacement | Removal |
+|---|---|---|
+| Dashboard TOML parsing of sandbox-owned files (`parse_providers_from_toml`, level globs, `load_agent_defaults_async`) | `resolve --json` | **removed** (#202) |
+| `~/.local/bin/agents-defaults.toml` double install | registry.d | **removed** (#204) |
+| quickstart awk-filtered agents-defaults rewrites | `lince-config apply` + `[dashboard].enabled_agents` | **removed** (#207) |
+| Python `[profiles.*]` / `default_profile` aliases (`resolve_providers`) | `migrate-providers` rewrite | window close (2.2, §5.6) |
+| Rust `serde(alias = "profiles")` etc. | resolve --json shapes | window close (2.2) |
+| Legacy shipped `agents-defaults.toml` files in repo | registry.d as hand-maintained source | when the dual-read window closes |
+
+## Rules for new config keys
+
+1. **Schema-first**: add the key to the embedded schema in `lince-config`
+   (with `description` + `default`) → `lince-config schema --write schemas/`
+   → `python3 scripts/gen_config_reference.py`. The reference and editor
+   support regenerate; `scripts/tests/test_schemas.py` +
+   `test_config_reference.py` fail on drift.
+2. **Default-deny**: a new policy field must not widen any boundary when
+   absent.
+3. **Version bump**: a key the old parser must not silently ignore ⇒ bump
+   the minor (`SCHEMA_VERSION_NATIVE`); the §2.1 contract handles the window.
+4. Shipped examples must validate clean: `scripts/tests/test_schemas.py`
+   checks every example/template with zero errors *and* zero warnings.
+
+## Skill authors
+
+- Write configuration ONLY through `lince-config apply` / `lince-config set
+  --target lince` / `validate` — never edit TOML files directly, never write
+  into `registry.d/` or `agents-defaults.toml`.
+- Validate your result: `lince-config resolve --agent <name>` fails that
+  agent only, with a named-key diagnostic.
+- Machine surfaces: `lince-config templates --json`, `discover --json`,
+  `resolve --json`.
+
+## Test entry points
+
+```bash
+python3 scripts/tests/test_registry_sync.py      # registry ↔ legacy parity
+python3 scripts/tests/test_schemas.py            # schemas + shipped examples
+python3 scripts/tests/test_resolve.py            # resolver semantics
+python3 scripts/tests/test_apply.py              # composition engine
+python3 scripts/tests/test_policy_record.py      # effective-policy record
+bash sandbox/tests/test-landlock-exec.sh         # Landlock fence gate
+cd lince-dashboard/plugin && cargo build --target wasm32-wasip1
+```

--- a/docs/migration-v2-users.md
+++ b/docs/migration-v2-users.md
@@ -1,0 +1,75 @@
+# Migrating to Config v2 (users)
+
+For people with an existing LINCE install. The *why* is in the
+[design doc](design/config-v2-design.md); this page only answers *what do I do*.
+
+## TL;DR
+
+```bash
+./quickstart.sh            # or: cd sandbox && ./update.sh ; cd ../lince-dashboard && ./update.sh
+lince-config discover      # see what's installed + suggested setup lines
+lince-config apply claude+normal+anthropic   # opt into v2 (one line per agent)
+lince-config validate --target lince         # verify
+```
+
+No `lince.toml`? **Nothing breaks.** Your old config files keep working
+through the dual-read window (see timeline below).
+
+## What happens automatically
+
+| Thing | Behavior |
+|---|---|
+| Old config files (`~/.agent-sandbox/config.toml`, `~/.config/lince-dashboard/config.toml`) | Still read, as long as `~/.config/lince/lince.toml` does **not** exist (dual-read) |
+| Shipped agent definitions | Now installed once to `~/.local/share/lince/registry.d/` (always overwritten on update — never edit them) |
+| Legacy `agents-defaults.toml` copies | Kept installed during the window; the `~/.local/bin/agents-defaults.toml` duplicate is removed |
+| Dashboard | Reads everything via `lince-config resolve --json` — same results on both paths |
+
+## The one hard switch
+
+Creating `~/.config/lince/lince.toml` (the first `lince-config apply` or
+`lince-config set --target lince`) makes it the **only** source: the old
+config files stop being read for agents/providers. If they still contain
+real customizations, `apply` **refuses** and lists them — migrate those keys
+first (table below), or pass `--force-v2` to proceed anyway.
+
+## What you must migrate manually
+
+| Legacy (where) | New location (how) |
+|---|---|
+| `[providers.vertex]` / `[claude.profiles.zai]` etc. in sandbox config | `[providers.<name>]` in `lince.toml` (env-var **names** + hosts; values stay in your shell env) |
+| `default_profile` / `default_provider` in `[sandbox]` | `lince-config apply <agent>+<provider>` (per-agent), or `[sandbox] default_provider` in `lince.toml` |
+| `sandbox_level = "paranoid"` on `[agents.<x>]` (dashboard config) | `lince-config apply <agent>+paranoid` |
+| Custom agents in `agents-defaults.toml` or `config.toml [agents.*]` | `[agents.<name>]` in `lince.toml` — 4 required keys (`binary`, `display_name`, `short_label`, `color`), the rest is derived. Worked example: design doc §7.2 |
+| `[security] allow_domains` | `[network] allowed_hosts` in `lince.toml` |
+| Raw mechanism tweaks (extra bwrap args, …) | `[experimental]` in `lince.toml` — voids the default-deny guarantee **visibly** |
+| `[logging]` / `[snapshot]` / `[git]` | Same tables, copied 1:1 |
+
+An automatic `lince config migrate` ships with the unified `lince` CLI
+(m-14); until then the table above is the migration.
+
+## How to verify
+
+```bash
+lince-config validate --target lince     # ✓ … is valid.  (zero warnings)
+lince-config resolve --agent claude      # JSON: check "level", "provider",
+                                         # "guarantee": "default-deny"
+```
+
+Healthy output: your chosen level/provider under `"origin": {"level": "user"}`,
+`"guarantee": "default-deny"`, and a `warnings: []` array.
+
+## Rollback
+
+- v2 is opt-in and reversible: **delete (or rename) `~/.config/lince/lince.toml`**
+  and resolution returns to your legacy files — they were never modified.
+- `update.sh` config merges back up to `*.bak.<timestamp>` next to each file.
+- Pin a previous version: check out the previous git tag and re-run the
+  module `install.sh` scripts.
+
+## Deprecation timeline
+
+| Release | Behavior |
+|---|---|
+| 2.0 (now) | `lince.toml` + `registry.d/` introduced; dual-read active; everything keeps working without action |
+| 2.1 | Dual-read still active; a migration notice prints on every run |
+| 2.2 | Legacy-only installs hard-error: `legacy config found but schema 2.2 requires lince.toml. Run: lince config migrate` |


### PR DESCRIPTION
Closes #213. Closing docs deliverable of epic #200 / m-16, written after the contracts landed (#202/#203/#204/#205/#207/#208/#221/#222) so every command shown is real.

## What

- **`docs/migration-v2-users.md`** — one screen, tables/checklists over prose:
  - TL;DR (4 commands), what happens automatically (dual-read window — *no `lince.toml` = nothing breaks*), the one hard switch (creating `lince.toml`, with the `apply` guard that refuses when legacy intent would be silently dropped), the manual legacy→v2 key mapping table, verification (`validate` + `resolve` and what healthy output looks like), rollback (delete `lince.toml` — legacy files are never modified), and the §5.6 deprecation timeline.
  - Honest about scope: the automatic `lince config migrate` is marked as the m-14 unified-CLI deliverable; until then the mapping table *is* the migration.
- **`docs/migration-v2-developers.md`** — contracts at a glance (registry.d / lince.toml / project overlay / `resolve --json` as the only read API / effective-policy record), adding-an-agent before→after, **removal schedule** for every legacy surface (what's already gone vs what dies when the window closes), schema-first rules for new keys (with the #212 regeneration loop), skill-author rules (only `apply`/`set --target lince`/`validate`, never direct TOML edits — the #209 contract), and the test entry points.
- Linked from `README.md` (new Config v2 paragraph) and the docs-site sidebar.

Style check per the issue: schematic, no section over ~10 lines of prose, "what do I do" only (the why links to the design doc once).

## How to test it

Docs-only PR — verification is review. Sanity:
```
$ python3 - <<'PY'   # every command mentioned in the user guide exists
import subprocess
for cmd in (["python3","lince-config/lince-config","discover","--json"],
            ["python3","lince-config/lince-config","templates","--json"],
            ["python3","lince-config/lince-config","validate","--help"],
            ["python3","lince-config/lince-config","apply","--help"]):
    assert subprocess.run(cmd, capture_output=True).returncode == 0, cmd
print("all guide commands exist")
PY
all guide commands exist
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)