### PR TITLE
feat(config): [experimental] raw backend overrides, gated + visible (#210)

### DIFF
--- a/docs/documentation/configuration-keys.md
+++ b/docs/documentation/configuration-keys.md
@@ -261,12 +261,15 @@ User intent, versioned, default-deny — design config-v2 §2. Project overlays 
 
 ### `[experimental]`
 
+Raw mechanism passthroughs (#210). Each active key voids the validated default-deny guarantee VISIBLY: spawn banner + resolve guarantee = 'void:<key>'. Never offered by guided flows.
+
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `landlock` | bool | — | — |
-| `raw_bwrap_args` | list[string] | — | — |
-| `seatbelt_extra` | str | — | — |
-| `permissive_network` | bool | — | — |
+| `landlock` | bool | — | Pre-#222 opt-in flag (Landlock now ships enabled by default via [security].landlock) |
+| `raw_bwrap_args` | list[string] | — | Extra bwrap arguments appended LAST to the generated command (expert valve — e.g. one extra --bind) |
+| `seatbelt_extra` | str | — | Seatbelt profile snippet appended verbatim to the generated .sb |
+| `permissive_network` | bool | — | Required to set [network].default = 'allow' |
+| `agents` | table | — | Per-agent overrides — appended after the global ones |
 
 ### `[logging]`
 

--- a/lince-config/lince-config
+++ b/lince-config/lince-config
@@ -92,6 +92,16 @@ LINCE_REGISTRY_DIRS = [
     Path(__file__).resolve().parent.parent / "registry.d",
 ]
 
+def _d(base: dict, desc: str, default=None) -> dict:
+    """Attach a description (+ default) to a schema fragment — the generation
+    source for the config reference (#212): scripts/gen_config_reference.py
+    renders these into the skill reference files and the docs site."""
+    out = {**base, "description": desc}
+    if default is not None:
+        out["default"] = default
+    return out
+
+
 _STR = {"type": "string"}
 _BOOL = {"type": "boolean"}
 _INT = {"type": "integer"}
@@ -320,11 +330,28 @@ LINCE_SCHEMA = {
         # escape hatches — OUTSIDE the version contract; warn only (§2.5).
         "experimental": {
             "type": "object",
+            "description": "Raw mechanism passthroughs (#210). Each active key "
+                           "voids the validated default-deny guarantee VISIBLY: "
+                           "spawn banner + resolve guarantee = 'void:<key>'. "
+                           "Never offered by guided flows.",
             "properties": {
-                "landlock": _BOOL,
-                "raw_bwrap_args": _STR_LIST,
-                "seatbelt_extra": _STR,
-                "permissive_network": _BOOL,
+                "landlock": _d(_BOOL, "Pre-#222 opt-in flag (Landlock now ships "
+                                      "enabled by default via [security].landlock)"),
+                "raw_bwrap_args": _d(_STR_LIST, "Extra bwrap arguments appended LAST "
+                                                "to the generated command (expert "
+                                                "valve — e.g. one extra --bind)"),
+                "seatbelt_extra": _d(_STR, "Seatbelt profile snippet appended "
+                                           "verbatim to the generated .sb"),
+                "permissive_network": _d(_BOOL, "Required to set [network].default "
+                                               "= 'allow'"),
+                "agents": _d({"type": "object", "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                        "raw_bwrap_args": _STR_LIST,
+                        "seatbelt_extra": _STR,
+                    },
+                    "additionalProperties": True,
+                }}, "Per-agent overrides — appended after the global ones"),
             },
             "additionalProperties": True,
         },
@@ -374,16 +401,6 @@ LINCE_SCHEMA = {
 
 # Legacy v1 provider entry ([providers.*] in the sandbox config — env holds
 # NAME = VALUE pairs there, unlike v2's list of names).
-def _d(base: dict, desc: str, default=None) -> dict:
-    """Attach a description (+ default) to a schema fragment — the generation
-    source for the config reference (#212): scripts/gen_config_reference.py
-    renders these into the skill reference files and the docs site."""
-    out = {**base, "description": desc}
-    if default is not None:
-        out["default"] = default
-    return out
-
-
 _V1_PROVIDER_SCHEMA = {
     "type": "object",
     "description": "A provider: named env-var bundle switching model "
@@ -1586,6 +1603,13 @@ def _validate_lince_file(path: Path, issues: list, overlay: bool = False) -> Non
             "level": "warn",
             "message": f"{path}: [experimental] is not honored in project overlays (§2.4)",
         })
+    if not overlay:
+        for key in _active_experimental_keys(parsed.get("experimental", {})):
+            issues.append({
+                "level": "warn",
+                "message": f"policy-overridden: [experimental].{key} is active — "
+                           f"the validated default-deny guarantee is void (§2.5)",
+            })
     # Hard version errors mean the file may follow a different schema —
     # skip key-level validation to avoid misleading diagnostics.
     if any(i["level"] == "error" for i in issues):
@@ -1895,6 +1919,24 @@ def _expand_provider_env_all(env: dict, providers: dict) -> dict:
     return out
 
 
+def _active_experimental_keys(experimental: dict) -> list[str]:
+    """Names of [experimental] keys that are actually ACTIVE (truthy),
+    including per-agent ones as 'agents.<name>.<key>' (#210)."""
+    if not isinstance(experimental, dict):
+        return []
+    active: list[str] = []
+    for key, val in experimental.items():
+        if key == "agents" and isinstance(val, dict):
+            for agent, table in val.items():
+                if isinstance(table, dict):
+                    for sub, sub_val in table.items():
+                        if sub_val not in (False, "", [], {}, None):
+                            active.append(f"agents.{agent}.{sub}")
+        elif val not in (False, "", [], {}, None):
+            active.append(key)
+    return active
+
+
 def build_resolved_view(
     project_dir: Path | None = None,
     agent_filter: str | None = None,
@@ -1926,6 +1968,7 @@ def build_resolved_view(
     guarantee = "default-deny"
     network: dict = {"default": "deny", "allowed_hosts": []}
     agent_policy: dict[str, dict] = {}     # name -> policy keys (level/provider/allowed_hosts)
+    active_experimental: list[str] = []    # [experimental] hatches in force (#210)
     agent_origin: dict[str, dict] = {}     # name -> {key: origin}
     user_provider_names_by_agent: dict[str, list] = {}
     user_provider_details: dict[str, dict] = {}  # name -> {env, env_unset}
@@ -1975,9 +2018,9 @@ def build_resolved_view(
             agent_policy[name] = policy
             agent_origin[name] = {k: "user" for k in policy}
         experimental = lince.get("experimental", {})
-        active = [k for k, v in experimental.items() if v not in (False, "", [], {}, None)]
-        if active:
-            guarantee = f"void:{active[0]}"
+        active_experimental = _active_experimental_keys(experimental)
+        if active_experimental:
+            guarantee = f"void:{active_experimental[0]}"
         sb = lince.get("sandbox", {})
         default_provider = sb.get("default_provider") or None
         enabled = lince.get("dashboard", {}).get("enabled_agents")
@@ -2318,6 +2361,13 @@ def build_resolved_view(
             },
             "variants": {"unsandboxed": _derive_unsandboxed(name, entry, env)},
             "allowed_hosts_effective": allowed_hosts,
+            # active [experimental] hatches affecting this agent (#210):
+            # globals + its own [experimental.agents.<name>] entries — lets
+            # the dashboard badge "custom policy" agents.
+            "experimental": [
+                k for k in active_experimental
+                if not k.startswith("agents.") or k.startswith(f"agents.{name}.")
+            ],
             "origin": origin,
         }
 

--- a/lince-dashboard/skills/lince-configure/references/lince-policy.md
+++ b/lince-dashboard/skills/lince-configure/references/lince-policy.md
@@ -84,12 +84,15 @@ Key reference for `~/.config/lince/lince.toml` (and the project overlay `<projec
 
 ## `[experimental]`
 
+Raw mechanism passthroughs (#210). Each active key voids the validated default-deny guarantee VISIBLY: spawn banner + resolve guarantee = 'void:<key>'. Never offered by guided flows.
+
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `landlock` | bool | — | — |
-| `raw_bwrap_args` | list[string] | — | — |
-| `seatbelt_extra` | str | — | — |
-| `permissive_network` | bool | — | — |
+| `landlock` | bool | — | Pre-#222 opt-in flag (Landlock now ships enabled by default via [security].landlock) |
+| `raw_bwrap_args` | list[string] | — | Extra bwrap arguments appended LAST to the generated command (expert valve — e.g. one extra --bind) |
+| `seatbelt_extra` | str | — | Seatbelt profile snippet appended verbatim to the generated .sb |
+| `permissive_network` | bool | — | Required to set [network].default = 'allow' |
+| `agents` | table | — | Per-agent overrides — appended after the global ones |
 
 ## `[logging]`
 

--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -2977,7 +2977,8 @@ def build_bwrap_cmd(config: dict, project_dir: Path,
                     agent_name: str = "claude",
                     proxy_env: dict[str, str] | None = None,
                     scratch_binds: list[tuple[str, str]] | None = None,
-                    landlock: dict | None = None) -> list[str]:
+                    landlock: dict | None = None,
+                    raw_bwrap_args: list[str] | None = None) -> list[str]:
     home = str(Path.home())
     home_p = Path.home()
     sandbox = config.get("sandbox", {})
@@ -3308,6 +3309,15 @@ def build_bwrap_cmd(config: dict, project_dir: Path,
                 args_source.append(da)
 
     agent_cmd = [agent_cfg["command"]] + args_source + list(agent_extra_args)
+
+    # --- [experimental].raw_bwrap_args (#210) ---------------------------------
+    # Appended LAST (mxc profileOverride precedent): the expert's args win
+    # over every generated option. Before the trailing `--` like all options.
+    if raw_bwrap_args:
+        if cmd and cmd[-1] == "--":
+            cmd[-1:-1] = list(raw_bwrap_args)
+        else:
+            cmd += list(raw_bwrap_args)
 
     # --- Landlock hardening shim (#222) ---------------------------------------
     # Injected as the LAST bwrap argv element so its rule FDs open in the
@@ -3651,6 +3661,66 @@ def enforce_paranoid_fail_closed(level: str | None, record: dict) -> None:
 
 def _argv_digest(cmd: list[str]) -> str:
     return hashlib.sha256("\0".join(cmd).encode("utf-8", "replace")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# [experimental] escape hatches (#210, design config-v2 §2.5)
+#
+# Raw mechanism passthroughs from the USER policy file (lince.toml) — the
+# policy layer must not trap experts. Contract: overrides are appended LAST,
+# survive updates (they live in user-owned lince.toml), void the validated-
+# policy guarantee VISIBLY (spawn banner + resolve "guarantee": "void:<key>",
+# I5), and are never offered by guided flows.
+# ---------------------------------------------------------------------------
+
+LINCE_POLICY_PATH = Path.home() / ".config" / "lince" / "lince.toml"
+
+
+def load_experimental_overrides(agent_name: str) -> dict:
+    """Read [experimental] (+ [experimental.agents.<name>]) from lince.toml.
+
+    Returns {"raw_bwrap_args": [...], "seatbelt_extra": str, "active": [keys]}.
+    Per-agent values append after (bwrap args) / below (seatbelt) the global
+    ones. Missing/malformed lince.toml -> empty overrides.
+    """
+    out = {"raw_bwrap_args": [], "seatbelt_extra": "", "active": []}
+    try:
+        with open(LINCE_POLICY_PATH, "rb") as fh:
+            experimental = tomllib.load(fh).get("experimental", {})
+    except (FileNotFoundError, tomllib.TOMLDecodeError, OSError):
+        return out
+    if not isinstance(experimental, dict):
+        return out
+
+    def absorb(table: dict, scope: str) -> None:
+        args = table.get("raw_bwrap_args")
+        if isinstance(args, list) and args:
+            out["raw_bwrap_args"] += [str(a) for a in args]
+            out["active"].append(f"raw_bwrap_args{scope}")
+        extra = table.get("seatbelt_extra")
+        if isinstance(extra, str) and extra.strip():
+            out["seatbelt_extra"] += ("\n" if out["seatbelt_extra"] else "") + extra
+            out["active"].append(f"seatbelt_extra{scope}")
+
+    absorb(experimental, "")
+    per_agent = experimental.get("agents", {})
+    if isinstance(per_agent, dict):
+        agent_tbl = per_agent.get(agent_name, {})
+        if isinstance(agent_tbl, dict):
+            absorb(agent_tbl, f" (agents.{agent_name})")
+    return out
+
+
+def print_experimental_banner(active: list[str]) -> None:
+    """I5: escape hatches void the guarantee VISIBLY, at spawn."""
+    if not active:
+        return
+    print(
+        f"\033[1;31m⚠  EXPERIMENTAL policy override active: {', '.join(active)}\n"
+        f"   The validated default-deny guarantee is VOID for this launch "
+        f"(lince.toml [experimental], design §2.5).\033[0m",
+        file=sys.stderr,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -4357,6 +4427,9 @@ def cmd_run(args, agent_extra: list[str]) -> None:
         sb_combined_env.update(sb_proxy_env)
         sb_combined_env.update(sb_git_env)
 
+        # [experimental] escape hatches (#210).
+        sb_experimental = load_experimental_overrides(agent_name)
+
         # Build the seatbelt command (generates a runtime profile with the
         # real project dir injected)
         cmd, runtime_profile = build_seatbelt_cmd(
@@ -4383,6 +4456,18 @@ def cmd_run(args, agent_extra: list[str]) -> None:
             except OSError:
                 pass
             return
+
+        # [experimental].seatbelt_extra (#210): appended VERBATIM, last, to the
+        # generated runtime profile — later Seatbelt rules win.
+        if sb_experimental["seatbelt_extra"]:
+            try:
+                with open(runtime_profile, "a", encoding="utf-8") as fh:
+                    fh.write("\n;; [experimental].seatbelt_extra (lince.toml, #210)\n")
+                    fh.write(sb_experimental["seatbelt_extra"] + "\n")
+            except OSError as exc:
+                print(f"agent-sandbox: warning: could not append seatbelt_extra: {exc}",
+                      file=sys.stderr)
+        print_experimental_banner(sb_experimental["active"])
 
         # Print level-specific warnings (e.g. paranoid limitations on Seatbelt)
         level_warnings = check_seatbelt_level_warnings(backend, sandbox_level, config)
@@ -4731,6 +4816,9 @@ def cmd_run(args, agent_extra: list[str]) -> None:
             sys.exit(1)
         # normal: graceful — the shim logs and continues bwrap-only.
 
+    # [experimental] escape hatches (#210) — read from the user policy file.
+    experimental = load_experimental_overrides(agent_name)
+
     # Build command
     cmd = build_bwrap_cmd(config, project_dir, agent_extra, log_file,
                           profile=profile, safe_mode=args.safe,
@@ -4739,7 +4827,8 @@ def cmd_run(args, agent_extra: list[str]) -> None:
                           agent_name=agent_name,
                           proxy_env=proxy_env if proxy_env else None,
                           scratch_binds=scratch_binds or None,
-                          landlock=landlock)
+                          landlock=landlock,
+                          raw_bwrap_args=experimental["raw_bwrap_args"] or None)
 
     # Paranoid wrap: create a userns + fresh netns OUTSIDE bwrap so we can
     # bring up loopback (needs CAP_NET_ADMIN, which non-setuid bwrap drops
@@ -4825,6 +4914,7 @@ def cmd_run(args, agent_extra: list[str]) -> None:
     claude_scratched = any(
         target == str(Path.home() / ".claude") for _, target in scratch_binds
     )
+    print_experimental_banner(experimental["active"])
     print("agent-sandbox")
     print(f"  config      {config_path}")
     print(f"  backend     agent-sandbox (bubblewrap)")

--- a/schemas/lince.schema.json
+++ b/schemas/lince.schema.json
@@ -389,21 +389,45 @@
     },
     "experimental": {
       "type": "object",
+      "description": "Raw mechanism passthroughs (#210). Each active key voids the validated default-deny guarantee VISIBLY: spawn banner + resolve guarantee = 'void:<key>'. Never offered by guided flows.",
       "properties": {
         "landlock": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Pre-#222 opt-in flag (Landlock now ships enabled by default via [security].landlock)"
         },
         "raw_bwrap_args": {
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "description": "Extra bwrap arguments appended LAST to the generated command (expert valve \u2014 e.g. one extra --bind)"
         },
         "seatbelt_extra": {
-          "type": "string"
+          "type": "string",
+          "description": "Seatbelt profile snippet appended verbatim to the generated .sb"
         },
         "permissive_network": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Required to set [network].default = 'allow'"
+        },
+        "agents": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "raw_bwrap_args": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "seatbelt_extra": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": true
+          },
+          "description": "Per-agent overrides \u2014 appended after the global ones"
         }
       },
       "additionalProperties": true

--- a/scripts/tests/test_resolve.py
+++ b/scripts/tests/test_resolve.py
@@ -215,6 +215,28 @@ class ResolveTestCase(unittest.TestCase):
         view = self.resolve()
         self.assertEqual(view["guarantee"], "void:permissive_network")
 
+    def test_experimental_reported_per_agent(self):
+        """#210: per-agent hatches surface on that agent only; globals on all."""
+        self.write_lince(
+            'version = "2.0"\n'
+            '[experimental]\nseatbelt_extra = "(allow file-write* (subpath \\"/opt\\"))"\n'
+            '[experimental.agents.codex]\nraw_bwrap_args = ["--hostname", "x"]\n'
+        )
+        view = self.resolve()
+        self.assertTrue(view["guarantee"].startswith("void:"))
+        self.assertIn("seatbelt_extra", view["agents"]["claude"]["experimental"])
+        self.assertNotIn("agents.codex.raw_bwrap_args",
+                         view["agents"]["claude"]["experimental"])
+        self.assertIn("agents.codex.raw_bwrap_args",
+                      view["agents"]["codex"]["experimental"])
+
+    def test_experimental_validate_warns_not_blocks(self):
+        self.write_lince('version = "2.0"\n[experimental]\nraw_bwrap_args = ["--dev-bind", "/x", "/x"]\n')
+        issues = []
+        self.lc._validate_lince_file(self.lince_cfg, issues)
+        self.assertTrue(any("policy-overridden" in i["message"] for i in issues))
+        self.assertFalse(any(i["level"] == "error" for i in issues))
+
     def test_custom_agent_in_lince_toml(self):
         self.write_lince(
             'version = "2.0"\n'


### PR DESCRIPTION
Closes #210. Final m-17 item of this wave. The `[experimental]` schema + the `guarantee: "void:<key>"` resolve flip shipped with #203/#202 — this PR adds the missing **mechanism wiring**, the validate warning, and per-agent reporting.

## What

- **agent-sandbox honors `lince.toml [experimental]`** (global + `[experimental.agents.<name>]`, per-agent appended after global):
  - `raw_bwrap_args` appended **last** to the generated bwrap command (mxc `profileOverride` precedent — the expert's args win over every generated option). The #222 Landlock rw-rule derivation runs after the append, so an expert `--bind` gets a matching Landlock rule automatically — one intent, two mechanisms even on the escape hatch.
  - `seatbelt_extra` appended **verbatim, last** to the generated runtime `.sb` (later Seatbelt rules win).
  - **Spawn banner (I5)** on both backends: bold-red `⚠ EXPERIMENTAL policy override active: <keys> … guarantee is VOID`.
- **`validate` warns, never blocks**: `policy-overridden: [experimental].<key> is active — the validated default-deny guarantee is void (§2.5)`.
- **`resolve --json`**: per-agent `"experimental"` list (globals + that agent's own entries) on top of the existing `guarantee` flip — the dashboard badge hook for "custom policy" agents.
- **Contract documented in the schema** (descriptions, per-agent table) → generated references regenerated. Overrides live in user-owned `lince.toml`, so they survive updates by construction; `templates`/`apply`/the v2 skill never offer them (the skill explicitly warns before setting one).

## How to test it (acceptance, run live)

```
# expert adds ONE bwrap bind — no template forking:
$ cat ~/.config/lince/lince.toml
version = "2.0"
[experimental]
raw_bwrap_args = ["--bind", "/tmp/lince-extra", "/tmp/lince-extra"]

$ agent-sandbox run -p proj --agent bash -- -c 'cat /tmp/lince-extra/probe.txt'
⚠  EXPERIMENTAL policy override active: raw_bwrap_args
   The validated default-deny guarantee is VOID for this launch …
visible                                  ← the bind works

$ lince-config validate --target lince
  ⚠ policy-overridden: [experimental].raw_bwrap_args is active — the validated default-deny guarantee is void (§2.5)
  0 error(s), 1 warning(s).             ← flags, does not block

$ lince-config resolve --agent claude | jq '{guarantee, exp: .agents.claude.experimental}'
guarantee: void:raw_bwrap_args | claude experimental: ['raw_bwrap_args']

$ python3 scripts/tests/test_resolve.py        # 17 tests OK (+2: per-agent reporting, warn-not-block)
$ python3 scripts/tests/test_schemas.py && python3 scripts/tests/test_config_reference.py \
  && python3 scripts/tests/test_policy_record.py && python3 scripts/tests/test_default_config.py  # OK
$ bash sandbox/tests/test-landlock-exec.sh     # ALL 10 CHECKS PASSED
$ ruff check sandbox/agent-sandbox             # 49 == main baseline
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)