### PR TITLE
fix(sandbox): expose ~/.serena read-only so Serena MCP keeps host config

### DIFF
--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -77,9 +77,15 @@ persist_toolchains = true
 # ~/Applications/apache-maven-3.9.14/bin).
 auto_expose_path = true
 
-# Extra home subdirectories to expose read-only (relative to $HOME)
-# .config/gcloud is needed for Vertex AI / Google Cloud authentication
-home_ro_dirs = [".config/gcloud"]
+# Extra home subdirectories to expose read-only (relative to $HOME).
+# Each is mounted only if it exists on the host, so listing a dir you
+# don't use is harmless.
+# .config/gcloud is needed for Vertex AI / Google Cloud authentication.
+# .serena lets the Serena MCP server read your host config (so it honors
+# web_dashboard_open_on_launch and won't pop a browser on every launch);
+# Serena's writable data (memories/caches) lives in the project's own
+# .serena dir, which is already read-write inside the sandbox.
+home_ro_dirs = [".config/gcloud", ".serena"]
 
 # Default provider — env-var bundle used when -P / --provider is not given.
 # Set to a name defined in [providers.*] / [<agent>.providers.*] below.

--- a/sandbox/config.toml.example
+++ b/sandbox/config.toml.example
@@ -17,9 +17,15 @@ persist_toolchains = true
 # ~/Applications/apache-maven-3.9.14/bin).
 auto_expose_path = true
 
-# Extra home subdirectories to expose read-only (relative to $HOME)
-# .config/gcloud is needed for Vertex AI / Google Cloud authentication
-home_ro_dirs = [".config/gcloud"]
+# Extra home subdirectories to expose read-only (relative to $HOME).
+# Each is mounted only if it exists on the host, so listing a dir you
+# don't use is harmless.
+# .config/gcloud is needed for Vertex AI / Google Cloud authentication.
+# .serena lets the Serena MCP server read your host config (so it honors
+# web_dashboard_open_on_launch and won't pop a browser on every launch);
+# Serena's writable data (memories/caches) lives in the project's own
+# .serena dir, which is already read-write inside the sandbox.
+home_ro_dirs = [".config/gcloud", ".serena"]
 
 # Default provider — env-var bundle used when -P / --provider is not given.
 # Set to a name defined in [providers.*] / [<agent>.providers.*] below.


### PR DESCRIPTION
Closes #250

## Problem

The bwrap sandbox tmpfs-hides the entire `$HOME` and only re-binds dirs listed in `home_ro_dirs` / `home_rw_dirs` / `.claude`. `~/.serena` was not exposed, so when an agent spawns the Serena MCP server (`uvx … serena start-mcp-server`) inside the sandbox, Serena can't see the host `~/.serena/serena_config.yml`, regenerates a fresh default (`web_dashboard_open_on_launch=true`), and pops a browser on every launch. The user's host setting has no effect.

## Fix

Add `.serena` to the default `home_ro_dirs`, next to the existing `.config/gcloud` exposure:

- `home_ro_dirs` binds a dir **only if it exists** → no side effect for users who don't run Serena (unlike `home_rw_dirs`, which would unconditionally `mkdir ~/.serena` for everyone).
- **Read-only is sufficient**: Serena's writable data (memories/caches) lives in `$projectDir/.serena` (`project_serena_folder_location`), already read-write inside the sandbox. In `~/.serena` Serena only needs to read its config.

Edited both single-sourced copies — `_DEFAULT_CONFIG` in `sandbox/agent-sandbox` and `sandbox/config.toml.example` — kept byte-identical per #205.

## Testing

- `python3 scripts/tests/test_default_config.py` ✅ (byte-identical guard + schema validation)
- `python3 scripts/tests/test_schemas.py` ✅ (17 tests)
- Functional check: building the bwrap command from the default config now emits `--ro-bind <home>/.serena` (mounted only because the dir exists).

## Note for existing installs

This fixes **new** installs. Existing users need `agent-sandbox init --force` (or to add `.serena` to `home_ro_dirs` manually).

🤖 Generated with [Claude Code](https://claude.com/claude-code)