### PR TITLE
fix(config-v2): post-wave review findings — I7 net gap, I4 redaction, Landlock bind ports

### DIFF
--- a/lince-config/lince-config
+++ b/lince-config/lince-config
@@ -1375,11 +1375,21 @@ def cmd_check(args) -> int:
     return 1 if any(i["level"] == "error" for i in issues) else 0
 
 
-_SENSITIVE_KEY_KEYWORDS = ("API_KEY", "SECRET", "TOKEN", "PASSWORD", "ACCESS_KEY", "PRIVATE_KEY")
+# Substrings (matched against the UPPERCASE key name) that mark a value as a
+# credential. Broadened past the obvious *_API_KEY forms so a non-standard key
+# (LLM_GATEWAY_CRED, *_AUTH, *_BEARER) does not leak its literal value through
+# resolve --json (I4, #222 review). These substrings do not appear in the
+# common non-secret config var names (REGION, PROJECT, LOCATION, BASE_URL,
+# ENDPOINT, ACCOUNT_ID), so over-redaction of legit literals stays unlikely.
+_SENSITIVE_KEY_KEYWORDS = (
+    "API_KEY", "APIKEY", "SECRET", "TOKEN", "PASSWORD", "PASSWD", "PASSPHRASE",
+    "ACCESS_KEY", "PRIVATE_KEY", "AUTH", "BEARER", "CRED", "SIGNING_KEY",
+    "SESSION_KEY",
+)
 
-# Regexes for credentials that are recognizable from the value alone, regardless
-# of the key name. Conservative — only matches well-known prefixes/structures to
-# avoid flagging arbitrary strings.
+# Regexes for credentials recognizable from the value alone, regardless of the
+# key name. Conservative — well-known prefixes plus a long-opaque-token catch
+# for raw tokens under innocuous key names.
 _SENSITIVE_VALUE_PATTERNS = (
     re.compile(r"^sk-[A-Za-z0-9_\-]{16,}"),         # Anthropic / OpenAI style
     re.compile(r"^xai-[A-Za-z0-9_\-]{16,}"),        # xAI
@@ -1389,6 +1399,11 @@ _SENSITIVE_VALUE_PATTERNS = (
     re.compile(r"^AKIA[0-9A-Z]{16}"),               # AWS access key
     re.compile(r"^AIza[0-9A-Za-z_\-]{20,}"),        # Google API key
     re.compile(r"^-----BEGIN [A-Z ]*PRIVATE KEY"),  # PEM private key
+    # Long opaque token (>=32 chars, only token chars, mixes letters+digits):
+    # almost never a config literal (regions/projects/URLs are shorter and use
+    # ./:/spaces), so the false-positive cost is low while it catches raw
+    # bearer-style secrets under non-obvious key names.
+    re.compile(r"^(?=.*[A-Za-z])(?=.*[0-9])[A-Za-z0-9_\-]{32,}$"),
 )
 
 
@@ -2077,9 +2092,21 @@ def build_resolved_view(
                 for pname, ptbl in provs.items():
                     if not isinstance(ptbl, dict):
                         continue
+                    raw_env = ptbl.get("env", {}) or {}
+                    # Availability must be judged on the RAW value, before
+                    # redaction rewrites literals to "$NAME" (#222 review): a
+                    # provider configured with a literal key counts as ready
+                    # even with nothing in the host env.
+                    configured = any(
+                        str(v).strip()
+                        and not _is_env_self_ref(k, str(v))
+                        and not str(v).startswith("$")
+                        for k, v in raw_env.items()
+                    )
                     user_provider_details[pname] = {
-                        "env": _redact_env(ptbl.get("env", {}) or {}),
+                        "env": _redact_env(raw_env),
                         "env_unset": list(ptbl.get("env_unset", []) or []),
+                        "configured": configured,
                     }
 
         # User [agents.*] overrides: sandbox config first (jail keys), then
@@ -2249,10 +2276,10 @@ def build_resolved_view(
         details = user_provider_details.get(pname, {})
         env_map = dict(details.get("env", {}))
         env_keys = sorted(set(shipped.get("env", [])) | set(env_map))
-        available = any(_env_available(k) for k in env_keys) or any(
-            not _is_env_self_ref(k, str(v)) and not str(v).startswith("$")
-            for k, v in env_map.items()
-        )
+        # A provider is available if any of its env NAMES is set in the host
+        # env, or it was configured with a literal value (judged pre-redaction
+        # at collection time — the redacted env_map here is names-only, I4).
+        available = any(_env_available(k) for k in env_keys) or details.get("configured", False)
         providers_out[pname] = {
             "env_keys": env_keys,
             "hosts": list(shipped.get("hosts", [])),

--- a/lince-dashboard/plugin/src/dashboard.rs
+++ b/lince-dashboard/plugin/src/dashboard.rs
@@ -718,6 +718,12 @@ fn render_detail_panel(agent: &AgentInfo, cols: usize, max_rows: usize, agent_ty
             if let Some(ref reason) = p.degraded_reason {
                 extra.push_str(&format!(" \x1b[1;33m{}\x1b[0m", reason));
             }
+            if !p.experimental.is_empty() {
+                extra.push_str(&format!(
+                    " \x1b[1;33moverride: {}\x1b[0m",
+                    p.experimental.join(", ")
+                ));
+            }
             let line = format!(
                 " {}Enforced:{} {}{}{} [{}]{}",
                 CYAN, RESET, color, p.badge(), RESET, p.backend, extra,

--- a/lince-dashboard/plugin/src/types.rs
+++ b/lince-dashboard/plugin/src/types.rs
@@ -393,17 +393,34 @@ pub struct EnforcedPolicy {
     pub net_limitation: Option<String>,
     #[serde(default)]
     pub degraded_reason: Option<String>,
+    /// True when an [experimental] hatch (raw_bwrap_args / seatbelt_extra) is
+    /// active for this launch (#210): the boundary may be widened in ways the
+    /// mechanism layer can't attest, so fs/net ticks must NOT be trusted as a
+    /// clean "fully enforced" result.
+    #[serde(default)]
+    pub policy_overridden: bool,
+    #[serde(default)]
+    pub experimental: Vec<String>,
 }
 
 impl EnforcedPolicy {
+    /// Fully enforced ONLY when both axes hold AND no experimental override is
+    /// in force (an override voids the validated-policy guarantee, §2.5).
     pub fn fully_enforced(&self) -> bool {
-        self.fs_enforced && self.net_enforced
+        self.fs_enforced && self.net_enforced && !self.policy_overridden
     }
 
-    /// Compact badge: which boundary the kernel actually enforced.
+    /// Compact badge: which boundary the kernel actually enforced. An active
+    /// [experimental] override appends a custom-policy marker (#210) so a
+    /// widened boundary never reads as a clean fs✓ net✓.
     pub fn badge(&self) -> String {
         let tick = |ok: bool| if ok { "\u{2713}" } else { "\u{2717}" };
-        format!("fs{} net{}", tick(self.fs_enforced), tick(self.net_enforced))
+        let base = format!("fs{} net{}", tick(self.fs_enforced), tick(self.net_enforced));
+        if self.policy_overridden {
+            format!("{} \u{26a0}custom", base)
+        } else {
+            base
+        }
     }
 }
 
@@ -698,6 +715,18 @@ mod tests {
         assert!(!p.fully_enforced());
         assert_eq!(p.badge(), "fs\u{2717} net\u{2717}");
         assert_eq!(p.degraded_reason.as_deref(), Some("delegated to nono"));
+    }
+
+    /// An [experimental] override (#210) voids the clean fully_enforced result
+    /// even when both axes tick, and the badge shows a custom-policy marker.
+    #[test]
+    fn enforced_policy_experimental_override_voids_clean_result() {
+        let json = r#"{"backend":"bwrap","fs_enforced":true,"net_enforced":true,
+            "policy_overridden":true,"experimental":["raw_bwrap_args"]}"#;
+        let p: EnforcedPolicy = serde_json::from_str(json).unwrap();
+        assert!(!p.fully_enforced());
+        assert!(p.badge().contains("custom"));
+        assert_eq!(p.experimental, vec!["raw_bwrap_args".to_string()]);
     }
 
     fn make_agent(status: AgentStatus, exit_code: Option<i32>) -> AgentInfo {

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -814,6 +814,23 @@ configure_agent_selection() {
 
     echo ""
     echo -e "${CYAN}Persisting agent selection to ~/.config/lince/lince.toml...${NC}"
+
+    # Probe the v2 switch up front with a dry-run: if pre-existing legacy
+    # customizations would be silently dropped, `apply` refuses (asking for
+    # --force-v2). Detect that once and stop with a single clear, actionable
+    # message instead of looping a refusal per agent (#222 review).
+    local probe_err
+    probe_err="$("$LC" apply "${SELECTED_AGENTS[0]}+normal" --dry-run 2>&1 >/dev/null)"
+    if echo "$probe_err" | grep -q -- "--force-v2"; then
+        echo -e "  ${YELLOW}⚠ Existing legacy customizations block the Config v2 switch —"
+        echo -e "    your agent selection was NOT persisted. All registry agents stay"
+        echo -e "    available in the dashboard picker.${NC}"
+        echo -e "    To apply your picks (${SELECTED_AGENTS[*]}): migrate your legacy"
+        echo -e "    config first (see docs/migration-v2-users.md), then run e.g."
+        echo -e "      lince-config apply ${SELECTED_AGENTS[0]}+normal"
+        return
+    fi
+
     local ok=true
     for agent in "${SELECTED_AGENTS[@]}"; do
         if ! "$LC" apply "${agent}+normal" >/dev/null 2>&1; then
@@ -834,10 +851,9 @@ configure_agent_selection() {
     if [ "$ok" = true ]; then
         echo -e "${GREEN}✓ Agents enabled: ${SELECTED_AGENTS[*]}${NC}"
     else
-        echo -e "  ${YELLOW}⚠ Could not persist the agent selection (existing legacy"
-        echo -e "    customizations detected?). All registry agents stay available;"
-        echo -e "    run 'lince-config apply <agent>+<level>' manually after migrating"
-        echo -e "    (see docs/migration-v2-users.md).${NC}"
+        echo -e "  ${YELLOW}⚠ Could not fully persist the agent selection. All registry"
+        echo -e "    agents stay available; re-run 'lince-config apply <agent>+<level>'"
+        echo -e "    manually (see docs/migration-v2-users.md).${NC}"
     fi
 }
 

--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -3352,6 +3352,12 @@ def build_bwrap_cmd(config: dict, project_dir: Path,
             shim += ["--connect-port", str(port)]
         for port in landlock.get("bind_ports", []):
             shim += ["--bind-port", str(port)]
+        # Pass the restrict-axis intent explicitly so a deny-all (empty port
+        # list) is distinguishable from "leave this axis open" (#222 review).
+        if landlock.get("restrict_connect"):
+            shim += ["--restrict-connect"]
+        if landlock.get("restrict_bind"):
+            shim += ["--restrict-bind"]
         if landlock.get("fail_closed"):
             shim += ["--fail-closed"]
         shim += ["--"]
@@ -3592,13 +3598,23 @@ def build_policy_record(
     applied_before_exec: bool = True,
     inherited_by_subprocesses: str = "by-design (kernel namespaces)",
     degraded_reason: str | None = None,
+    experimental: list[str] | None = None,
 ) -> dict:
     """Assemble the §4.3.1 record. degraded_reason is REQUIRED whenever any
     *_enforced is false — asserted here so the degraded path can never be
-    silent (I7)."""
+    silent (I7).
+
+    ``experimental`` lists active [experimental] hatches (#210): they can
+    widen the boundary in ways the mechanism layer can't attest, so the
+    record carries ``policy_overridden`` and the dashboard badges it as
+    custom-policy instead of trusting a green fs/net result.
+    """
     if (not fs_enforced or not net_enforced) and not degraded_reason:
         raise ValueError("degraded_reason required when a boundary is not enforced (I7)")
+    experimental = experimental or []
     return {
+        "policy_overridden": bool(experimental),
+        "experimental": list(experimental),
         "schema": 1,
         "agent": agent_name,
         "agent_id": agent_id,
@@ -3812,13 +3828,24 @@ def _landlock_probe_capped() -> int:
 
 
 def apply_landlock_ruleset(abi: int, rw_paths: list[str], ro_paths: list[str],
-                           connect_ports: list[int], bind_ports: list[int]) -> None:
+                           connect_ports: list[int], bind_ports: list[int],
+                           restrict_connect: bool | None = None,
+                           restrict_bind: bool | None = None) -> None:
     """Self-restrict the current process (inherited across fork+execve).
 
-    The net mask is handled only when port rules were requested (spike
-    recommendation: proxy off at normal => net unrestricted, mask = 0).
+    CONNECT and BIND are handled INDEPENDENTLY: ``restrict_connect`` /
+    ``restrict_bind`` say which axes to enforce; the port lists are the
+    allowlists for each. Restricting one axis leaves the other unrestricted
+    (mask bit unset) — so allow_bind_ports at an open level fences BIND
+    without cutting CONNECT (#222 review). When unset, each defaults to
+    "restrict iff its port list is non-empty" (back-compat for direct calls).
     """
     import ctypes
+
+    if restrict_connect is None:
+        restrict_connect = bool(connect_ports)
+    if restrict_bind is None:
+        restrict_bind = bool(bind_ports)
 
     class RulesetAttr(ctypes.Structure):
         _fields_ = [
@@ -3850,13 +3877,17 @@ def apply_landlock_ruleset(abi: int, rw_paths: list[str], ro_paths: list[str],
         return res
 
     handled_fs = _landlock_fs_rights_for_abi(abi)
-    net_requested = bool(connect_ports or bind_ports)
+    net_handled = restrict_connect or restrict_bind
     attr = RulesetAttr(handled_access_fs=handled_fs, handled_access_net=0, scoped=0)
     size = 8  # ABI 1-3: fs field only
     if abi >= 4:
         size = 16
-        if net_requested:
-            attr.handled_access_net = _LANDLOCK_NET_BIND_TCP | _LANDLOCK_NET_CONNECT_TCP
+        net_mask = 0
+        if restrict_connect:
+            net_mask |= _LANDLOCK_NET_CONNECT_TCP
+        if restrict_bind:
+            net_mask |= _LANDLOCK_NET_BIND_TCP
+        attr.handled_access_net = net_mask
 
     ruleset_fd = check(
         libc.syscall(_SYS_LANDLOCK_CREATE_RULESET, ctypes.byref(attr),
@@ -3881,9 +3912,13 @@ def apply_landlock_ruleset(abi: int, rw_paths: list[str], ro_paths: list[str],
                     ctypes.c_uint32(0)), f"landlock_add_rule({path})")
             finally:
                 os.close(dir_fd)
-        if abi >= 4 and net_requested:
-            for access, ports in ((_LANDLOCK_NET_CONNECT_TCP, connect_ports),
-                                  (_LANDLOCK_NET_BIND_TCP, bind_ports)):
+        if abi >= 4 and net_handled:
+            rules: list[tuple[int, list[int]]] = []
+            if restrict_connect:
+                rules.append((_LANDLOCK_NET_CONNECT_TCP, connect_ports))
+            if restrict_bind:
+                rules.append((_LANDLOCK_NET_BIND_TCP, bind_ports))
+            for access, ports in rules:
                 for port in ports:
                     np = NetPortAttr(allowed_access=access, port=port)
                     check(libc.syscall(
@@ -3897,25 +3932,40 @@ def apply_landlock_ruleset(abi: int, rw_paths: list[str], ro_paths: list[str],
         os.close(ruleset_fd)
 
 
+# Writable bwrap mount destinations (2-token: SRC DEST). The `-try` variants
+# behave identically for fencing purposes — missing them left an expert's
+# raw_bwrap_args (#210) writable mount unfenced (#222 review).
+_BWRAP_RW_2ARG = ("--bind", "--dev-bind", "--bind-try", "--dev-bind-try")
+_BWRAP_RO_2ARG = ("--ro-bind", "--ro-bind-try")
+_BWRAP_RW_1ARG = ("--tmpfs", "--dev", "--proc", "--mqueue")
+
+
 def bwrap_rw_targets(cmd: list[str]) -> list[str]:
     """Derive the Landlock rw allow-list mechanically from the bwrap argv:
-    every writable mount destination (--bind/--dev-bind dst, --tmpfs, --dev,
-    --proc). 'Rule list = mirror of the bind list' (spike gotcha #4) — the
-    two mechanisms express ONE intent and can never drift."""
+    every writable mount destination (--bind/--dev-bind[-try] dst, --tmpfs,
+    --dev, --proc, --mqueue). 'Rule list = mirror of the bind list' (spike
+    gotcha #4) — the two mechanisms express ONE intent and can never drift.
+
+    Only the writable-mount families are matched explicitly; every other
+    token (flag values, single flags, the trailing agent argv) advances one
+    position, which can miss-but-never-mis-skip — a missed match would only
+    under-fence, never shift the parser onto a value and corrupt the list.
+    """
     targets: list[str] = []
     i = 0
-    while i < len(cmd):
+    n = len(cmd)
+    while i < n:
         arg = cmd[i]
-        if arg in ("--bind", "--dev-bind"):
-            if i + 2 < len(cmd):
+        if arg in _BWRAP_RW_2ARG:
+            if i + 2 < n:
                 targets.append(cmd[i + 2])
             i += 3
-        elif arg in ("--tmpfs", "--dev", "--proc"):
-            if i + 1 < len(cmd):
+        elif arg in _BWRAP_RO_2ARG:
+            i += 3
+        elif arg in _BWRAP_RW_1ARG:
+            if i + 1 < n:
                 targets.append(cmd[i + 1])
             i += 2
-        elif arg in ("--ro-bind", "--ro-bind-try"):
-            i += 3
         else:
             i += 1
     return list(dict.fromkeys(targets))
@@ -3961,9 +4011,15 @@ def cmd_landlock_exec(argv: list[str]) -> int:
     parser.add_argument("--ro", action="append", default=[], metavar="PATH")
     parser.add_argument("--connect-port", action="append", type=int, default=[], metavar="N")
     parser.add_argument("--bind-port", action="append", type=int, default=[], metavar="N")
+    # Restrict an axis even with an empty port list (deny-all): paranoid binds
+    # nothing, so --restrict-bind with no --bind-port denies all listeners.
+    parser.add_argument("--restrict-connect", action="store_true")
+    parser.add_argument("--restrict-bind", action="store_true")
     parser.add_argument("--fail-closed", action="store_true")
     args = parser.parse_args(shim_argv)
 
+    restrict_connect = args.restrict_connect or bool(args.connect_port)
+    restrict_bind = args.restrict_bind or bool(args.bind_port)
     ro_paths = args.ro if args.ro else ["/"]
     abi = _landlock_probe_capped()
     record_path = os.environ.get("LINCE_POLICY_RECORD_PATH")
@@ -3991,11 +4047,13 @@ def cmd_landlock_exec(argv: list[str]) -> int:
               file=sys.stderr)
         os.execvp(agent_argv[0], agent_argv)
 
-    net_requested = bool(args.connect_port or args.bind_port)
+    net_requested = restrict_connect or restrict_bind
     try:
         apply_landlock_ruleset(abi, rw_paths=args.rw, ro_paths=ro_paths,
                                connect_ports=args.connect_port,
-                               bind_ports=args.bind_port)
+                               bind_ports=args.bind_port,
+                               restrict_connect=restrict_connect,
+                               restrict_bind=restrict_bind)
     except OSError as exc:
         if record_path:
             landlock_update_record(
@@ -4051,18 +4109,30 @@ def landlock_plan(config: dict, sandbox_level: str | None,
         return None
     if sys.platform != "linux":
         return None
-    connect_ports: list[int] = []
     bind_ports: list[int] = [int(p) for p in sec.get("allow_bind_ports", [])]
+    connect_ports: list[int] = []
+    # The proxy/connect path is "active" at paranoid (unshare_net) and at any
+    # level with a live credential proxy; only then do we restrict CONNECT
+    # (to the bridge/proxy + extras). With no proxy, connect stays open
+    # (spike: "proxy off → net unrestricted") — but a user-set allow_bind_ports
+    # must STILL be honored, restricting BIND independently (#222 review:
+    # the old `if not connect_ports: bind_ports = []` silently dropped it).
+    net_active = bool(unshare_net or proxy_port)
     if unshare_net:
         connect_ports.append(PARANOID_BRIDGE_PORT)
     elif proxy_port:
         connect_ports.append(int(proxy_port))
     connect_ports += [int(p) for p in sec.get("allow_connect_ports", [])]
-    if not connect_ports:
-        bind_ports = []  # net mask only handled when the proxy path is active
+    restrict_connect = net_active
+    # Restrict BIND when the net layer is active (deny-all unless allow_bind_ports
+    # widens it) OR when the user opted in via allow_bind_ports at an otherwise
+    # open level. CONNECT stays open in the latter case.
+    restrict_bind = net_active or bool(bind_ports)
     return {
         "connect_ports": list(dict.fromkeys(connect_ports)),
         "bind_ports": list(dict.fromkeys(bind_ports)),
+        "restrict_connect": restrict_connect,
+        "restrict_bind": restrict_bind,
         "fail_closed": sandbox_level == "paranoid",
     }
 
@@ -4504,6 +4574,18 @@ def cmd_run(args, agent_extra: list[str]) -> None:
             ).hexdigest()
         except OSError:
             sb_profile_digest = None
+        # net_enforced must reflect REALITY, not be hardcoded (#222 review):
+        # paranoid demands a net boundary by definition; seatbelt delivers it
+        # only via the loopback-only profile (sb_unshare_net). If paranoid is
+        # requested but no restriction is in force, the record says so and
+        # enforce_paranoid_fail_closed refuses the launch (I7).
+        sb_net_requested = (sandbox_level == "paranoid") or sb_unshare_net
+        sb_net_enforced = sb_unshare_net
+        sb_net_degraded = (
+            None if (not sb_net_requested or sb_net_enforced)
+            else "network boundary requested but Seatbelt applied no egress "
+                 "restriction (unshare_net is off)"
+        )
         sb_record = build_policy_record(
             backend="seatbelt",
             agent_name=agent_name,
@@ -4515,9 +4597,11 @@ def cmd_run(args, agent_extra: list[str]) -> None:
                 if sb_unshare_net else "shared (no kernel restriction requested)"
             ),
             fs_enforced=True,
-            net_enforced=True,
+            net_enforced=(not sb_net_requested) or sb_net_enforced,
             profile_digest=sb_profile_digest,
             inherited_by_subprocesses="by-design (Seatbelt process tree)",
+            degraded_reason=sb_net_degraded,
+            experimental=sb_experimental["active"],
         )
         enforce_paranoid_fail_closed(sandbox_level, sb_record)
         write_policy_record(args.id, sb_record)
@@ -5005,6 +5089,25 @@ def cmd_run(args, agent_extra: list[str]) -> None:
             ).hexdigest()
         except OSError:
             helper_digest = None
+    # net_enforced must reflect REALITY, not be hardcoded (#222 review): a net
+    # boundary is actually enforced by the netns (unshare_net) or by Landlock
+    # TCP rules (ABI >= 4 with a restricted axis). paranoid demands one by
+    # definition, so if it is requested but no mechanism delivers it, the
+    # record says so and enforce_paranoid_fail_closed refuses the launch (I7).
+    landlock_net_enforced = bool(
+        landlock_active and landlock_abi >= 4
+        and landlock is not None
+        and (landlock.get("restrict_connect") or landlock.get("restrict_bind"))
+    )
+    bwrap_net_enforced = bwrap_unshare_net or landlock_net_enforced
+    bwrap_net_requested = (
+        sandbox_level == "paranoid" or bwrap_unshare_net or landlock_net_enforced
+    )
+    bwrap_net_degraded = (
+        None if (not bwrap_net_requested or bwrap_net_enforced)
+        else "network boundary requested but neither a network namespace "
+             "(unshare_net) nor Landlock TCP rules are in force"
+    )
     bwrap_record = build_policy_record(
         backend="bwrap",
         agent_name=agent_name,
@@ -5013,11 +5116,13 @@ def cmd_run(args, agent_extra: list[str]) -> None:
         requested_fs=requested_fs,
         requested_net=requested_net,
         fs_enforced=True,
-        net_enforced=True,
+        net_enforced=(not bwrap_net_requested) or bwrap_net_enforced,
         net_limitation=net_limitation,
         helper_version=helper_version,
         helper_digest=helper_digest,
         bwrap_args_digest=_argv_digest(cmd),
+        degraded_reason=bwrap_net_degraded,
+        experimental=experimental["active"],
     )
     enforce_paranoid_fail_closed(sandbox_level, bwrap_record)
     write_policy_record(args.id, bwrap_record)

--- a/sandbox/tests/test-landlock-exec.sh
+++ b/sandbox/tests/test-landlock-exec.sh
@@ -72,9 +72,13 @@ try:
     b.bind(("127.0.0.1", 0)); print("BIND_OK")
 except PermissionError: print("BIND_EACCES")
 """
+# --restrict-bind (no --bind-port) requests a deny-all bind fence alongside the
+# connect allowlist — paranoid's posture, and the explicit form since CONNECT
+# and BIND are now restricted independently (#222 review).
 print(subprocess.run(
     ["python3", sandbox, "__landlock-exec", "--rw", "/tmp",
-     "--connect-port", str(allowed), "--", "python3", "-c", code],
+     "--connect-port", str(allowed), "--restrict-bind",
+     "--", "python3", "-c", code],
     capture_output=True, text=True).stdout)
 EOF
 )
@@ -82,8 +86,32 @@ EOF
                                               || bad "net: connect to allowed port failed ($OUT)"
     echo "$OUT" | grep -q CONNECT_DENIED_EACCES && ok "net: connect to other port denied" \
                                                  || bad "net: connect to other port NOT denied ($OUT)"
-    echo "$OUT" | grep -q BIND_EACCES && ok "net: bind denied (no bind rule)" \
+    echo "$OUT" | grep -q BIND_EACCES && ok "net: bind denied (--restrict-bind, no bind rule)" \
                                        || bad "net: bind NOT denied ($OUT)"
+
+    # Independence: restricting CONNECT alone must leave BIND open (the #222
+    # review bug — old all-or-nothing coupling denied bind whenever connect
+    # was restricted, silently dropping allow_bind_ports semantics).
+    OUT2=$(python3 - "$SANDBOX" <<'EOF'
+import socket, subprocess, sys
+sandbox = sys.argv[1]
+l = socket.socket(); l.bind(("127.0.0.1", 0)); l.listen(1)
+allowed = l.getsockname()[1]
+code = """
+import socket
+b = socket.socket()
+try:
+    b.bind(("127.0.0.1", 0)); print("BIND_OPEN_OK")
+except PermissionError: print("BIND_OPEN_EACCES")
+"""
+print(subprocess.run(
+    ["python3", sandbox, "__landlock-exec", "--rw", "/tmp",
+     "--connect-port", str(allowed), "--", "python3", "-c", code],
+    capture_output=True, text=True).stdout)
+EOF
+)
+    echo "$OUT2" | grep -q BIND_OPEN_OK && ok "net: restrict-connect alone leaves bind open (independent axes)" \
+                                         || bad "net: connect restriction wrongly denied bind ($OUT2)"
 else
     echo "  [SKIP] net checks (ABI $ABI < 4)"
 fi

--- a/scripts/tests/test_policy_record.py
+++ b/scripts/tests/test_policy_record.py
@@ -97,6 +97,48 @@ class TestParanoidFailClosed(unittest.TestCase):
         MOD.enforce_paranoid_fail_closed(None, self.make(fs=False))  # no exit
 
 
+class TestRecordHonesty(unittest.TestCase):
+    """#222 review: the record's *_enforced must reflect reality, not be
+    hardcoded — otherwise the I7 gate can't catch a missing net boundary."""
+
+    def test_landlock_plan_keeps_bind_ports_without_proxy(self):
+        plan = MOD.landlock_plan(
+            {"security": {"allow_bind_ports": [3000]}},
+            "normal", unshare_net=False, proxy_port=None,
+        )
+        self.assertEqual(plan["bind_ports"], [3000])
+        self.assertTrue(plan["restrict_bind"])
+        self.assertFalse(plan["restrict_connect"])  # connect stays open
+
+    def test_landlock_plan_normal_open_has_no_net_rules(self):
+        plan = MOD.landlock_plan({"security": {}}, "normal", unshare_net=False, proxy_port=None)
+        self.assertFalse(plan["restrict_connect"])
+        self.assertFalse(plan["restrict_bind"])
+
+    def test_landlock_plan_paranoid_denies_bind_allows_bridge(self):
+        plan = MOD.landlock_plan({"security": {}}, "paranoid", unshare_net=True, proxy_port=None)
+        self.assertEqual(plan["connect_ports"], [MOD.PARANOID_BRIDGE_PORT])
+        self.assertTrue(plan["restrict_connect"] and plan["restrict_bind"])
+        self.assertEqual(plan["bind_ports"], [])  # deny all bind
+
+    def test_record_carries_experimental_override(self):
+        rec = MOD.build_policy_record(
+            backend="bwrap", agent_name="claude", agent_id="c1", level="normal",
+            requested_fs="x", requested_net="y", fs_enforced=True, net_enforced=True,
+            experimental=["raw_bwrap_args"],
+        )
+        self.assertTrue(rec["policy_overridden"])
+        self.assertEqual(rec["experimental"], ["raw_bwrap_args"])
+
+    def test_record_clean_when_no_override(self):
+        rec = MOD.build_policy_record(
+            backend="bwrap", agent_name="claude", agent_id="c1", level="normal",
+            requested_fs="x", requested_net="y", fs_enforced=True, net_enforced=True,
+        )
+        self.assertFalse(rec["policy_overridden"])
+        self.assertEqual(rec["experimental"], [])
+
+
 class TestRecordWrite(unittest.TestCase):
     def test_write_next_to_state_files(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/tests/test_resolve.py
+++ b/scripts/tests/test_resolve.py
@@ -111,6 +111,38 @@ class ResolveTestCase(unittest.TestCase):
         self.assertEqual(vertex["env"]["ANTHROPIC_API_KEY"], "$ANTHROPIC_API_KEY")
         self.assertEqual(vertex["env"]["CLOUD_ML_REGION"], "us-east5")
         self.assertTrue(vertex["available"])  # literal non-secret value configured
+
+    def test_provider_with_only_a_literal_secret_is_available(self):
+        """#222 review: availability is judged on the RAW value (pre-redaction),
+        so a provider configured only with a literal API key — and nothing in
+        the host env — still resolves as available (was wrongly hidden)."""
+        import os
+        os.environ.pop("ANTHROPIC_API_KEY", None)
+        self.sandbox_cfg.write_text(
+            '[providers.direct]\n'
+            'env = { ANTHROPIC_API_KEY = "sk-ant-onlyliteral0000000000" }\n',
+            encoding="utf-8",
+        )
+        view = self.resolve()
+        direct = view["providers"]["direct"]
+        self.assertTrue(direct["available"], "literal-configured provider hidden")
+        # but the value is still redacted out of the JSON (I4)
+        self.assertEqual(direct["env"]["ANTHROPIC_API_KEY"], "$ANTHROPIC_API_KEY")
+
+    def test_nonstandard_secret_key_is_redacted(self):
+        """#222 review: a secret under a non-standard key name (no API_KEY/
+        TOKEN substring) must not leak its literal value into resolve --json."""
+        self.sandbox_cfg.write_text(
+            '[providers.gw]\n'
+            'env = { LLM_GATEWAY_CRED = "k8f3p9q2x7m1w5v0n4", '
+            'GATEWAY_REGION = "eu-west" }\n',
+            encoding="utf-8",
+        )
+        view = self.resolve()
+        env = view["providers"]["gw"]["env"]
+        self.assertEqual(env["LLM_GATEWAY_CRED"], "$LLM_GATEWAY_CRED")  # redacted
+        self.assertEqual(env["GATEWAY_REGION"], "eu-west")  # non-secret kept
+        self.assertNotIn("k8f3p9q2", json.dumps(view))
         self.assertNotIn("LITERALSECRET", json.dumps(view))
 
     def test_legacy_dashboard_custom_agent_and_level(self):


### PR DESCRIPTION
Follow-up to the Config v2 wave 2 (m-16 + m-17, PRs #224–#236): fixes the findings from a high-effort self-review of the merged wave. Touches #221/#222 (effective-policy record + Landlock), #202 (resolve redaction), #210 (experimental).

## Security-relevant

**1. I7 net-axis gap — `net_enforced` was hardcoded `True`** (`agent-sandbox`, bwrap + seatbelt records). `enforce_paranoid_fail_closed` reads that field, so it could never catch a missing network boundary. `--sandbox-level paranoid` with `[security] unshare_net = false` and Landlock off would launch with **fully open egress, no error**. Now `net_enforced` reflects reality — enforced iff a netns (`unshare_net`) or Landlock TCP rules (ABI ≥ 4) are actually in force; paranoid demands a net boundary by definition, so the degraded case **fails closed naming the boundary**. Verified: `paranoid + unshare_net=false + landlock-off → exit 1`; normal-open net stays vacuously enforced (no false positive).

**2. I4 redaction gap** (`lince-config:_redact_env`). Secrets under non-standard key names (`LLM_GATEWAY_CRED`, `*_AUTH`, `*_BEARER`) or as bare opaque tokens passed through into `resolve --json`. Broadened the keyword list and added a long-opaque-token value pattern; non-secret config literals (regions, projects, base URLs, account IDs) still pass through (asserted both ways).

## Correctness

**3. `landlock_plan` silently dropped `allow_bind_ports`** when no connect port existed (normal, no proxy): `if not connect_ports: bind_ports = []`. CONNECT and BIND are now restricted **independently** (`apply_landlock_ruleset` + the shim's `--restrict-connect`/`--restrict-bind` flags). `allow_bind_ports` fences BIND without cutting CONNECT; paranoid still denies all bind. New gate check asserts axis-independence.

**4. `bwrap_rw_targets` missed `--bind-try`/`--dev-bind-try`** — an expert's `[experimental].raw_bwrap_args` writable mount went un-fenced by Landlock. Added the `-try` variants (+ `--mqueue`).

**5. Provider with only a literal value reported `available:false`** — redaction ran before the availability check, so the value was already `$NAME`. Availability is now judged on the **raw** value at collection time; a literal-key provider with nothing in the host env shows as ready (the value is still redacted out of the JSON).

## Minor

**6. `[experimental]` overrides now annotate the record** (`policy_overridden` + `experimental[]`). `EnforcedPolicy.fully_enforced()` returns false for an overridden run and the dashboard badges it `⚠custom` — a widened boundary (e.g. `seatbelt_extra` re-opening egress) no longer reads as a clean `fs✓ net✓`.

**7. quickstart agent selection** probes the v2 switch once (`apply --dry-run`) and prints one clear actionable message on a legacy-blocked host instead of looping a refusal per agent.

**8.** (not fixed, by design) Dashboard provider picker is empty in the `lince-config`-missing fallback. Re-adding discovery there would re-introduce the TOML-parsing duplication #202 deleted; `lince-config` is a hard dependency the install scripts ensure, and the fallback already surfaces `config_error` with the fix. Left as-is.

## How to test it

```
$ bash sandbox/tests/test-landlock-exec.sh         # LANDLOCK GATE: ALL 11 CHECKS PASSED
                                                   # (+ axis-independence: restrict-connect leaves bind open)
$ python3 scripts/tests/test_policy_record.py      # +5: landlock_plan bind/paranoid, record honesty, experimental
$ python3 scripts/tests/test_resolve.py            # +2: literal-only provider available; non-standard secret redacted
$ for t in schemas apply discover registry_sync default_config config_reference; do python3 scripts/tests/test_$t.py; done   # all OK

# Real bwrap E2E:
$ agent-sandbox run --agent bash --id b1 -- -c ok   # record: net_enforced honest, policy_overridden:false
$ # with [experimental].raw_bwrap_args → banner + policy_overridden:true, experimental:["raw_bwrap_args"]

# Rust (wasmtime, host cargo test link-broken on main):
$ cargo build --target wasm32-wasip1                # clean
$ cargo test --target wasm32-wasip1 --no-run && wasmtime run --preload zellij=stub.wat <test>.wasm
test result: ok. 61 passed; 0 failed                # +1: experimental override voids clean result

$ ruff check sandbox/agent-sandbox lince-config/lince-config   # agent-sandbox at main baseline (49), lince-config clean
$ bash -n quickstart.sh                              # OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)