### PR TITLE
test(sandbox): pin sys.platform for landlock_plan tests (#242)

### DIFF
--- a/scripts/tests/test_policy_record.py
+++ b/scripts/tests/test_policy_record.py
@@ -14,6 +14,7 @@ import os
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
@@ -101,6 +102,14 @@ class TestRecordHonesty(unittest.TestCase):
     """#222 review: the record's *_enforced must reflect reality, not be
     hardcoded — otherwise the I7 gate can't catch a missing net boundary."""
 
+    # landlock_plan() short-circuits to None off Linux, so these three would
+    # fail with a TypeError on a macOS dev host (#242). The plan itself is
+    # pure dict arithmetic — no syscalls — so pinning the platform exercises
+    # the real semantics from any host. Keep the patch on these three only:
+    # probe_landlock_abi() guards a genuine ctypes syscall on the same flag,
+    # and forcing it "linux" off-Linux would dial an arbitrary syscall number.
+
+    @mock.patch("sys.platform", "linux")
     def test_landlock_plan_keeps_bind_ports_without_proxy(self):
         plan = MOD.landlock_plan(
             {"security": {"allow_bind_ports": [3000]}},
@@ -110,16 +119,26 @@ class TestRecordHonesty(unittest.TestCase):
         self.assertTrue(plan["restrict_bind"])
         self.assertFalse(plan["restrict_connect"])  # connect stays open
 
+    @mock.patch("sys.platform", "linux")
     def test_landlock_plan_normal_open_has_no_net_rules(self):
         plan = MOD.landlock_plan({"security": {}}, "normal", unshare_net=False, proxy_port=None)
         self.assertFalse(plan["restrict_connect"])
         self.assertFalse(plan["restrict_bind"])
 
+    @mock.patch("sys.platform", "linux")
     def test_landlock_plan_paranoid_denies_bind_allows_bridge(self):
         plan = MOD.landlock_plan({"security": {}}, "paranoid", unshare_net=True, proxy_port=None)
         self.assertEqual(plan["connect_ports"], [MOD.PARANOID_BRIDGE_PORT])
         self.assertTrue(plan["restrict_connect"] and plan["restrict_bind"])
         self.assertEqual(plan["bind_ports"], [])  # deny all bind
+
+    @mock.patch("sys.platform", "darwin")
+    def test_landlock_plan_is_none_off_linux(self):
+        """The guard the three tests above patch away is itself load-bearing:
+        no Landlock shim may be planned on a non-Linux host."""
+        self.assertIsNone(
+            MOD.landlock_plan({"security": {}}, "paranoid", unshare_net=True, proxy_port=None)
+        )
 
     def test_record_carries_experimental_override(self):
         rec = MOD.build_policy_record(


### PR DESCRIPTION
Closes #242.

## What changed

`landlock_plan()` returns `None` when `sys.platform != "linux"` — correct runtime behaviour — but the three plan-construction tests in `scripts/tests/test_policy_record.py` index straight into the result, so they raise `TypeError: 'NoneType' object is not subscriptable` on a macOS dev host while the rest of the file is perfectly cross-platform.

This pins `sys.platform` to `"linux"` on exactly those three tests via `mock.patch`.

I chose mocking over marking them Linux-only (the issue offers both) because the plan is pure dict arithmetic with no syscalls — so mocking exercises the real semantics from any host, whereas a skip would mean macOS/non-Linux CI never covers that logic at all.

**The scoping is deliberate, not incidental.** `probe_landlock_abi()` gates a real `ctypes` syscall (`__NR_landlock_create_ruleset` = 444) on the same `sys.platform` flag, and `build_policy_record()` calls it. A class-wide patch would therefore make a non-Linux host dial syscall 444 on Darwin, where that number means something else entirely. The patch stays on the three plan tests, which never touch the probe.

Also adds `test_landlock_plan_is_none_off_linux`, so the guard the other three patch away is itself covered — otherwise this change would silently remove the only assertion that no Landlock shim gets planned off-Linux.

## How to test

On Linux:

```bash
python3 scripts/tests/test_policy_record.py   # Ran 14 tests — OK
```

To verify the non-Linux path without a Mac, pin the platform before the module loads:

```python
# as_darwin.py
import runpy, sys
sys.platform = "darwin"
sys.argv = [sys.argv[1], *sys.argv[2:]]
runpy.run_path(sys.argv[0], run_name="__main__")
```

```bash
python3 as_darwin.py scripts/tests/test_policy_record.py
```

| | before | after |
|---|---|---|
| Linux | Ran 13 — OK | Ran 14 — OK |
| simulated macOS | Ran 13 — **FAILED (errors=3)** | Ran 14 — OK |

The "before" column reproduces the issue report exactly.

## Backward compatibility

Test-only change; no runtime code touched. `ruff check` on the file reports the same 4 pre-existing findings before and after (EXE001, I001, C408, SIM117) — left alone to keep the PR focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)