### PR TITLE
fix(dashboard): absolutize wizard completer matches against launch_dir

### DIFF
--- a/lince-dashboard/plugin/src/config.rs
+++ b/lince-dashboard/plugin/src/config.rs
@@ -417,6 +417,27 @@ pub fn shell_path_expr(path: &str) -> String {
     }
 }
 
+/// Resolve a path-completer match against the launch directory.
+///
+/// The legacy glob completer (used when no project roots are configured) runs
+/// in the plugin host's launch CWD and emits bare relative names like
+/// `synoptic`; the multi-root `find` emits absolute paths. Written to
+/// `project_dir` verbatim, a relative match is rejected by the absolute-path
+/// validation at the ProjectDir step — see #125. Prefix relative matches with
+/// `launch_dir` so every candidate is absolute; already-absolute and
+/// `~`-prefixed matches are location-independent and pass through unchanged.
+/// With no known launch dir there is nothing to resolve against, so the match
+/// is returned as-is.
+pub fn absolutize_under(launch_dir: Option<&str>, path: &str) -> String {
+    if path.starts_with('/') || path.starts_with('~') {
+        return path.to_string();
+    }
+    match launch_dir {
+        Some(base) if !base.is_empty() => format!("{}/{}", base.trim_end_matches('/'), path),
+        _ => path.to_string(),
+    }
+}
+
 /// Find the longest common prefix among a list of strings.
 /// Returns an empty string if the list is empty.
 /// Handles multi-byte UTF-8 correctly by snapping to char boundaries.
@@ -1221,6 +1242,41 @@ fn embedded_event_maps() -> &'static HashMap<String, HashMap<String, String>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #125: the legacy glob completer emits bare relative names; they must be
+    /// resolved against the launch dir before reaching `project_dir`.
+    #[test]
+    fn absolutize_under_prefixes_relative_matches() {
+        assert_eq!(
+            absolutize_under(Some("/home/u/work"), "synoptic"),
+            "/home/u/work/synoptic"
+        );
+        // A trailing slash on the base must not double up.
+        assert_eq!(
+            absolutize_under(Some("/home/u/work/"), "synoptic"),
+            "/home/u/work/synoptic"
+        );
+    }
+
+    /// Absolute (multi-root `find`) and `~`-prefixed matches are already
+    /// location-independent and must pass through untouched — in particular
+    /// `~/api` must not become `<launch>/~/api`.
+    #[test]
+    fn absolutize_under_passes_through_absolute_and_tilde() {
+        assert_eq!(
+            absolutize_under(Some("/home/u/work"), "/srv/projects/api"),
+            "/srv/projects/api"
+        );
+        assert_eq!(absolutize_under(Some("/home/u/work"), "~/api"), "~/api");
+    }
+
+    /// With no usable launch dir there is nothing to resolve against, so the
+    /// match is returned unchanged rather than guessed at.
+    #[test]
+    fn absolutize_under_without_launch_dir_is_noop() {
+        assert_eq!(absolutize_under(None, "synoptic"), "synoptic");
+        assert_eq!(absolutize_under(Some(""), "synoptic"), "synoptic");
+    }
 
     /// Pre-#81 `agents-defaults.toml` files used `profiles = [...]`. The
     /// rename added `#[serde(alias = "profiles")]` on `AgentTypeConfig.providers`

--- a/lince-dashboard/plugin/src/main.rs
+++ b/lince-dashboard/plugin/src/main.rs
@@ -428,6 +428,9 @@ impl ZellijPlugin for State {
                         true
                     }
                     Some(config::CMD_PATH_COMPLETE) => {
+                        // #125: capture the launch dir before borrowing the
+                        // wizard, to absolutize relative completer matches below.
+                        let launch_dir = self.launch_dir.clone();
                         if let Some(ref mut wizard) = self.wizard {
                             // Discard stale results if the input changed since the request.
                             let expected = context.get("prefix").map(|s| s.as_str());
@@ -447,6 +450,13 @@ impl ZellijPlugin for State {
                                 // different code paths end up in distinct
                                 // swimlanes — see also `sort_agents_by_dir`.
                                 .map(|l| l.trim_end_matches('/').to_string())
+                                // #125: resolve relative legacy-glob matches
+                                // against the launch dir before collapsing, so
+                                // every candidate is absolute and passes the
+                                // ProjectDir absolute-path check. Runs before
+                                // `collapse_tilde`, so a plain `/` test suffices
+                                // — the raw completer output never contains `~`.
+                                .map(|l| config::absolutize_under(launch_dir.as_deref(), &l))
                                 .map(|l| config::collapse_tilde(&l))
                                 .collect();
                             matches.sort();


### PR DESCRIPTION
Closes #125.

The wizard's Tab completer surfaces relative paths. With no `project_search_roots` configured (the default), `CMD_PATH_COMPLETE` takes the legacy glob branch, which globs in the launch CWD and emits bare names like `synoptic`. The handler wrote the match into `wizard.project_dir` with only trailing-slash trim and `collapse_tilde`, so the relative name reached `project_dir` verbatim.

Severity is lower than the title says (thanks @maeste for catching this on the issue): today the live symptom is a completer dead-end. The spawn crash in the title is unreachable behind the #126 backstop (main.rs:1416), which rejects a relative `project_dir` at the ProjectDir step with "Project dir must be an absolute path (Tab to autocomplete).". Since that message points back at Tab, accepting the suggestion refills the same rejected value.

Fix: resolve each match against `launch_dir` in the handler's shared map chain (`config::absolutize_under`), so both the single-match and common-prefix branches emit absolute paths, the shape the multi-root `find` already produces. Already-absolute and `~`-prefixed matches pass through. It runs before `collapse_tilde`, so a plain `/` test is enough: the raw completer output never contains `~`.

Validation:
- `cargo build --target wasm32-wasip1`: clean.
- `cargo clippy --target wasm32-wasip1`: 26 pre-existing warnings, none in the added lines.
- Added `absolutize_under` unit tests: relative match prefixed, trailing-slash base does not double up, absolute and `~` pass through, `None` and empty base are no-ops.

Not run: the in-crate tests do not execute standalone. The plugin test binary imports the Zellij host (`zellij::host_run_plugin_command`), so `wasmtime` cannot instantiate it without Zellij; the tests compile for `wasm32-wasip1` but I could not run them here. I checked the helper logic by running the same six assertions against a native copy. If CI runs the suite a specific way, point me at it and I will match it.

I kept the fix in the handler (per the issue body) rather than absolutizing in the legacy glob in `config.rs`, since the handler is where both completion sources converge.
