### PR TITLE
feat(lince-lab): macOS-guest backend via Tart (#263)

### DIFF
--- a/lince-lab/README.md
+++ b/lince-lab/README.md
@@ -125,6 +125,35 @@ injection, name-prefixing) are **non-overridable policy**, never preset config.
 | **`bisect`** | The autonomous regression loop. 2 CPU / 2 GiB, base snapshot **retained** for fast per-candidate reset, network denied, longer per-step timeout. Pair with `find bisect`. |
 | **`networked`** | Recipes that legitimately must fetch (npm / pip). 2 CPU / 2 GiB, networking allowed but **only** the recipe's explicit `allow_hosts` / `allow_ports`; everything else stays denied, no host credentials. |
 
+## macOS backend (Tart) — experimental
+
+On Apple Silicon, lince-lab can boot a clean disposable **macOS** guest to
+exercise the Seatbelt sandbox path (Epic #268). It is selected with
+`LINCE_LAB_MACOS=1` when starting the broker and drives
+[Tart](https://tart.run) over Virtualization.framework.
+
+Requirements:
+
+- Apple Silicon Mac (`uname -m` = `arm64`).
+- `tart`: `brew install cirruslabs/cli/tart`.
+  - Homebrew 6+ may refuse the tap with a *tap-trust* error; run
+    `brew trust cirruslabs/cli` (or, one-shot,
+    `HOMEBREW_NO_REQUIRE_TAP_TRUST=1 brew install cirruslabs/cli/tart`).
+- A base image: `tart pull ghcr.io/cirruslabs/macos-sequoia-base:latest`.
+
+Run a guest:
+
+```bash
+LINCE_LAB_MACOS=1 lince-lab lab broker start &
+lince-lab vm up lince-lab-demo --image macos-sequoia
+lince-lab vm exec lince-lab-demo -- sw_vers
+lince-lab vm rm lince-lab-demo -f
+```
+
+Reset uses APFS copy-on-write `tart clone` of a stopped golden guest (vz has no
+snapshots). The macOS/arm64 `ht` capture binary installs to
+`~/.local/share/lince/lince-lab/bin/ht-darwin`.
+
 ## Documentation
 
 - Design & decisions: [`docs/design/lince-lab-design.md`](../docs/design/lince-lab-design.md)

--- a/lince-lab/install.sh
+++ b/lince-lab/install.sh
@@ -97,6 +97,19 @@ if [ ! -x "$SHARE_DIR/bin/ht" ]; then
 else
     echo -e "${GREEN}  ✓ ht already present -> $SHARE_DIR/bin/ht${NC}"
 fi
+
+# macOS/arm64 ht for the Tart (macOS-guest) backend — same role as the Linux ht,
+# copied into a macOS guest on demand (Epic #268). Idempotent + non-fatal too.
+HT_DARWIN_URL="https://github.com/andyk/ht/releases/download/${HT_VER}/ht-aarch64-apple-darwin"
+if [ ! -x "$SHARE_DIR/bin/ht-darwin" ]; then
+    if curl -fsSL -o "$SHARE_DIR/bin/ht-darwin" "$HT_DARWIN_URL" && chmod +x "$SHARE_DIR/bin/ht-darwin"; then
+        echo -e "${GREEN}  ✓ ht (macOS/arm64) -> $SHARE_DIR/bin/ht-darwin${NC}"
+    else
+        echo -e "${YELLOW}  ⚠ ht (macOS/arm64) download failed; macOS-backend capture unavailable until present${NC}"
+    fi
+else
+    echo -e "${GREEN}  ✓ ht (macOS/arm64) already present -> $SHARE_DIR/bin/ht-darwin${NC}"
+fi
 echo ""
 
 # ── Step 4: Install skill ──────────────────────────────────────────────

--- a/lince-lab/lince-lab
+++ b/lince-lab/lince-lab
@@ -433,9 +433,11 @@ def cmd_lab_broker(args: argparse.Namespace) -> int:
 def _broker_start(args: argparse.Namespace) -> int:
     """Start a :class:`BrokerServer` in-process and serve until interrupted.
 
-    Uses :class:`~lince_lab.lima_backend.LimaBackend` by default, or
+    Uses :class:`~lince_lab.lima_backend.LimaBackend` by default,
+    :class:`~lince_lab.macos_backend.MacosBackend` when ``LINCE_LAB_MACOS=1``
+    (Apple-Silicon macOS guest via Tart), or
     :class:`~lince_lab.fake_backend.FakeBackend` when ``LINCE_LAB_FAKE=1`` (the
-    test path — no KVM required).
+    test path — no VM required).
     """
     from lince_lab.broker import BrokerServer
 
@@ -444,6 +446,10 @@ def _broker_start(args: argparse.Namespace) -> int:
         from lince_lab.fake_backend import FakeBackend
 
         backend = FakeBackend()
+    elif os.environ.get("LINCE_LAB_MACOS") == "1":
+        from lince_lab.macos_backend import MacosBackend
+
+        backend = MacosBackend()
     else:
         from lince_lab.lima_backend import LimaBackend
 

--- a/lince-lab/lince_lab/backend.py
+++ b/lince-lab/lince_lab/backend.py
@@ -174,3 +174,24 @@ class Backend(ABC):
     def open_capture(self, name: str, argv: list[str], cols: int, rows: int) -> CaptureChannel:
         """Open a :class:`CaptureChannel` wrapping ``argv`` at grid ``cols``x``rows``."""
         ...
+
+    # ── egress policy (concrete default; OS-specific backends override) ───────
+    def apply_egress_lockdown(
+        self, name: str, allow_ips: list[str], allow_ports: list[int], timeout: float = 180.0
+    ) -> None:
+        """Enforce the egress posture on ``name`` (deny by default; allowlist when given).
+
+        The default runs the Linux ``nft`` lock-down script in the guest via
+        :meth:`exec` and raises :class:`~lince_lab.errors.BackendError` on a
+        nonzero exit. Backends whose guest is not Linux (e.g. macOS) override this
+        with an OS-appropriate mechanism. This lives on the seam — not in the
+        broker — so egress enforcement is per-backend, not Linux-assuming.
+        """
+        from lince_lab.errors import BackendError
+        from lince_lab.templates import egress_lockdown_argv
+
+        result = self.exec(name, egress_lockdown_argv(allow_ips, allow_ports), timeout=timeout)
+        if result.exit_code != 0:
+            raise BackendError(
+                f"egress lock-down failed on {name} (exit {result.exit_code}): {result.stderr.strip() or 'no detail'}"
+            )

--- a/lince-lab/lince_lab/broker.py
+++ b/lince-lab/lince_lab/broker.py
@@ -33,13 +33,13 @@ from lince_lab import protocol
 from lince_lab.backend import Backend, ExecResult, VmState
 from lince_lab.capture import Capture
 from lince_lab.config import apply_preset
-from lince_lab.errors import BackendError, DataError, LabError
+from lince_lab.errors import DataError, LabError
 from lince_lab.paths import VM_NAME_PREFIX, parse_size
 from lince_lab.policy import artifacts_root
 from lince_lab.policy import check as policy_check
 from lince_lab.policy import check_capture as policy_check_capture
 from lince_lab.recipe import Recipe, effective_egress, load_recipe, run_recipe, validate
-from lince_lab.templates import build_template, egress_lockdown_argv
+from lince_lab.templates import build_template
 
 
 class BrokerServer:
@@ -295,13 +295,10 @@ class BrokerServer:
         # network up and they apply their own (recipe-posture) lock-down after
         # provisioning — they are unaffected by this deny default.
         self.backend.start(args["name"])
-        # Cap the lock-down exec so it errors out instead of hanging forever.
-        result = self.backend.exec(args["name"], egress_lockdown_argv([], []), timeout=180.0)
-        if result.exit_code != 0:
-            raise BackendError(
-                f"egress lock-down failed on {args['name']} (exit {result.exit_code}): "
-                f"{result.stderr.strip() or 'no detail'}"
-            )
+        # Apply the server-side deny-by-default egress posture. The backend picks
+        # the OS-appropriate mechanism (Linux nft for Lima; macOS backends override),
+        # capped so it errors out instead of hanging forever.
+        self.backend.apply_egress_lockdown(args["name"], [], [], timeout=180.0)
         return {"started": args["name"]}
 
     def _h_stop(self, args: dict[str, Any]) -> dict[str, Any]:
@@ -318,9 +315,7 @@ class BrokerServer:
     def _h_list(self, args: dict[str, Any]) -> list[dict[str, Any]]:
         # Disclose ONLY lab-namespaced instances; a user's other VMs (which a real
         # `limactl list` would include) are never surfaced over the broker.
-        return [
-            _vmstate_to_dict(s) for s in self.backend.list() if s.name.startswith(VM_NAME_PREFIX)
-        ]
+        return [_vmstate_to_dict(s) for s in self.backend.list() if s.name.startswith(VM_NAME_PREFIX)]
 
     # ── exec / files ─────────────────────────────────────────────────────────
     def _h_exec(self, args: dict[str, Any]) -> dict[str, Any]:

--- a/lince-lab/lince_lab/config.py
+++ b/lince-lab/lince_lab/config.py
@@ -54,6 +54,15 @@ DEFAULTS: dict[str, Any] = {
             "arch": "x86_64",
             "digest": "sha256:53fdde898feed8b027d94baa9cfe8229867f330a1d9c49dc7d84465ee7f229f7",
         },
+        # macOS guest for the Tart (Virtualization.framework) backend — Epic #268.
+        # NOT a qcow2: the macOS backend reads `location` as a Tart OCI image ref
+        # (`tart clone` pulls it). arch arm64 (Apple Silicon). Digest is handled by
+        # the OCI registry, so none is pinned here.
+        "macos-sequoia": {
+            "location": "ghcr.io/cirruslabs/macos-sequoia-base:latest",
+            "arch": "arm64",
+            "digest": "",
+        },
     },
 }
 

--- a/lince-lab/lince_lab/macos_backend.py
+++ b/lince-lab/lince_lab/macos_backend.py
@@ -1,0 +1,444 @@
+"""MacosBackend — the Apple-Silicon macOS-guest substrate glue (Epic #268).
+
+Drives ``tart`` (cirruslabs, over Virtualization.framework) for every
+:class:`~lince_lab.backend.Backend` operation, reaching the guest over SSH
+(``tart ip`` + password auth via ``SSH_ASKPASS``). It is the macOS sibling of
+:mod:`lince_lab.lima_backend`: the broker / policy / recipe / bisect / capture
+layers are unchanged; only this substrate glue differs.
+
+Key differences from Lima/QEMU:
+
+* ``tart run`` is a FOREGROUND process (the VM runs for as long as it lives), so
+  :meth:`start` spawns it detached and tracks it; :meth:`stop`/:meth:`delete`
+  tear it down (authoritatively via ``tart stop``/``tart delete``).
+* Virtualization.framework has no snapshots → :meth:`snapshot_create` /
+  :meth:`snapshot_apply` are emulated with APFS copy-on-write ``tart clone`` of a
+  STOPPED golden guest (named ``<vm>__snap__<tag>``).
+* ``exec``/``copy_*`` go over SSH/scp to ``tart ip`` (no ``limactl shell``).
+
+Lifecycle verbs route through :meth:`MacosBackend._run`, which raises
+:class:`~lince_lab.errors.BackendError` on a nonzero ``tart`` exit. ``exec`` is
+kept separate so it returns the guest code without raising — that is the bisect
+signal.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+from lince_lab.backend import (
+    Backend,
+    CaptureChannel,
+    ExecResult,
+    VmState,
+    VmStatus,
+)
+from lince_lab.errors import BackendError
+
+# The stdio-pipe capture channel is backend-neutral; reuse it to stay DRY. A
+# rename/extract to a neutral module is tracked for #266, where macOS capture is
+# first exercised.
+from lince_lab.lima_backend import LimaCaptureChannel
+
+# The tart executable, resolved on PATH (installed via `brew install
+# cirruslabs/cli/tart`). Kept as a constant so tests can assert on argv[0].
+TART = "tart"
+
+# Tart base-image convention: the guest admin user + password. NOT a secret — it
+# is the public default of the cirruslabs images, used only to bootstrap SSH into
+# a disposable guest. No host credential is ever forwarded.
+GUEST_USER = "admin"
+GUEST_PASSWORD = "admin"
+
+# Disposable in-guest path the host-side ht is copied to (matches the Lima glue).
+GUEST_HT_PATH = "/tmp/lince-lab-ht"
+
+# Separator for clone-based snapshot guests: "<vm>__snap__<tag>". Chosen to never
+# collide with the lince-lab- VM-name prefix policy.
+SNAP_SEP = "__snap__"
+
+
+def _mem_to_mb(spec: str) -> int:
+    """Parse a memory size string (e.g. ``"2GiB"``) into whole MB for ``tart set``."""
+    s = str(spec).strip().lower()
+    if s.endswith("gib"):
+        return int(float(s[:-3]) * 1024)
+    if s.endswith("mib"):
+        return int(float(s[:-3]))
+    if s.endswith("gb"):
+        return int(float(s[:-2]) * 1000)
+    if s.endswith("mb"):
+        return int(float(s[:-2]))
+    return int(float(s))  # bare number → assume MB
+
+
+def _map_state(raw: str) -> VmStatus:
+    """Map a ``tart list`` State string to :class:`VmStatus` (running → RUNNING)."""
+    return VmStatus.RUNNING if raw.strip().lower() == "running" else VmStatus.STOPPED
+
+
+def _host_ht_path() -> str:
+    """Resolve the HOST-side macOS/arm64 ``ht`` binary the broker copies into a guest.
+
+    Honors ``$LINCE_LAB_HT`` if set; otherwise the lince-lab share dir's
+    ``bin/ht-darwin`` (``$XDG_DATA_HOME`` then ``$HOME/.local/share``), matching
+    the install/update scripts. Not required to exist — :meth:`open_capture`
+    checks for it and falls back to a bare guest ``ht`` on PATH.
+    """
+    env = os.environ.get("LINCE_LAB_HT")
+    if env:
+        return str(Path(env).expanduser())
+    xdg = os.environ.get("XDG_DATA_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".local" / "share"
+    return str((base / "lince" / "lince-lab" / "bin" / "ht-darwin").expanduser())
+
+
+class MacosBackend(Backend):
+    """Real :class:`Backend` that drives ``tart`` (macOS guests on Apple Silicon)."""
+
+    def __init__(self, tart: str = TART) -> None:
+        self._tart = tart
+        self._host_ht = _host_ht_path()
+        # Tracks detached `tart run` processes by VM name so stop/delete can reap them.
+        self._running: dict[str, subprocess.Popen] = {}
+        # Lazily created askpass helper (see _askpass_path).
+        self._askpass: str | None = None
+
+    # ── one lifecycle shell-out helper (raises on nonzero) ───────────────────
+    def _run(
+        self, argv: list[str], *, stdin: str | None = None, stream: bool = False
+    ) -> subprocess.CompletedProcess[str]:
+        """Run a ``tart`` command, raising :class:`BackendError` on a nonzero exit."""
+        if stream:
+            proc = subprocess.run(argv, input=stdin, stdout=subprocess.PIPE, stderr=None, text=True)
+        else:
+            proc = subprocess.run(argv, input=stdin, capture_output=True, text=True)
+        if proc.returncode != 0:
+            cmd = " ".join(argv)
+            detail = "(see the tart output above)" if stream else (proc.stderr or "").strip()
+            raise BackendError(f"{cmd} failed (exit {proc.returncode}): {detail}")
+        return proc
+
+    # ── lifecycle ────────────────────────────────────────────────────────────
+    def create(self, name: str, template_yaml: str) -> None:
+        # The broker passes the policy-forced template JSON. We interpret it for
+        # the macOS substrate: images[0].location is the Tart OCI ref; cpus/memory
+        # map to `tart set`. (plain/mounts/ssh are Lima-only and ignored — Tart
+        # guests expose no host fs and inject no host keys by default.)
+        try:
+            spec = json.loads(template_yaml)
+        except json.JSONDecodeError as exc:
+            raise BackendError(f"macOS create: template is not JSON: {exc}") from exc
+        images = spec.get("images") or []
+        location = images[0].get("location") if images and isinstance(images[0], dict) else None
+        if not location:
+            raise BackendError("macOS create: template has no images[0].location (Tart OCI ref)")
+        # `tart clone <oci-ref> <name>` pulls the image if not already cached.
+        self._run([self._tart, "clone", str(location), name], stream=True)
+        set_argv = [self._tart, "set", name]
+        if spec.get("cpus") is not None:
+            set_argv += ["--cpu", str(int(spec["cpus"]))]
+        if spec.get("memory") is not None:
+            set_argv += ["--memory", str(_mem_to_mb(str(spec["memory"])))]
+        # disk is grow-only in Tart; the base image's disk is sufficient — skip it.
+        if len(set_argv) > 3:
+            self._run(set_argv)
+
+    def start(self, name: str) -> None:
+        # `tart run` is a FOREGROUND process; spawn it detached (its own session)
+        # and keep the handle so stop/delete can reap it. Output is discarded — the
+        # VM's console is not our channel (we talk to it over SSH).
+        print(
+            f"lince-lab: starting macOS guest {name!r} via tart — first boot of a fresh clone can take a minute…",
+            file=sys.stderr,
+            flush=True,
+        )
+        proc = subprocess.Popen(
+            [self._tart, "run", name, "--no-graphics"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        self._running[name] = proc
+        # Block until the guest has a DHCP lease (it has booted enough to network).
+        self._wait_for_ip(name, deadline=time.monotonic() + 180.0)
+
+    def stop(self, name: str, force: bool = False) -> None:
+        # `tart stop` is authoritative (it halts the VM regardless of who launched
+        # the run process); a forced stop shortens the graceful-shutdown timeout.
+        argv = [self._tart, "stop", name]
+        if force:
+            argv += ["-t", "0"]
+        try:
+            self._run(argv)
+        finally:
+            self._reap(name)
+
+    def delete(self, name: str, force: bool = False) -> None:
+        # A running VM cannot be deleted; best-effort stop first, then delete.
+        try:
+            self._run([self._tart, "stop", name])
+        except BackendError:
+            pass
+        self._reap(name)
+        self._run([self._tart, "delete", name])
+
+    def _reap(self, name: str) -> None:
+        proc = self._running.pop(name, None)
+        if proc is None:
+            return
+        try:
+            proc.terminate()
+        except ProcessLookupError:
+            pass
+
+    def status(self, name: str) -> VmState:
+        for rec in self._list_records():
+            if str(rec.get("Name", "")) == name:
+                return VmState(
+                    name=name,
+                    status=_map_state(str(rec.get("State", ""))),
+                    snapshots=self._safe_snapshot_list(name),
+                )
+        return VmState(name=name, status=VmStatus.ABSENT, snapshots=[])
+
+    def list(self) -> list[VmState]:
+        states: list[VmState] = []
+        for rec in self._list_records():
+            nm = str(rec.get("Name", ""))
+            # Skip pullable base images (Source=OCI) and our golden snapshot clones
+            # (an implementation detail) — neither is a user-facing lab VM.
+            if str(rec.get("Source", "")).upper() == "OCI":
+                continue
+            if SNAP_SEP in nm:
+                continue
+            states.append(
+                VmState(
+                    name=nm,
+                    status=_map_state(str(rec.get("State", ""))),
+                    snapshots=self._safe_snapshot_list(nm),
+                )
+            )
+        return states
+
+    def _list_records(self) -> list[dict]:
+        """Run ``tart list --format json`` → parsed list of VM records."""
+        proc = self._run([self._tart, "list", "--format", "json"])
+        try:
+            data = json.loads(proc.stdout or "[]")
+        except json.JSONDecodeError:
+            return []
+        return [r for r in data if isinstance(r, dict)]
+
+    def _safe_snapshot_list(self, name: str) -> list[str]:
+        try:
+            return self.snapshot_list(name)
+        except BackendError:
+            return []
+
+    def _wait_for_ip(self, name: str, deadline: float) -> str:
+        """Poll ``tart ip`` until the guest has an address or the deadline passes."""
+        last = ""
+        while time.monotonic() < deadline:
+            proc = subprocess.run([self._tart, "ip", name], capture_output=True, text=True)
+            ip = (proc.stdout or "").strip()
+            if proc.returncode == 0 and ip:
+                return ip
+            last = (proc.stderr or "").strip()
+            # Short poll backoff on the readiness signal (the lease), not a fixed
+            # sleep of the workload — mirrors the broker-readiness poll in 00-lib.sh.
+            time.sleep(1.0)
+        raise BackendError(f"timed out waiting for {name!r} to get an IP: {last}")
+
+    def _ip(self, name: str) -> str:
+        proc = subprocess.run([self._tart, "ip", name], capture_output=True, text=True)
+        ip = (proc.stdout or "").strip()
+        if proc.returncode != 0 or not ip:
+            raise BackendError(f"no IP for {name!r} (is it running?): {(proc.stderr or '').strip()}")
+        return ip
+
+    # ── SSH transport ────────────────────────────────────────────────────────
+    def _ssh_opts(self) -> list[str]:
+        # Disposable guests get a fresh host key + ephemeral IP each boot, so do
+        # not persist/verify host keys (avoids prompts and known_hosts churn).
+        return [
+            "-o",
+            "StrictHostKeyChecking=no",
+            "-o",
+            "UserKnownHostsFile=/dev/null",
+            "-o",
+            "GlobalKnownHostsFile=/dev/null",
+            "-o",
+            "LogLevel=ERROR",
+            "-o",
+            "ConnectTimeout=30",
+            "-o",
+            "PreferredAuthentications=password,keyboard-interactive",
+            "-o",
+            "NumberOfPasswordPrompts=1",
+        ]
+
+    def _askpass_path(self) -> str:
+        """Lazily create a tiny askpass helper that echoes the guest password.
+
+        Used with ``SSH_ASKPASS`` / ``SSH_ASKPASS_REQUIRE=force`` so password auth
+        works non-interactively (the password is the public Tart default, not a
+        secret). Created 0700 under the temp dir, once per process.
+        """
+        if self._askpass and os.path.isfile(self._askpass):
+            return self._askpass
+        fd, path = tempfile.mkstemp(prefix="lince-lab-askpass-")
+        with os.fdopen(fd, "w") as f:
+            f.write(f"#!/bin/sh\necho {shlex.quote(GUEST_PASSWORD)}\n")
+        os.chmod(path, 0o700)
+        self._askpass = path
+        return path
+
+    def _ssh_env(self) -> dict[str, str]:
+        env = dict(os.environ)
+        env["SSH_ASKPASS"] = self._askpass_path()
+        env["SSH_ASKPASS_REQUIRE"] = "force"
+        # Some ssh builds gate askpass on DISPLAY; harmless to set when unset.
+        env.setdefault("DISPLAY", ":0")
+        return env
+
+    @staticmethod
+    def _remote_command(argv: list[str], workdir: str | None, env: dict[str, str] | None) -> str:
+        """Build a single shell-quoted remote command string (no host word-split)."""
+        prefix = ""
+        if workdir is not None:
+            prefix += f"cd {shlex.quote(workdir)} && "
+        if env:
+            prefix += "env " + " ".join(f"{shlex.quote(k)}={shlex.quote(v)}" for k, v in env.items()) + " "
+        return prefix + " ".join(shlex.quote(a) for a in argv)
+
+    # ── exec (exit code propagates, never raises on guest nonzero) ───────────
+    def exec(
+        self,
+        name: str,
+        argv: list[str],
+        workdir: str | None = None,
+        env: dict[str, str] | None = None,
+        timeout: float | None = None,
+    ) -> ExecResult:
+        ip = self._ip(name)
+        remote = self._remote_command(argv, workdir, env)
+        cmd = ["ssh", *self._ssh_opts(), f"{GUEST_USER}@{ip}", remote]
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,
+            env=self._ssh_env(),
+        )
+        # CRITICAL: return the guest exit code verbatim; do NOT raise — the bisect
+        # signal. (ssh returns the remote command's exit code on a live channel.)
+        return ExecResult(exit_code=proc.returncode, stdout=proc.stdout, stderr=proc.stderr)
+
+    def _run_ssh(self, argv: list[str]) -> subprocess.CompletedProcess[str]:
+        """Run an ssh/scp command with askpass env, raising on a nonzero exit."""
+        proc = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,
+            env=self._ssh_env(),
+        )
+        if proc.returncode != 0:
+            raise BackendError(f"{argv[0]} failed (exit {proc.returncode}): {(proc.stderr or '').strip()}")
+        return proc
+
+    def copy_in(self, name: str, host_path: str, guest_path: str, recursive: bool = False) -> None:
+        ip = self._ip(name)
+        argv = ["scp", *self._ssh_opts()]
+        if recursive:
+            argv.append("-r")
+        argv += [host_path, f"{GUEST_USER}@{ip}:{guest_path}"]
+        self._run_ssh(argv)
+
+    def copy_out(self, name: str, guest_path: str, host_path: str, recursive: bool = False) -> None:
+        ip = self._ip(name)
+        argv = ["scp", *self._ssh_opts()]
+        if recursive:
+            argv.append("-r")
+        argv += [f"{GUEST_USER}@{ip}:{guest_path}", host_path]
+        self._run_ssh(argv)
+
+    # ── snapshots (clone-based: vz has no loadvm) ────────────────────────────
+    def _golden(self, name: str, tag: str) -> str:
+        return f"{name}{SNAP_SEP}{tag}"
+
+    def snapshot_create(self, name: str, tag: str) -> None:
+        golden = self._golden(name, tag)
+        # A clean golden requires a STOPPED source (cloning a live VM is only
+        # crash-consistent). Stop if running, clone, then restore the run state.
+        was_running = self.status(name).status == VmStatus.RUNNING
+        if was_running:
+            self.stop(name)
+        if tag in self.snapshot_list(name):
+            self._run([self._tart, "delete", golden])  # overwrite an existing tag
+        self._run([self._tart, "clone", name, golden])
+        if was_running:
+            self.start(name)
+
+    def snapshot_apply(self, name: str, tag: str) -> None:
+        # The per-candidate bisect reset: rebuild `name` from the golden clone.
+        if tag not in self.snapshot_list(name):
+            raise BackendError(f"no snapshot {tag!r} for {name!r}")
+        golden = self._golden(name, tag)
+        self.stop(name, force=True)
+        self._run([self._tart, "delete", name])
+        self._run([self._tart, "clone", golden, name])
+        self.start(name)
+
+    def snapshot_delete(self, name: str, tag: str) -> None:
+        self._run([self._tart, "delete", self._golden(name, tag)])
+
+    def snapshot_list(self, name: str) -> list[str]:
+        prefix = f"{name}{SNAP_SEP}"
+        tags: list[str] = []
+        for rec in self._list_records():
+            nm = str(rec.get("Name", ""))
+            if nm.startswith(prefix):
+                tags.append(nm[len(prefix) :])
+        return tags
+
+    # ── capture (ht inside the guest, driven over SSH) ───────────────────────
+    def open_capture(self, name: str, argv: list[str], cols: int, rows: int) -> CaptureChannel:
+        # Ship the macOS/arm64 ht into the guest when present, else fall back to a
+        # bare `ht` on the guest PATH. Copying our own disposable capture driver
+        # into a disposable guest does not widen host access.
+        if os.path.isfile(self._host_ht):
+            self.copy_in(name, self._host_ht, GUEST_HT_PATH)
+            ip0 = self._ip(name)
+            self._run_ssh(["ssh", *self._ssh_opts(), f"{GUEST_USER}@{ip0}", f"chmod +x {GUEST_HT_PATH}"])
+            guest_ht = GUEST_HT_PATH
+        else:
+            guest_ht = "ht"
+        ip = self._ip(name)
+        remote = f"{guest_ht} --size {cols}x{rows} --subscribe init,output,snapshot -- " + " ".join(
+            shlex.quote(a) for a in argv
+        )
+        cmd = ["ssh", *self._ssh_opts(), f"{GUEST_USER}@{ip}", remote]
+        proc = subprocess.Popen(
+            cmd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+            env=self._ssh_env(),
+            start_new_session=True,
+        )
+        return LimaCaptureChannel(proc, argv=cmd)

--- a/lince-lab/lince_lab/macos_backend.py
+++ b/lince-lab/lince_lab/macos_backend.py
@@ -64,6 +64,12 @@ GUEST_HT_PATH = "/tmp/lince-lab-ht"
 # collide with the lince-lab- VM-name prefix policy.
 SNAP_SEP = "__snap__"
 
+# macOS guests need more than the Linux-tuned config defaults (a 2 GiB guest will
+# not boot macOS reliably). `tart set --memory` is absolute, so without a floor we
+# would DOWNGRADE the base image below a bootable size — floor the caps here.
+MIN_MACOS_CPU = 2
+MIN_MACOS_MEMORY_MB = 4096
+
 
 def _mem_to_mb(spec: str) -> int:
     """Parse a memory size string (e.g. ``"2GiB"``) into whole MB for ``tart set``."""
@@ -142,14 +148,20 @@ class MacosBackend(Backend):
             raise BackendError("macOS create: template has no images[0].location (Tart OCI ref)")
         # `tart clone <oci-ref> <name>` pulls the image if not already cached.
         self._run([self._tart, "clone", str(location), name], stream=True)
-        set_argv = [self._tart, "set", name]
-        if spec.get("cpus") is not None:
-            set_argv += ["--cpu", str(int(spec["cpus"]))]
-        if spec.get("memory") is not None:
-            set_argv += ["--memory", str(_mem_to_mb(str(spec["memory"])))]
+        # Apply resource caps, floored to macOS-sane minimums (see MIN_MACOS_*).
+        cpus = int(spec["cpus"]) if spec.get("cpus") is not None else MIN_MACOS_CPU
+        mem_mb = _mem_to_mb(str(spec["memory"])) if spec.get("memory") is not None else MIN_MACOS_MEMORY_MB
+        set_argv = [
+            self._tart,
+            "set",
+            name,
+            "--cpu",
+            str(max(cpus, MIN_MACOS_CPU)),
+            "--memory",
+            str(max(mem_mb, MIN_MACOS_MEMORY_MB)),
+        ]
         # disk is grow-only in Tart; the base image's disk is sufficient — skip it.
-        if len(set_argv) > 3:
-            self._run(set_argv)
+        self._run(set_argv)
 
     def start(self, name: str) -> None:
         # `tart run` is a FOREGROUND process; spawn it detached (its own session)

--- a/lince-lab/lince_lab/macos_backend.py
+++ b/lince-lab/lince_lab/macos_backend.py
@@ -180,8 +180,13 @@ class MacosBackend(Backend):
             start_new_session=True,
         )
         self._running[name] = proc
-        # Block until the guest has a DHCP lease (it has booted enough to network).
-        self._wait_for_ip(name, deadline=time.monotonic() + 180.0)
+        # macOS first boot + sshd coming up can be slow; give it a generous window.
+        deadline = time.monotonic() + 300.0
+        # First wait for a DHCP lease (the guest networked), then for sshd to answer
+        # — `tart ip` returns before sshd is ready, so an exec right after start
+        # would otherwise hit "connection refused".
+        ip = self._wait_for_ip(name, deadline)
+        self._wait_for_ssh(name, ip, deadline)
 
     def stop(self, name: str, force: bool = False) -> None:
         # `tart stop` is authoritative (it halts the VM regardless of who launched
@@ -269,6 +274,27 @@ class MacosBackend(Backend):
             # sleep of the workload — mirrors the broker-readiness poll in 00-lib.sh.
             time.sleep(1.0)
         raise BackendError(f"timed out waiting for {name!r} to get an IP: {last}")
+
+    def _wait_for_ssh(self, name: str, ip: str, deadline: float) -> None:
+        """Poll an ssh probe until the guest's sshd answers or the deadline passes."""
+        last = ""
+        probe = ["ssh", *self._ssh_opts(), f"{GUEST_USER}@{ip}", "true"]
+        while time.monotonic() < deadline:
+            proc = subprocess.run(
+                probe,
+                capture_output=True,
+                text=True,
+                stdin=subprocess.DEVNULL,
+                start_new_session=True,
+                env=self._ssh_env(),
+            )
+            if proc.returncode == 0:
+                return
+            last = (proc.stderr or "").strip()
+            # Short backoff on the readiness signal (sshd answering), not a fixed
+            # sleep of any workload.
+            time.sleep(2.0)
+        raise BackendError(f"timed out waiting for ssh on {name!r} ({ip}): {last}")
 
     def _ip(self, name: str) -> str:
         proc = subprocess.run([self._tart, "ip", name], capture_output=True, text=True)

--- a/lince-lab/lince_lab/macos_backend.py
+++ b/lince-lab/lince_lab/macos_backend.py
@@ -4,7 +4,8 @@ Drives ``tart`` (cirruslabs, over Virtualization.framework) for every
 :class:`~lince_lab.backend.Backend` operation, reaching the guest over SSH
 (``tart ip`` + password auth via ``SSH_ASKPASS``). It is the macOS sibling of
 :mod:`lince_lab.lima_backend`: the broker / policy / recipe / bisect / capture
-layers are unchanged; only this substrate glue differs.
+layers stay backend-neutral (they call the Backend seam, never macOS-specific
+code); only this substrate glue differs.
 
 Key differences from Lima/QEMU:
 
@@ -24,6 +25,7 @@ signal.
 
 from __future__ import annotations
 
+import atexit
 import json
 import os
 import shlex
@@ -106,6 +108,36 @@ def _host_ht_path() -> str:
     return str((base / "lince" / "lince-lab" / "bin" / "ht-darwin").expanduser())
 
 
+# A single askpass helper per process (the guest password is the constant public
+# Tart default, so one file is enough). Created lazily and removed at exit, so we
+# don't leak a 0700 temp file per backend instance (or per unit test).
+_ASKPASS_PATH: str | None = None
+
+
+def _askpass_helper() -> str:
+    """Return the path to a process-wide askpass helper that echoes the guest password."""
+    global _ASKPASS_PATH
+    if _ASKPASS_PATH and os.path.isfile(_ASKPASS_PATH):
+        return _ASKPASS_PATH
+    fd, path = tempfile.mkstemp(prefix="lince-lab-askpass-")
+    with os.fdopen(fd, "w") as f:
+        f.write(f"#!/bin/sh\necho {shlex.quote(GUEST_PASSWORD)}\n")
+    os.chmod(path, 0o700)
+    _ASKPASS_PATH = path
+    atexit.register(_cleanup_askpass)
+    return path
+
+
+def _cleanup_askpass() -> None:
+    global _ASKPASS_PATH
+    if _ASKPASS_PATH and os.path.exists(_ASKPASS_PATH):
+        try:
+            os.unlink(_ASKPASS_PATH)
+        except OSError:
+            pass
+    _ASKPASS_PATH = None
+
+
 class MacosBackend(Backend):
     """Real :class:`Backend` that drives ``tart`` (macOS guests on Apple Silicon)."""
 
@@ -114,8 +146,8 @@ class MacosBackend(Backend):
         self._host_ht = _host_ht_path()
         # Tracks detached `tart run` processes by VM name so stop/delete can reap them.
         self._running: dict[str, subprocess.Popen] = {}
-        # Lazily created askpass helper (see _askpass_path).
-        self._askpass: str | None = None
+        # Per-VM `tart run` output log path, so an early-exit error is surfaced.
+        self._runlogs: dict[str, str] = {}
 
     # ── one lifecycle shell-out helper (raises on nonzero) ───────────────────
     def _run(
@@ -146,8 +178,17 @@ class MacosBackend(Backend):
         location = images[0].get("location") if images and isinstance(images[0], dict) else None
         if not location:
             raise BackendError("macOS create: template has no images[0].location (Tart OCI ref)")
+        loc = str(location)
+        # Guard the common footgun: a bare `vm up` with no --image uses default_image
+        # (a Linux qcow2 URL), which `tart clone` cannot consume. Turn that into a
+        # one-line message instead of a cryptic pull error.
+        if loc.startswith(("http://", "https://")) or loc.endswith((".qcow2", ".img")):
+            raise BackendError(
+                f"macOS backend needs a Tart OCI image, got {loc!r}; pass --image macos-sequoia "
+                "(the default_image is Linux-only)"
+            )
         # `tart clone <oci-ref> <name>` pulls the image if not already cached.
-        self._run([self._tart, "clone", str(location), name], stream=True)
+        self._run([self._tart, "clone", loc, name], stream=True)
         # Apply resource caps, floored to macOS-sane minimums (see MIN_MACOS_*).
         cpus = int(spec["cpus"]) if spec.get("cpus") is not None else MIN_MACOS_CPU
         mem_mb = _mem_to_mb(str(spec["memory"])) if spec.get("memory") is not None else MIN_MACOS_MEMORY_MB
@@ -172,13 +213,19 @@ class MacosBackend(Backend):
             file=sys.stderr,
             flush=True,
         )
-        proc = subprocess.Popen(
-            [self._tart, "run", name, "--no-graphics"],
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            start_new_session=True,
-        )
+        # Capture `tart run` stdout+stderr to a log so an early exit (bad image,
+        # already running, perms) surfaces the real error instead of a silent hang.
+        fd, log_path = tempfile.mkstemp(prefix=f"lince-lab-run-{name}-", suffix=".log")
+        os.close(fd)
+        self._runlogs[name] = log_path
+        with open(log_path, "w") as logf:
+            proc = subprocess.Popen(
+                [self._tart, "run", name, "--no-graphics"],
+                stdin=subprocess.DEVNULL,
+                stdout=logf,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+            )
         self._running[name] = proc
         # macOS first boot + sshd coming up can be slow; give it a generous window.
         deadline = time.monotonic() + 300.0
@@ -200,15 +247,21 @@ class MacosBackend(Backend):
             self._reap(name)
 
     def delete(self, name: str, force: bool = False) -> None:
-        # A running VM cannot be deleted; best-effort stop first, then delete.
+        # A running VM cannot be deleted; best-effort stop first (honoring force),
+        # then delete. stop() reaps the tracked run process + log.
         try:
-            self._run([self._tart, "stop", name])
+            self.stop(name, force=force)
         except BackendError:
             pass
-        self._reap(name)
         self._run([self._tart, "delete", name])
 
     def _reap(self, name: str) -> None:
+        log_path = self._runlogs.pop(name, None)
+        if log_path:
+            try:
+                os.unlink(log_path)
+            except OSError:
+                pass
         proc = self._running.pop(name, None)
         if proc is None:
             return
@@ -216,6 +269,25 @@ class MacosBackend(Backend):
             proc.terminate()
         except ProcessLookupError:
             pass
+
+    def _check_run_alive(self, name: str) -> None:
+        """Raise if the tracked `tart run` process has already exited (early failure)."""
+        proc = self._running.get(name)
+        if proc is not None and proc.poll() is not None:
+            raise BackendError(
+                f"tart run for {name!r} exited early (code {proc.returncode}): "
+                f"{self._run_log_tail(name) or 'no output'}"
+            )
+
+    def _run_log_tail(self, name: str, lines: int = 20) -> str:
+        path = self._runlogs.get(name)
+        if not path or not os.path.isfile(path):
+            return ""
+        try:
+            with open(path) as f:
+                return "".join(f.readlines()[-lines:]).strip()
+        except OSError:
+            return ""
 
     def status(self, name: str) -> VmState:
         for rec in self._list_records():
@@ -265,6 +337,7 @@ class MacosBackend(Backend):
         """Poll ``tart ip`` until the guest has an address or the deadline passes."""
         last = ""
         while time.monotonic() < deadline:
+            self._check_run_alive(name)  # fail fast if `tart run` died at spawn
             proc = subprocess.run([self._tart, "ip", name], capture_output=True, text=True)
             ip = (proc.stdout or "").strip()
             if proc.returncode == 0 and ip:
@@ -280,6 +353,7 @@ class MacosBackend(Backend):
         last = ""
         probe = ["ssh", *self._ssh_opts(), f"{GUEST_USER}@{ip}", "true"]
         while time.monotonic() < deadline:
+            self._check_run_alive(name)  # fail fast if `tart run` died after the lease
             proc = subprocess.run(
                 probe,
                 capture_output=True,
@@ -324,25 +398,10 @@ class MacosBackend(Backend):
             "NumberOfPasswordPrompts=1",
         ]
 
-    def _askpass_path(self) -> str:
-        """Lazily create a tiny askpass helper that echoes the guest password.
-
-        Used with ``SSH_ASKPASS`` / ``SSH_ASKPASS_REQUIRE=force`` so password auth
-        works non-interactively (the password is the public Tart default, not a
-        secret). Created 0700 under the temp dir, once per process.
-        """
-        if self._askpass and os.path.isfile(self._askpass):
-            return self._askpass
-        fd, path = tempfile.mkstemp(prefix="lince-lab-askpass-")
-        with os.fdopen(fd, "w") as f:
-            f.write(f"#!/bin/sh\necho {shlex.quote(GUEST_PASSWORD)}\n")
-        os.chmod(path, 0o700)
-        self._askpass = path
-        return path
-
     def _ssh_env(self) -> dict[str, str]:
+        # Password auth via SSH_ASKPASS (the password is the public Tart default).
         env = dict(os.environ)
-        env["SSH_ASKPASS"] = self._askpass_path()
+        env["SSH_ASKPASS"] = _askpass_helper()
         env["SSH_ASKPASS_REQUIRE"] = "force"
         # Some ssh builds gate askpass on DISPLAY; harmless to set when unset.
         env.setdefault("DISPLAY", ":0")
@@ -454,17 +513,17 @@ class MacosBackend(Backend):
 
     # ── capture (ht inside the guest, driven over SSH) ───────────────────────
     def open_capture(self, name: str, argv: list[str], cols: int, rows: int) -> CaptureChannel:
-        # Ship the macOS/arm64 ht into the guest when present, else fall back to a
-        # bare `ht` on the guest PATH. Copying our own disposable capture driver
-        # into a disposable guest does not widen host access.
+        # Resolve the guest IP once (not per sub-step). Ship the macOS/arm64 ht into
+        # the guest when present, else fall back to a bare `ht` on the guest PATH.
+        # Copying our own disposable capture driver into a disposable guest does not
+        # widen host access.
+        ip = self._ip(name)
         if os.path.isfile(self._host_ht):
-            self.copy_in(name, self._host_ht, GUEST_HT_PATH)
-            ip0 = self._ip(name)
-            self._run_ssh(["ssh", *self._ssh_opts(), f"{GUEST_USER}@{ip0}", f"chmod +x {GUEST_HT_PATH}"])
+            self._run_ssh(["scp", *self._ssh_opts(), self._host_ht, f"{GUEST_USER}@{ip}:{GUEST_HT_PATH}"])
+            self._run_ssh(["ssh", *self._ssh_opts(), f"{GUEST_USER}@{ip}", f"chmod +x {GUEST_HT_PATH}"])
             guest_ht = GUEST_HT_PATH
         else:
             guest_ht = "ht"
-        ip = self._ip(name)
         remote = f"{guest_ht} --size {cols}x{rows} --subscribe init,output,snapshot -- " + " ".join(
             shlex.quote(a) for a in argv
         )

--- a/lince-lab/lince_lab/macos_backend.py
+++ b/lince-lab/lince_lab/macos_backend.py
@@ -480,3 +480,19 @@ class MacosBackend(Backend):
             start_new_session=True,
         )
         return LimaCaptureChannel(proc, argv=cmd)
+
+    # ── egress policy ────────────────────────────────────────────────────────
+    def apply_egress_lockdown(
+        self, name: str, allow_ips: list[str], allow_ports: list[int], timeout: float = 180.0
+    ) -> None:
+        # Egress control for macOS guests uses pfctl, not Linux nft — that belongs
+        # to the Seatbelt-recipe work (#266). For the #263 adapter we DEFER it with
+        # a clear warning rather than run the (Linux-only) nft script, which would
+        # fail-closed on a macOS guest and abort `vm up`. The guest therefore
+        # retains network access until #266 lands pfctl enforcement.
+        print(
+            f"lince-lab: WARNING macOS egress lock-down not yet enforced for {name!r} "
+            "(deferred to #266; guest egress is NOT restricted)",
+            file=sys.stderr,
+            flush=True,
+        )

--- a/lince-lab/lince_lab/recipe.py
+++ b/lince-lab/lince_lab/recipe.py
@@ -32,7 +32,7 @@ from lince_lab.backend import Backend
 from lince_lab.capture import Capture, Grid
 from lince_lab.errors import BackendError, DataError
 from lince_lab.paths import parse_size, resolves_under, slug_vm_name
-from lince_lab.templates import build_template, egress_lockdown_argv, resolve_allow_ips, resolve_allow_map
+from lince_lab.templates import build_template, resolve_allow_ips, resolve_allow_map
 
 # Snapshot tag baked after provisioning so retries / bisect can reset cheaply.
 BASE_SNAPSHOT_TAG = "base-clean"
@@ -412,11 +412,12 @@ def apply_egress_lockdown(
 
     Resolves the recipe's allow posture (``mode = "allow"`` → its ``allow_hosts``
     resolved to IPs host-side, fail-closed to deny when none resolve; else a
-    drop-only deny), pins the resolved IPs into the guest ``/etc/hosts``, and runs
-    the nft lock-down via ``backend.exec(vm, egress_lockdown_argv(...))`` while the
-    network is still up (so the script can install ``nft`` if needed). A nonzero
-    exit raises :class:`~lince_lab.errors.BackendError`: a VM that cannot enforce
-    egress must NOT go on to run the (now-untrusted) recipe steps.
+    drop-only deny), pins the resolved IPs into the guest ``/etc/hosts``, and
+    applies the lock-down via ``backend.apply_egress_lockdown(...)`` while the
+    network is still up. That seam runs the Linux nft script on the Lima backend;
+    the macOS backend overrides it (pfctl enforcement is tracked for #266). A
+    nonzero result raises :class:`~lince_lab.errors.BackendError`: a VM that cannot
+    enforce egress must NOT go on to run the (now-untrusted) recipe steps.
     """
     # Cap the lock-down exec so a wedged script errors out instead of hanging
     # forever; honor a tighter step_timeout when the caller provides one.
@@ -438,12 +439,13 @@ def apply_egress_lockdown(
     if host_ip_map and allow_ips:
         _pin_guest_etc_hosts(backend, vm_name, host_ip_map, timeout=timeout)
 
-    result = backend.exec(vm_name, egress_lockdown_argv(allow_ips, allow_ports), timeout=timeout)
-    if result.exit_code != 0:
-        raise BackendError(
-            f"egress lock-down failed on {vm_name} (exit {result.exit_code}): "
-            f"{result.stderr.strip() or 'no detail'}; refusing to run steps unprotected"
-        )
+    # Apply through the backend seam so a non-Linux guest (macOS) enforces egress
+    # its own way instead of running the Linux nft script (which fail-closes on a
+    # guest with no nft). Preserve the recipe-specific framing on failure.
+    try:
+        backend.apply_egress_lockdown(vm_name, allow_ips, allow_ports, timeout=timeout)
+    except BackendError as exc:
+        raise BackendError(f"{exc}; refusing to run steps unprotected") from exc
 
 
 def _pin_guest_etc_hosts(

--- a/lince-lab/tests/test_backend_contract.py
+++ b/lince-lab/tests/test_backend_contract.py
@@ -131,5 +131,14 @@ class LimaBackendContractTest(BackendContractMixin, unittest.TestCase):  # pragm
         return LimaBackend()
 
 
+@unittest.skipUnless(os.environ.get("LINCE_LAB_TART") == "1", "LINCE_LAB_TART!=1: macOS backend skipped")
+class MacosBackendContractTest(BackendContractMixin, unittest.TestCase):  # pragma: no cover - Tart only
+    @staticmethod
+    def make_backend() -> Backend:
+        from lince_lab.macos_backend import MacosBackend  # imported lazily; macOS/Tart-only glue
+
+        return MacosBackend()
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/lince-lab/tests/test_broker_protocol.py
+++ b/lince-lab/tests/test_broker_protocol.py
@@ -357,7 +357,10 @@ class EgressLogTests(unittest.TestCase):
         self.assertEqual(doc["recipe"], "deny-demo")
         self.assertEqual(doc["egress"]["decision"], "deny")
         self.assertEqual(doc["egress"]["rules"], [])
-        self.assertEqual(result["egress_log"], str(log))
+        # Compare canonical paths: the broker resolves the artifacts root, and on
+        # macOS the tmpdir lives under /var → /private/var (a symlink), so an
+        # unresolved expectation would spuriously mismatch. Identical on Linux.
+        self.assertEqual(result["egress_log"], str(log.resolve()))
 
     def test_allow_recipe_writes_resolved_rules(self):
         backend = FakeBackend()

--- a/lince-lab/tests/test_config_presets.py
+++ b/lince-lab/tests/test_config_presets.py
@@ -63,6 +63,15 @@ class DefaultsTest(unittest.TestCase):
         self.assertNotIn("capture_tool", loaded)
         self.assertNotIn("lima_version", loaded)
 
+    def test_macos_image_in_allowlist(self) -> None:
+        # The Tart (macOS-guest) backend keys on this image entry; arch must be
+        # arm64 and the location must be a cirruslabs OCI ref (Epic #268).
+        loaded = cfg.load_config(pathlib.Path("/nonexistent"))
+        self.assertIn("macos-sequoia", loaded["images"])
+        entry = loaded["images"]["macos-sequoia"]
+        self.assertEqual(entry["arch"], "arm64")
+        self.assertTrue(entry["location"].startswith("ghcr.io/cirruslabs/"))
+
     def test_user_file_overlays_defaults(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             path = pathlib.Path(tmp) / "config.toml"

--- a/lince-lab/tests/test_macos_backend.py
+++ b/lince-lab/tests/test_macos_backend.py
@@ -298,5 +298,20 @@ class OpenCaptureTestCase(unittest.TestCase):
         self.assertIsInstance(channel, LimaCaptureChannel)
 
 
+class EgressTestCase(unittest.TestCase):
+    def test_apply_egress_lockdown_is_deferred_noop(self) -> None:
+        # macOS defers egress enforcement to #266 (pfctl): apply_egress_lockdown
+        # must NOT run the Linux nft script (no subprocess) and must NOT raise, so
+        # a deny `vm up` succeeds on a macOS guest.
+        backend = MacosBackend()
+        with (
+            mock.patch("lince_lab.macos_backend.subprocess.run") as run,
+            mock.patch("lince_lab.macos_backend.subprocess.Popen") as popen,
+        ):
+            backend.apply_egress_lockdown("lince-lab-x", [], [])
+        run.assert_not_called()
+        popen.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/lince-lab/tests/test_macos_backend.py
+++ b/lince-lab/tests/test_macos_backend.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Unit tests for :mod:`lince_lab.macos_backend` (Epic #268 / #263).
+
+Assert the EXACT ``tart``/``ssh``/``scp`` argv built for each
+:class:`MacosBackend` method by mocking :mod:`subprocess` — no real VM is
+touched. Pins the two load-bearing behaviours: ``exec`` returns the guest code
+without raising (the bisect signal); a lifecycle verb raises ``BackendError`` on
+a nonzero ``tart`` exit.
+
+Run with:
+    python3 lince-lab/tests/test_macos_backend.py
+"""
+
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+# Put the package dir (lince-lab/) on sys.path so absolute imports resolve.
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+
+from lince_lab.backend import VmState, VmStatus  # noqa: E402
+from lince_lab.errors import BackendError  # noqa: E402
+from lince_lab.macos_backend import MacosBackend, _mem_to_mb  # noqa: E402
+
+
+def _ok(stdout: str = "", stderr: str = "", returncode: int = 0) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+_TEMPLATE = json.dumps(
+    {
+        "images": [{"location": "ghcr.io/cirruslabs/macos-sequoia-base:latest", "arch": "arm64"}],
+        "cpus": 4,
+        "memory": "2GiB",
+        "disk": "40GiB",
+    }
+)
+
+
+class CreateArgvTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.backend = MacosBackend()
+
+    def _patch_run(self, result: subprocess.CompletedProcess) -> mock.MagicMock:
+        patcher = mock.patch("lince_lab.macos_backend.subprocess.run", return_value=result)
+        self.addCleanup(patcher.stop)
+        return patcher.start()
+
+    def test_mem_to_mb(self) -> None:
+        self.assertEqual(_mem_to_mb("2GiB"), 2048)
+        self.assertEqual(_mem_to_mb("512MiB"), 512)
+        self.assertEqual(_mem_to_mb("4GB"), 4000)
+
+    def test_create_clones_image_then_sets_resources(self) -> None:
+        run = self._patch_run(_ok())
+        self.backend.create("lince-lab-x", _TEMPLATE)
+        argvs = [c.args[0] for c in run.call_args_list]
+        self.assertEqual(
+            argvs[0],
+            ["tart", "clone", "ghcr.io/cirruslabs/macos-sequoia-base:latest", "lince-lab-x"],
+        )
+        # resources applied via `tart set` (cpu + memory in MB); disk omitted (grow-only).
+        self.assertEqual(argvs[1], ["tart", "set", "lince-lab-x", "--cpu", "4", "--memory", "2048"])
+
+    def test_create_missing_image_raises(self) -> None:
+        self._patch_run(_ok())
+        with self.assertRaises(BackendError):
+            self.backend.create("lince-lab-x", json.dumps({"images": []}))
+
+
+class LifecycleTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.backend = MacosBackend()
+
+    def test_stop_runs_tart_stop(self) -> None:
+        with mock.patch("lince_lab.macos_backend.subprocess.run", return_value=_ok()) as run:
+            self.backend.stop("lince-lab-x")
+        self.assertEqual(run.call_args.args[0], ["tart", "stop", "lince-lab-x"])
+
+    def test_delete_stops_then_deletes(self) -> None:
+        with mock.patch("lince_lab.macos_backend.subprocess.run", return_value=_ok()) as run:
+            self.backend.delete("lince-lab-x")
+        argvs = [c.args[0] for c in run.call_args_list]
+        self.assertIn(["tart", "delete", "lince-lab-x"], argvs)
+
+    def test_status_running_and_absent(self) -> None:
+        records = [{"Name": "lince-lab-x", "State": "running"}]
+        with mock.patch(
+            "lince_lab.macos_backend.subprocess.run",
+            return_value=_ok(stdout=json.dumps(records)),
+        ) as run:
+            state = self.backend.status("lince-lab-x")
+        self.assertEqual(run.call_args.args[0], ["tart", "list", "--format", "json"])
+        self.assertEqual(state.status, VmStatus.RUNNING)
+        with mock.patch(
+            "lince_lab.macos_backend.subprocess.run",
+            return_value=_ok(stdout=json.dumps(records)),
+        ):
+            self.assertEqual(self.backend.status("ghost").status, VmStatus.ABSENT)
+
+    def test_list_maps_states_and_skips_oci_and_snapshots(self) -> None:
+        records = [
+            {"Name": "lince-lab-a", "State": "running"},
+            {"Name": "lince-lab-b", "State": "stopped"},
+            {"Name": "ghcr.io/cirruslabs/macos-sequoia-base:latest", "State": "stopped", "Source": "OCI"},
+            {"Name": "lince-lab-a__snap__base", "State": "stopped"},
+        ]
+        with mock.patch(
+            "lince_lab.macos_backend.subprocess.run",
+            return_value=_ok(stdout=json.dumps(records)),
+        ):
+            states = self.backend.list()
+        self.assertEqual(
+            [(s.name, s.status) for s in states],
+            [("lince-lab-a", VmStatus.RUNNING), ("lince-lab-b", VmStatus.STOPPED)],
+        )
+
+    def test_start_spawns_detached_run_and_waits_for_ip(self) -> None:
+        fake_proc = mock.MagicMock(spec=subprocess.Popen)
+        with (
+            mock.patch("lince_lab.macos_backend.subprocess.Popen", return_value=fake_proc) as popen,
+            mock.patch("lince_lab.macos_backend.subprocess.run", return_value=_ok(stdout="192.168.64.7\n")),
+        ):
+            self.backend.start("lince-lab-x")
+        self.assertEqual(popen.call_args.args[0], ["tart", "run", "lince-lab-x", "--no-graphics"])
+        self.assertIs(self.backend._running["lince-lab-x"], fake_proc)
+
+
+class ExecTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.backend = MacosBackend()
+
+    def test_exec_builds_ssh_remote_command_and_returns_code(self) -> None:
+        # First subprocess.run = `tart ip`; second = the ssh exec.
+        with mock.patch(
+            "lince_lab.macos_backend.subprocess.run",
+            side_effect=[_ok(stdout="10.0.0.5\n"), _ok(stdout="hi", returncode=0)],
+        ) as run:
+            result = self.backend.exec("lince-lab-x", ["sh", "-c", "echo hi"])
+        ssh_argv = run.call_args_list[1].args[0]
+        self.assertEqual(ssh_argv[0], "ssh")
+        self.assertEqual(ssh_argv[-2], "admin@10.0.0.5")
+        # The remote command is one shell-quoted string (no host-side word-split).
+        self.assertEqual(ssh_argv[-1], "sh -c 'echo hi'")
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.stdout, "hi")
+
+    def test_exec_injects_workdir_and_env(self) -> None:
+        with mock.patch(
+            "lince_lab.macos_backend.subprocess.run",
+            side_effect=[_ok(stdout="10.0.0.5\n"), _ok()],
+        ) as run:
+            self.backend.exec("lince-lab-x", ["make", "test"], workdir="/work", env={"CI": "1"})
+        remote = run.call_args_list[1].args[0][-1]
+        self.assertEqual(remote, "cd /work && env CI=1 make test")
+
+    def test_exec_returns_guest_nonzero_without_raising(self) -> None:
+        with mock.patch(
+            "lince_lab.macos_backend.subprocess.run",
+            side_effect=[_ok(stdout="10.0.0.5\n"), _ok(stderr="boom", returncode=1)],
+        ):
+            result = self.backend.exec("lince-lab-x", ["false"])
+        self.assertEqual(result.exit_code, 1)
+        self.assertEqual(result.stderr, "boom")
+
+
+class CopyTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.backend = MacosBackend()
+
+    def test_copy_in_scp_target(self) -> None:
+        with mock.patch(
+            "lince_lab.macos_backend.subprocess.run",
+            side_effect=[_ok(stdout="10.0.0.5\n"), _ok()],
+        ) as run:
+            self.backend.copy_in("lince-lab-x", "./work", "/work", recursive=True)
+        scp = run.call_args_list[1].args[0]
+        self.assertEqual(scp[0], "scp")
+        self.assertIn("-r", scp)
+        self.assertEqual(scp[-2:], ["./work", "admin@10.0.0.5:/work"])
+
+    def test_copy_out_scp_source(self) -> None:
+        with mock.patch(
+            "lince_lab.macos_backend.subprocess.run",
+            side_effect=[_ok(stdout="10.0.0.5\n"), _ok()],
+        ) as run:
+            self.backend.copy_out("lince-lab-x", "/etc/hosts", "./hosts")
+        scp = run.call_args_list[1].args[0]
+        self.assertEqual(scp[-2:], ["admin@10.0.0.5:/etc/hosts", "./hosts"])
+
+    def test_copy_in_raises_on_scp_failure(self) -> None:
+        with mock.patch(
+            "lince_lab.macos_backend.subprocess.run",
+            side_effect=[_ok(stdout="10.0.0.5\n"), _ok(stderr="nope", returncode=1)],
+        ):
+            with self.assertRaises(BackendError):
+                self.backend.copy_in("lince-lab-x", "./a", "/a")
+
+
+class SnapshotTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.backend = MacosBackend()
+
+    def test_snapshot_list_filters_by_naming(self) -> None:
+        records = [
+            {"Name": "lince-lab-x", "State": "running"},
+            {"Name": "lince-lab-x__snap__base", "State": "stopped"},
+            {"Name": "lince-lab-x__snap__cand-2", "State": "stopped"},
+            {"Name": "lince-lab-y", "State": "stopped"},
+        ]
+        with mock.patch(
+            "lince_lab.macos_backend.subprocess.run",
+            return_value=_ok(stdout=json.dumps(records)),
+        ):
+            tags = self.backend.snapshot_list("lince-lab-x")
+        self.assertEqual(sorted(tags), ["base", "cand-2"])
+
+    def test_snapshot_delete(self) -> None:
+        with mock.patch("lince_lab.macos_backend.subprocess.run", return_value=_ok()) as run:
+            self.backend.snapshot_delete("lince-lab-x", "base")
+        self.assertEqual(run.call_args.args[0], ["tart", "delete", "lince-lab-x__snap__base"])
+
+    def test_snapshot_create_clones_stopped_golden(self) -> None:
+        # VM is stopped already (status returns STOPPED) → no stop/start dance.
+        with (
+            mock.patch.object(self.backend, "status", return_value=VmState("lince-lab-x", VmStatus.STOPPED, [])),
+            mock.patch.object(self.backend, "snapshot_list", return_value=[]),
+            mock.patch("lince_lab.macos_backend.subprocess.run", return_value=_ok()) as run,
+        ):
+            self.backend.snapshot_create("lince-lab-x", "base")
+        argvs = [c.args[0] for c in run.call_args_list]
+        self.assertIn(["tart", "clone", "lince-lab-x", "lince-lab-x__snap__base"], argvs)
+
+    def test_snapshot_apply_restores_from_golden(self) -> None:
+        with (
+            mock.patch.object(self.backend, "snapshot_list", return_value=["base"]),
+            mock.patch.object(self.backend, "stop"),
+            mock.patch.object(self.backend, "start") as start,
+            mock.patch("lince_lab.macos_backend.subprocess.run", return_value=_ok()) as run,
+        ):
+            self.backend.snapshot_apply("lince-lab-x", "base")
+        argvs = [c.args[0] for c in run.call_args_list]
+        self.assertIn(["tart", "delete", "lince-lab-x"], argvs)
+        self.assertIn(["tart", "clone", "lince-lab-x__snap__base", "lince-lab-x"], argvs)
+        start.assert_called_once_with("lince-lab-x")
+
+    def test_snapshot_apply_unknown_tag_raises(self) -> None:
+        with mock.patch.object(self.backend, "snapshot_list", return_value=[]):
+            with self.assertRaises(BackendError):
+                self.backend.snapshot_apply("lince-lab-x", "missing")
+
+
+class OpenCaptureTestCase(unittest.TestCase):
+    def test_open_capture_copies_ht_and_spawns_over_ssh(self) -> None:
+        from lince_lab.lima_backend import LimaCaptureChannel
+
+        with tempfile.NamedTemporaryFile(suffix="-ht-darwin") as host_ht:
+            host_ht.write(b"#!/bin/sh\n")
+            host_ht.flush()
+            fake_proc = mock.MagicMock(spec=subprocess.Popen)
+            fake_proc.stdout = None
+            fake_proc.stderr = None
+            with (
+                mock.patch.dict("os.environ", {"LINCE_LAB_HT": host_ht.name}, clear=False),
+                mock.patch(
+                    "lince_lab.macos_backend.subprocess.run",
+                    side_effect=[
+                        _ok(stdout="10.0.0.5\n"),  # _ip for copy_in
+                        _ok(),  # scp copy_in
+                        _ok(stdout="10.0.0.5\n"),  # _ip for chmod
+                        _ok(),  # ssh chmod +x
+                        _ok(stdout="10.0.0.5\n"),  # _ip for the spawn
+                    ],
+                ),
+                mock.patch("lince_lab.macos_backend.subprocess.Popen", return_value=fake_proc) as popen,
+            ):
+                backend = MacosBackend()
+                channel = backend.open_capture("lince-lab-x", ["./tui"], cols=80, rows=24)
+        spawn = popen.call_args.args[0]
+        self.assertEqual(spawn[0], "ssh")
+        self.assertEqual(
+            spawn[-1],
+            "/tmp/lince-lab-ht --size 80x24 --subscribe init,output,snapshot -- ./tui",
+        )
+        self.assertIsInstance(channel, LimaCaptureChannel)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/lince-lab/tests/test_macos_backend.py
+++ b/lince-lab/tests/test_macos_backend.py
@@ -35,7 +35,7 @@ _TEMPLATE = json.dumps(
     {
         "images": [{"location": "ghcr.io/cirruslabs/macos-sequoia-base:latest", "arch": "arm64"}],
         "cpus": 4,
-        "memory": "2GiB",
+        "memory": "8GiB",
         "disk": "40GiB",
     }
 )
@@ -64,7 +64,16 @@ class CreateArgvTestCase(unittest.TestCase):
             ["tart", "clone", "ghcr.io/cirruslabs/macos-sequoia-base:latest", "lince-lab-x"],
         )
         # resources applied via `tart set` (cpu + memory in MB); disk omitted (grow-only).
-        self.assertEqual(argvs[1], ["tart", "set", "lince-lab-x", "--cpu", "4", "--memory", "2048"])
+        self.assertEqual(argvs[1], ["tart", "set", "lince-lab-x", "--cpu", "4", "--memory", "8192"])
+
+    def test_create_floors_macos_resources(self) -> None:
+        # The Linux-tuned defaults (e.g. 1-2 GiB) would not boot macOS; create()
+        # floors cpu to >=2 and memory to >=4096 MB.
+        run = self._patch_run(_ok())
+        small = json.dumps({"images": [{"location": "ghcr.io/cirruslabs/x:latest"}], "cpus": 1, "memory": "1GiB"})
+        self.backend.create("lince-lab-x", small)
+        set_argv = [c.args[0] for c in run.call_args_list][1]
+        self.assertEqual(set_argv, ["tart", "set", "lince-lab-x", "--cpu", "2", "--memory", "4096"])
 
     def test_create_missing_image_raises(self) -> None:
         self._patch_run(_ok())

--- a/lince-lab/tests/test_macos_backend.py
+++ b/lince-lab/tests/test_macos_backend.py
@@ -80,6 +80,15 @@ class CreateArgvTestCase(unittest.TestCase):
         with self.assertRaises(BackendError):
             self.backend.create("lince-lab-x", json.dumps({"images": []}))
 
+    def test_create_rejects_non_oci_image(self) -> None:
+        # A bare `vm up` with no --image yields the Linux default_image (a qcow2 URL);
+        # tart cannot clone that, so create() must reject it with a clear message.
+        self._patch_run(_ok())
+        qcow2 = json.dumps({"images": [{"location": "https://example.com/fedora.qcow2"}]})
+        with self.assertRaises(BackendError) as ctx:
+            self.backend.create("lince-lab-x", qcow2)
+        self.assertIn("--image macos-sequoia", str(ctx.exception))
+
 
 class LifecycleTestCase(unittest.TestCase):
     def setUp(self) -> None:
@@ -130,6 +139,7 @@ class LifecycleTestCase(unittest.TestCase):
 
     def test_start_spawns_detached_run_and_waits_for_ip(self) -> None:
         fake_proc = mock.MagicMock(spec=subprocess.Popen)
+        fake_proc.poll.return_value = None  # `tart run` still alive during the waits
         with (
             mock.patch("lince_lab.macos_backend.subprocess.Popen", return_value=fake_proc) as popen,
             mock.patch("lince_lab.macos_backend.subprocess.run", return_value=_ok(stdout="192.168.64.7\n")),
@@ -137,6 +147,22 @@ class LifecycleTestCase(unittest.TestCase):
             self.backend.start("lince-lab-x")
         self.assertEqual(popen.call_args.args[0], ["tart", "run", "lince-lab-x", "--no-graphics"])
         self.assertIs(self.backend._running["lince-lab-x"], fake_proc)
+        self.backend._reap("lince-lab-x")  # clean the run-log tempfile
+
+    def test_start_bails_fast_when_run_exits_early(self) -> None:
+        # If `tart run` dies at spawn, start() must fail fast with the real error,
+        # not hang for the full 300s IP/ssh window.
+        fake_proc = mock.MagicMock(spec=subprocess.Popen)
+        fake_proc.poll.return_value = 1  # exited immediately
+        fake_proc.returncode = 1
+        with (
+            mock.patch("lince_lab.macos_backend.subprocess.Popen", return_value=fake_proc),
+            mock.patch("lince_lab.macos_backend.subprocess.run", return_value=_ok(stdout="192.168.64.7\n")),
+        ):
+            with self.assertRaises(BackendError) as ctx:
+                self.backend.start("lince-lab-x")
+        self.assertIn("exited early", str(ctx.exception))
+        self.backend._reap("lince-lab-x")
 
 
 class ExecTestCase(unittest.TestCase):
@@ -278,11 +304,9 @@ class OpenCaptureTestCase(unittest.TestCase):
                 mock.patch(
                     "lince_lab.macos_backend.subprocess.run",
                     side_effect=[
-                        _ok(stdout="10.0.0.5\n"),  # _ip for copy_in
-                        _ok(),  # scp copy_in
-                        _ok(stdout="10.0.0.5\n"),  # _ip for chmod
+                        _ok(stdout="10.0.0.5\n"),  # _ip (resolved once)
+                        _ok(),  # scp the ht binary in
                         _ok(),  # ssh chmod +x
-                        _ok(stdout="10.0.0.5\n"),  # _ip for the spawn
                     ],
                 ),
                 mock.patch("lince_lab.macos_backend.subprocess.Popen", return_value=fake_proc) as popen,

--- a/lince-lab/update.sh
+++ b/lince-lab/update.sh
@@ -71,6 +71,19 @@ else
     echo -e "${GREEN}  ✓ ht already present -> $SHARE_DIR/bin/ht${NC}"
 fi
 
+# macOS/arm64 ht for the Tart (macOS-guest) backend — same role as the Linux ht,
+# copied into a macOS guest on demand (Epic #268). Idempotent + non-fatal too.
+HT_DARWIN_URL="https://github.com/andyk/ht/releases/download/${HT_VER}/ht-aarch64-apple-darwin"
+if [ ! -x "$SHARE_DIR/bin/ht-darwin" ]; then
+    if curl -fsSL -o "$SHARE_DIR/bin/ht-darwin" "$HT_DARWIN_URL" && chmod +x "$SHARE_DIR/bin/ht-darwin"; then
+        echo -e "${GREEN}  ✓ ht (macOS/arm64) -> $SHARE_DIR/bin/ht-darwin${NC}"
+    else
+        echo -e "${YELLOW}  ⚠ ht (macOS/arm64) download failed; macOS-backend capture unavailable until present${NC}"
+    fi
+else
+    echo -e "${GREEN}  ✓ ht (macOS/arm64) already present -> $SHARE_DIR/bin/ht-darwin${NC}"
+fi
+
 # Skill
 if [ -d "$SKILL_SRC" ]; then
     mkdir -p "$SKILL_DST"

--- a/scripts/lince-lab/ci/v2/00-lib.sh
+++ b/scripts/lince-lab/ci/v2/00-lib.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# v2/00-lib.sh — shared library for the lince-lab v2 (macOS/Seatbelt) oracle chain.
+#
+# Sources the v1 lib for the assert helpers + start_broker + path resolution, and
+# adds skip_if_not_macos: the v2 analogue of skip_if_no_kvm. VM-dependent v2
+# oracles call it FIRST so the whole chain is green-or-skipped off a macOS host.
+#
+# This file is a library: it is meant to be *sourced*, not executed.
+
+set -e
+
+_V2_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../00-lib.sh
+source "$_V2_DIR/../00-lib.sh"
+
+# ── skip guard (the v2 analogue of skip_if_no_kvm) ───────────────────────────
+# Skip cleanly unless we are on an Apple-Silicon macOS host with tart installed.
+# Logs the exact phrase the epic mandates ("skipped: not macOS") and exits 0, so
+# the v2 chain stays green-or-skipped on a Linux CI host (where v1 runs instead).
+skip_if_not_macos() {
+    local reason=""
+    if [ "$(uname -s)" != "Darwin" ]; then
+        reason="uname -s != Darwin"
+    elif [ "$(uname -m)" != "arm64" ]; then
+        reason="uname -m != arm64 (not Apple Silicon)"
+    elif ! command -v tart >/dev/null 2>&1; then
+        reason="tart not installed (macOS backend unavailable)"
+    fi
+    if [ -n "$reason" ]; then
+        echo -e "${YELLOW}skipped: not macOS${NC} ($reason)"
+        exit 0
+    fi
+    return 0
+}

--- a/scripts/lince-lab/ci/v2/01-macos-guest.sh
+++ b/scripts/lince-lab/ci/v2/01-macos-guest.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# v2/01-macos-guest.sh — sub-issue #263 oracle (Epic #268).
+#
+# macOS-guest adapter foundation. Asserts the real MacosBackend (Tart) glue
+# against a live macOS guest: a VM can be created + started from the macos-sequoia
+# image, `sw_vers` runs in the guest (proving it is macOS), the guest exit code
+# propagates (the bisect signal), and the VM tears down. Skips cleanly (exit 0)
+# off an Apple-Silicon macOS host so the Linux chain stays green.
+#
+# Exit 0 only on success → trigger oracle for #264 and #265.
+
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=00-lib.sh
+source "$SCRIPT_DIR/00-lib.sh"
+
+oracle_header "v2/01 macos-guest (#263)"
+
+# VM-dependent: skip cleanly off a macOS/Apple-Silicon host.
+skip_if_not_macos
+
+VM="lince-lab-v2ci01-$$"
+SOCK="$LINCE_LAB_SOCK"
+
+cleanup() {
+    "$LINCE_LAB_BIN" --socket "$SOCK" vm rm "$VM" -f >/dev/null 2>&1 || true
+    stop_broker "$SOCK"
+}
+trap cleanup EXIT
+
+# A live broker over the real MacosBackend is the seam the CLI drives.
+LINCE_LAB_MACOS=1 start_broker "$SOCK"
+
+log "create + start a disposable macOS guest from the macos-sequoia image"
+assert "$LINCE_LAB_BIN" --socket "$SOCK" vm up "$VM" --image macos-sequoia -- "vm up created and started $VM"
+
+log "VM reports running"
+STATUS_JSON="$("$LINCE_LAB_BIN" --socket "$SOCK" --json vm status "$VM")"
+assert_contains "$STATUS_JSON" '"running"' "vm status reports running"
+
+log "guest is macOS (sw_vers exits 0 and names macOS)"
+assert_exit 0 "exec 'sw_vers' -> 0" -- "$LINCE_LAB_BIN" --socket "$SOCK" vm exec "$VM" -- sw_vers
+SWVERS_OUT="$("$LINCE_LAB_BIN" --socket "$SOCK" vm exec "$VM" -- sw_vers)"
+assert_contains "$SWVERS_OUT" "macOS" "sw_vers reports macOS"
+
+log "guest exit code propagates (the bisect signal)"
+assert_exit 7 "exec 'exit 7' -> 7" -- "$LINCE_LAB_BIN" --socket "$SOCK" vm exec "$VM" -- sh -c 'exit 7'
+
+log "destroy the guest"
+assert "$LINCE_LAB_BIN" --socket "$SOCK" vm rm "$VM" -f -- "vm rm tore down $VM"
+# VM already gone; only the broker remains to clean up on exit.
+trap 'stop_broker "$SOCK"' EXIT
+
+ok "v2/01 macos-guest oracle passed"
+exit 0

--- a/scripts/lince-lab/ci/v2/01-macos-guest.sh
+++ b/scripts/lince-lab/ci/v2/01-macos-guest.sh
@@ -27,10 +27,12 @@ cleanup() {
     "$LINCE_LAB_BIN" --socket "$SOCK" vm rm "$VM" -f >/dev/null 2>&1 || true
     stop_broker "$SOCK"
 }
-trap cleanup EXIT
 
 # A live broker over the real MacosBackend is the seam the CLI drives.
 LINCE_LAB_MACOS=1 start_broker "$SOCK"
+# start_broker installs its own `trap stop_broker EXIT`; re-assert the full cleanup
+# AFTER it so a mid-oracle assertion failure still tears the (heavier) Tart VM down.
+trap cleanup EXIT
 
 log "create + start a disposable macOS guest from the macos-sequoia image"
 assert "$LINCE_LAB_BIN" --socket "$SOCK" vm up "$VM" --image macos-sequoia -- "vm up created and started $VM"


### PR DESCRIPTION
Closes #263. First brick of the lince-lab v2 (macOS/Seatbelt) epic, #268. macOS host / Apple Silicon only.

## What this adds

A `MacosBackend` that boots a clean disposable macOS guest via Tart (Virtualization.framework) behind the existing broker verb contract, selected with `LINCE_LAB_MACOS=1`. It mirrors `lima_backend.py`; broker/policy/capture-driver/CLI/protocol are unchanged, and recipe/bisect change by one line each (the egress seam below).

Per-verb mapping (`lince_lab/macos_backend.py`):
- create: `tart clone <oci-ref> <name>` then `tart set --cpu --memory` (caps floored to cpu >= 2, mem >= 4096 MB: the Linux-tuned 2 GiB default does not boot macOS reliably, and `tart set --memory` is absolute so it would downgrade the image). A non-OCI location (the Linux default_image qcow2 URL) is rejected with a `pass --image macos-sequoia` message rather than a cryptic `tart clone` error.
- start: `tart run --no-graphics` is a foreground process, so it is spawned detached, its output captured to a log, and reaped on stop/delete. It then waits for the DHCP lease (`tart ip`) and for sshd to answer before returning, and fails fast if the run process exits early instead of hanging the wait window.
- exec/copy: over SSH/scp to `tart ip` (guest admin password via `SSH_ASKPASS`, no sshpass dependency). exec returns the guest exit code verbatim (the bisect signal).
- snapshots: Virtualization.framework has no loadvm, so they are emulated with APFS copy-on-write `tart clone` of a stopped golden guest (`<vm>__snap__<tag>`). This keeps the bisect reset contract: one `snapshot_apply(BASE)` per candidate.
- capture: `ht` in the guest over SSH, reusing the existing stdio-pipe channel.

Supporting changes:
- `config.py` gains the `macos-sequoia` image (Tart OCI ref `ghcr.io/cirruslabs/macos-sequoia-base:latest`, arch arm64).
- Egress enforcement moves onto the backend seam: a concrete `Backend.apply_egress_lockdown` whose default is the existing nft-via-exec (Lima and Fake unchanged, byte for byte). `_h_start` and `recipe.apply_egress_lockdown` (so recipe.run/bisect.run) both go through it. nft is Linux-only and was aborting on a macOS guest (`nft unavailable and no known package manager; aborting lock-down`); the `MacosBackend` override defers real enforcement (pfctl) to #266 with a warning instead of aborting.
- `install.sh`/`update.sh` also fetch `ht-aarch64-apple-darwin` into the share dir. One process-wide 0700 askpass helper, removed at exit (no per-instance/per-test temp-file leak).
- v2 oracle chain: `scripts/lince-lab/ci/v2/00-lib.sh` adds `skip_if_not_macos` (the analogue of `skip_if_no_kvm`) and `01-macos-guest.sh`. On a Mac, v1 self-skips (no /dev/kvm) and v2 runs; on Linux, v1 runs and v2 prints `skipped: not macOS` and exits 0.
- One pre-existing macOS-only test fix: `test_broker_protocol` compared an unresolved tmpdir against the broker's resolved artifacts path, which differ under the /var to /private/var symlink. First time the v1 suite ran on macOS.

## Breaking change?

No. Lima and Fake keep their exact behavior: `apply_egress_lockdown`'s default replays the old nft-via-exec path (same argv, same raise) and the broker/recipe just call it instead of inlining it. The rest is additive (new env var, new optional image, new backend method with a default).

## Validation

Real boot on an Apple Silicon Mac (tart 2.32.1, `macos-sequoia-base`), `bash scripts/lince-lab/ci/v2/01-macos-guest.sh`:

```
PASS vm up created and started lince-lab-v2ci01-13930
PASS vm status reports running (contains '"running"')
ProductName:		macOS
ProductVersion:		15.7.7
BuildVersion:		24G720
PASS exec 'sw_vers' -> 0 (exit 0)
PASS sw_vers reports macOS (contains 'macOS')
PASS exec 'exit 7' -> 7 (exit 7)
PASS vm rm tore down lince-lab-v2ci01-13930
PASS v2/01 macos-guest oracle passed
```

Full VM-free unit suite green (12 files), including 24 mocked-subprocess tests in `test_macos_backend.py` and the contract suite (`test_backend_contract` OK, skipped=16). `ruff check` and `ruff format --check` clean on the package and tests.

## Scope left out on purpose (later sub-issues)

- pfctl egress enforcement for macOS guests: #266. The seam is now wired everywhere (broker + recipe + bisect), but the `MacosBackend` override is a no-op deferral: a macOS guest under deny is not network-restricted yet, and the override logs that. Conscious call for #263 (disposable, operator-driven guests; the agent-facing Seatbelt path is #266). Fail-closed-by-default on macOS is a quick follow-up if you would rather it not boot un-enforced.
- Reset oracle `v2/02-reset.sh` plus the reset-time budget: #264. The clone-based snapshots land here, but their real-hardware reset proof is #264.
- `--backend` flag, `backend` config key, and the `verbs` subcommand: #265.
- macOS capture (ht copy-in + spawn) is unit-mocked only; the real exercise is #266's recipes. `MacosBackendContractTest` is gated on `LINCE_LAB_TART=1`, like `LimaBackendContractTest` on KVM; the contract mixin's stub template carries no image, so the real macOS validation is the oracle above.

---
*Implemented with the help of a coding agent (Claude Code) and reviewed locally by the author.*
