### PR TITLE
fix(dashboard): route Seatbelt spawns through agent-sandbox argv — was bare inner command, unsandboxed (#237)

### DIFF
--- a/lince-dashboard/plugin/src/agent.rs
+++ b/lince-dashboard/plugin/src/agent.rs
@@ -217,6 +217,15 @@ pub fn resolve_nono_profile(agent_type: &str, level: &str) -> String {
 ///
 /// The returned argv is final — no more placeholder substitution needed
 /// downstream.
+/// Backends whose spawn rides the generic `agent-sandbox run` argv (and thus
+/// must also receive the `-P <provider>` passthrough in `spawn_agent_custom`).
+fn backend_rides_agent_sandbox(backend: &SandboxBackend) -> bool {
+    matches!(
+        backend,
+        SandboxBackend::AgentSandbox | SandboxBackend::Seatbelt
+    )
+}
+
 fn synthesize_sandboxed_command(
     agent_type: &str,
     backend: &SandboxBackend,
@@ -227,11 +236,14 @@ fn synthesize_sandboxed_command(
 ) -> Option<Vec<String>> {
     let base = agent_type_base_name(agent_type);
 
-    // AgentSandbox (bwrap) doesn't need per-agent inner-command knowledge —
-    // agent-sandbox resolves the inner binary and args itself via --agent.
-    // Handle it generically so any agent type (including future ones) gets
-    // --sandbox-level passed through correctly.
-    if matches!(backend, SandboxBackend::AgentSandbox) {
+    // AgentSandbox (bwrap) and Seatbelt don't need per-agent inner-command
+    // knowledge — agent-sandbox resolves the inner binary and args itself via
+    // --agent, and implements both backends. Handle them generically so any
+    // agent type (including future ones) gets --sandbox-level passed through
+    // correctly. Seatbelt pins `--backend seatbelt` explicitly so the wizard's
+    // choice survives whatever the user's [sandbox].backend config says (#237);
+    // bwrap stays unpinned so the script's `auto` keeps deciding.
+    if backend_rides_agent_sandbox(backend) {
         let mut cmd = vec![
             "agent-sandbox".to_string(),
             "run".to_string(),
@@ -242,6 +254,10 @@ fn synthesize_sandboxed_command(
             "--agent".to_string(),
             base.to_string(),
         ];
+        if matches!(backend, SandboxBackend::Seatbelt) {
+            cmd.push("--backend".to_string());
+            cmd.push("seatbelt".to_string());
+        }
         if level != "normal" {
             cmd.push("--sandbox-level".to_string());
             cmd.push(level.to_string());
@@ -357,11 +373,8 @@ fn synthesize_sandboxed_command(
             }
         }
         SandboxBackend::None => inner_command,
-        // AgentSandbox handled by the early return above.
-        SandboxBackend::AgentSandbox => unreachable!(),
-        // Seatbelt uses the same inner command as None — sandbox-exec
-        // profiles are applied externally via launch configuration.
-        SandboxBackend::Seatbelt => inner_command,
+        // AgentSandbox and Seatbelt handled by the early return above.
+        SandboxBackend::AgentSandbox | SandboxBackend::Seatbelt => unreachable!(),
     })
 }
 
@@ -530,11 +543,12 @@ fn spawn_inner(
                 provider.as_deref(),
             ));
         }
-        // For agent-sandbox (bwrap) agents, pass the provider via -P flag so
-        // agent-sandbox can resolve the provider's env vars internally. Nono
-        // agents already have `--profile` (nono's own concept, unrelated to
-        // provider) baked into their command template.
-        if type_config.sandboxed && *effective_backend == SandboxBackend::AgentSandbox {
+        // For agents riding the agent-sandbox argv (bwrap and seatbelt), pass
+        // the provider via -P flag so agent-sandbox can resolve the provider's
+        // env vars internally. Nono agents already have `--profile` (nono's
+        // own concept, unrelated to provider) baked into their command
+        // template.
+        if type_config.sandboxed && backend_rides_agent_sandbox(effective_backend) {
             if let Some(ref p) = provider {
                 if !p.is_empty() {
                     expanded.push("-P".to_string());
@@ -772,6 +786,93 @@ pub fn reconcile_panes(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- #237: Seatbelt spawns must ride the agent-sandbox argv ---
+
+    #[test]
+    fn seatbelt_normal_routes_through_agent_sandbox_with_backend_pinned() {
+        let argv = synthesize_sandboxed_command(
+            "claude",
+            &SandboxBackend::Seatbelt,
+            "normal",
+            "agent-3",
+            "/tmp/proj",
+            None,
+        )
+        .expect("seatbelt must synthesize a sandboxed command");
+        assert_eq!(
+            argv,
+            vec![
+                "agent-sandbox",
+                "run",
+                "-p",
+                "/tmp/proj",
+                "--id",
+                "agent-3",
+                "--agent",
+                "claude",
+                "--backend",
+                "seatbelt",
+            ]
+        );
+    }
+
+    #[test]
+    fn seatbelt_paranoid_appends_sandbox_level() {
+        let argv = synthesize_sandboxed_command(
+            "codex",
+            &SandboxBackend::Seatbelt,
+            "paranoid",
+            "agent-7",
+            "/tmp/proj",
+            None,
+        )
+        .expect("seatbelt must synthesize a sandboxed command");
+        assert_eq!(
+            argv,
+            vec![
+                "agent-sandbox",
+                "run",
+                "-p",
+                "/tmp/proj",
+                "--id",
+                "agent-7",
+                "--agent",
+                "codex",
+                "--backend",
+                "seatbelt",
+                "--sandbox-level",
+                "paranoid",
+            ]
+        );
+    }
+
+    #[test]
+    fn agent_sandbox_arm_keeps_backend_unpinned() {
+        // bwrap spawns stay flag-free so the script's `auto` (and the user's
+        // [sandbox].backend) keeps deciding — only Seatbelt pins explicitly.
+        let argv = synthesize_sandboxed_command(
+            "claude",
+            &SandboxBackend::AgentSandbox,
+            "normal",
+            "agent-1",
+            "/tmp/proj",
+            None,
+        )
+        .expect("agent-sandbox must synthesize a sandboxed command");
+        assert!(!argv.contains(&"--backend".to_string()));
+        assert_eq!(argv[0], "agent-sandbox");
+    }
+
+    #[test]
+    fn provider_gate_covers_both_agent_sandbox_argv_backends() {
+        // The -P provider passthrough must reach every backend that rides the
+        // agent-sandbox argv (gate at spawn_agent_custom), i.e. bwrap AND seatbelt.
+        assert!(backend_rides_agent_sandbox(&SandboxBackend::AgentSandbox));
+        assert!(backend_rides_agent_sandbox(&SandboxBackend::Seatbelt));
+        assert!(!backend_rides_agent_sandbox(&SandboxBackend::Nono));
+        assert!(!backend_rides_agent_sandbox(&SandboxBackend::None));
+    }
 
     #[test]
     fn passthrough_self_ref_dollar_form() {

--- a/lince-dashboard/tests/run-plugin-tests.sh
+++ b/lince-dashboard/tests/run-plugin-tests.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Run the dashboard plugin's Rust unit tests.
+#
+# `cargo test` on the host target fails to link (the zellij host imports only
+# exist inside the Zellij runtime), so the suite is built for wasm32-wasip1
+# and run under wasmtime with a no-op stub of the host interface
+# (zellij-host-stub.wat). Same recipe as PR #226's validation.
+#
+# Requirements: rustup toolchain with the wasm32-wasip1 target, wasmtime.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_DIR="$SCRIPT_DIR/../plugin"
+STUB="$SCRIPT_DIR/zellij-host-stub.wat"
+
+command -v wasmtime >/dev/null 2>&1 || {
+    echo "error: wasmtime not found (brew install wasmtime / dnf install wasmtime)" >&2
+    exit 1
+}
+
+CARGO="$HOME/.cargo/bin/cargo"
+[ -x "$CARGO" ] || CARGO="cargo"
+
+cd "$PLUGIN_DIR"
+PATH="$HOME/.cargo/bin:$PATH" "$CARGO" test --target wasm32-wasip1 --no-run
+
+WASM="$(ls -t target/wasm32-wasip1/debug/deps/lince_dashboard-*.wasm | head -1)"
+[ -n "$WASM" ] || { echo "error: no test artifact found" >&2; exit 1; }
+
+# NOTE: tests are built with panic=abort on wasm, so the run stops at the
+# first failing test. Re-run with a name filter to isolate failures:
+#   wasmtime run --preload zellij=<stub> <wasm> <test_name_substring>
+exec wasmtime run --preload "zellij=$STUB" "$WASM" "$@"

--- a/lince-dashboard/tests/zellij-host-stub.wat
+++ b/lince-dashboard/tests/zellij-host-stub.wat
@@ -1,0 +1,10 @@
+;; Minimal stub of the Zellij host interface, for running the plugin's unit
+;; tests under wasmtime (the real functions only exist inside the Zellij
+;; runtime). Unit tests exercise pure logic and never reach a host call; the
+;; no-op body satisfies the import at instantiation time.
+;;
+;; Used by tests/run-plugin-tests.sh:
+;;   wasmtime run --preload zellij=tests/zellij-host-stub.wat <test>.wasm
+(module
+  (func (export "host_run_plugin_command"))
+)


### PR DESCRIPTION
Closes #237. Direction confirmed by @maeste in the issue thread (generic argv + `--backend seatbelt` pinned + the provider-gate spot).

### What is the current behavior?

The `SandboxBackend::Seatbelt` arm of `synthesize_sandboxed_command` returns the bare inner command (stub since #183: "profiles are applied externally via launch configuration" — never built), so every wizard spawn with backend seatbelt runs the agent with no sandbox while the pane is labeled and color-coded as contained. For claude that's an unsandboxed `claude --dangerously-skip-permissions`.

### What is the new behavior?

- Seatbelt rides the same generic `agent-sandbox run -p <dir> --id <id> --agent <base>` argv as the AgentSandbox arm, with `--backend seatbelt` pinned explicitly so the wizard's choice survives whatever the user's `[sandbox].backend` says. bwrap stays unpinned (script-side `auto` keeps deciding — existing behavior preserved, asserted by test).
- The `-P <provider>` passthrough gate widens from `== AgentSandbox` to the new `backend_rides_agent_sandbox()` helper (the spot flagged in the issue thread), so seatbelt agents don't silently lose provider resolution.
- Test infrastructure: `tests/run-plugin-tests.sh` + `tests/zellij-host-stub.wat` make the PR #226 test recipe reproducible (`cargo test --target wasm32-wasip1 --no-run` + wasmtime with the host-fn stub). Until now the stub lived only on the author's machine.

### Does this PR introduce a breaking change?

No. AgentSandbox argv is byte-identical to before (test-asserted); Nono and None arms untouched.

### Validation

- Unit tests: 4 new (seatbelt normal/paranoid argv, bwrap stays unpinned, provider gate), suite **65 passed, 0 failed** under wasmtime.
- `cargo build --target wasm32-wasip1` clean.
- macOS 26.5.1 runtime: the exact synthesized argv accepted by `agent-sandbox` end-to-end (banner: `seatbelt (/usr/bin/sandbox-exec)`, runtime profile resolved), and the profile actively enforces on the spawned process — `/bin/ps` inside the sandbox returns `Operation not permitted`.
- NOT run: a live wizard click-through inside Zellij (the plugin binary with this fix isn't installed into my running dashboard). The argv this PR produces is the one verified above; happy to do a full wizard pass after review if you want it on the record.

---
*Implemented with the help of a coding agent (Claude Code) and reviewed locally by the author.*
