### PR TITLE
feat(sandbox): make the snapshot store addressable across projects (#23, #24)

### DIFF
--- a/docs/documentation/sandbox/cli-reference.md
+++ b/docs/documentation/sandbox/cli-reference.md
@@ -127,9 +127,12 @@ Create a filesystem snapshot of the project directory and/or the agent config di
 
 ```
 agent-sandbox snapshot-list [-a AGENT] [-p DIR] [--config-only | --project-only]
+                            [--all]
 ```
 
 List available snapshots grouped by type (project/config) with timestamps and disk usage.
+
+By default only the current directory's project is shown. `--all` lists every project and agent in the store, labelled by project path, with a running disk-usage total — useful when you work across several repositories and want to see where the space went.
 
 | Flag | Default | Description |
 |------|---------|-------------|
@@ -137,6 +140,28 @@ List available snapshots grouped by type (project/config) with timestamps and di
 | `-p`, `--project` | `.` (cwd) | Project directory |
 | `--config-only` | off | Show only config snapshots |
 | `--project-only` | off | Show only project snapshots |
+| `--all`, `--all-projects` | off | List every project and agent, not just the current directory |
+
+```
+$ agent-sandbox snapshot-list --all --project-only
+Project snapshots (all projects):
+
+  /home/u/alpha *
+    hash: f0b4f623dc47
+    20260731T094810  14 B
+
+  /home/u/beta
+    hash: 29cf69c51318
+    20260731T094810  13 B
+
+  /home/u/deleted  (missing — project moved/deleted)
+    hash: 0985dd0c546f
+    20260731T094810  13 B
+
+  total: 40 B
+```
+
+`*` marks the current directory's project. Snapshot directories are namespaced by a one-way hash of the project path, so each one also records the path it came from; directories created before that record existed are listed by hash as `(unknown project — no origin recorded)` and remain fully listable and prunable.
 
 ---
 
@@ -183,9 +208,12 @@ Interactive restore from a snapshot. Presents each changed file for per-file acc
 ```
 agent-sandbox snapshot-prune [-a AGENT] [-p DIR]
                              [--config-only] [--project-only] [--all]
+                             [--all-projects]
 ```
 
 Remove old snapshots beyond the configured maximum count (`max_project_snapshots`, `max_config_snapshots`).
+
+By default pruning is scoped to the current directory's project, so snapshots belonging to other projects — and to projects you have since moved or deleted — are never reclaimed. `--all-projects` prunes every project and agent in the store, applying the same per-project maximum to each.
 
 | Flag | Default | Description |
 |------|---------|-------------|
@@ -193,7 +221,17 @@ Remove old snapshots beyond the configured maximum count (`max_project_snapshots
 | `-p`, `--project` | `.` (cwd) | Project directory |
 | `--config-only` | off | Prune only config snapshots |
 | `--project-only` | off | Prune only project snapshots |
-| `--all` | off | Prune both project and config snapshots |
+| `--all` | off | Prune both project and config snapshots (this is already the default) |
+| `--all-projects` | off | Prune every project and agent, not just the current directory |
+
+> `--all` and `--all-projects` are different axes: `--all` selects *which kinds* of snapshot to prune (project vs config), `--all-projects` selects *whose* (current directory vs the whole store).
+
+```
+$ agent-sandbox snapshot-prune --all-projects --project-only
+  /home/u/beta: removed 4
+  /home/u/deleted  (missing — project moved/deleted): removed 4
+Project snapshots (all 4 project(s)): removed 12, max=3 each
+```
 
 ---
 

--- a/docs/documentation/sandbox/security-model.md
+++ b/docs/documentation/sandbox/security-model.md
@@ -197,7 +197,7 @@ Static variables can also be set via `[env.extra]` for every run regardless of p
 | **Tmpfs home is writable** | The `$HOME` tmpfs overlay is writable (that is how tmpfs works). The agent can create temporary files like `~/temp.txt`, but they are ephemeral and vanish when the sandbox exits. They never touch your real home directory |
 | **Credential proxy and HTTPS** | The proxy rewrites `*_BASE_URL` to `http://localhost:PORT`. All major AI SDKs support base URL overrides, so this is transparent. Custom HTTP clients that ignore `*_BASE_URL` env vars will not benefit from the proxy |
 | **Learn mode accuracy** | `strace` captures actual I/O but may miss paths checked with `access()` or `stat()` without opening. The learn sandbox is permissive, so the agent may access paths blocked in the real sandbox. Use the report as guidance, not as an exhaustive spec |
-| **Snapshot disk usage** | Snapshots use hardlinks for deduplication but still consume disk for changed files. Monitor with `agent-sandbox snapshot-list` and configure `max_project_snapshots` / `max_config_snapshots` |
+| **Snapshot disk usage** | Snapshots use hardlinks for deduplication but still consume disk for changed files. Monitor with `agent-sandbox snapshot-list --all`, reclaim across every project with `agent-sandbox snapshot-prune --all-projects`, and configure `max_project_snapshots` / `max_config_snapshots` |
 
 ---
 

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -201,7 +201,7 @@ Lists (e.g. `extra_rw`, `allow_domains`) are **appended**, not replaced, so proj
 
 9. **Learn mode accuracy**: The `learn` command uses `strace` to trace syscalls, which captures actual I/O but may miss paths that are checked with `access()` or `stat()` without opening. It also runs in a permissive sandbox, so the agent may access paths that would be blocked in the real sandbox. Use the report as guidance, not as an exhaustive specification.
 
-10. **Snapshot disk usage**: While snapshots use hardlinks for deduplication, they still consume disk space for changed files. Monitor usage with `agent-sandbox snapshot-list` and configure `max_project_snapshots` / `max_config_snapshots` to limit growth.
+10. **Snapshot disk usage**: While snapshots use hardlinks for deduplication, they still consume disk space for changed files. Monitor usage with `agent-sandbox snapshot-list --all` (every project, not just the current directory) and configure `max_project_snapshots` / `max_config_snapshots` to limit growth. Because the per-project maximum is only applied to the project you run from, use `agent-sandbox snapshot-prune --all-projects` to reclaim space across the whole store, including projects you have moved or deleted.
 
 ## Troubleshooting
 

--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -5768,6 +5768,66 @@ def get_project_hash(project_dir: Path) -> str:
     return hashlib.sha256(canonical.encode()).hexdigest()[:12]
 
 
+# Sidecar naming the project a hashed snapshot dir came from. The hash is
+# one-way, so without it the store can only ever be addressed from inside the
+# originating directory — you cannot list or reclaim another project's
+# snapshots, or even discover that they exist (#23, #24).
+SNAPSHOT_ORIGIN_FILE = ".origin"
+
+
+def write_snapshot_origin(snapshot_base_dir: Path, project_dir: Path) -> None:
+    """Record which project a hashed snapshot dir belongs to."""
+    try:
+        snapshot_base_dir.mkdir(parents=True, exist_ok=True)
+        (snapshot_base_dir / SNAPSHOT_ORIGIN_FILE).write_text(
+            f"{project_dir}\n",
+        )
+    except OSError:
+        pass  # a missing label must never fail the snapshot itself
+
+
+def read_snapshot_origin(snapshot_base_dir: Path) -> Path | None:
+    """Project a hashed snapshot dir came from, or None if unlabelled.
+
+    Returns None for dirs created before the sidecar existed; they stay
+    listable and prunable by hash.
+    """
+    try:
+        raw = (
+            snapshot_base_dir / SNAPSHOT_ORIGIN_FILE
+        ).read_text().strip()
+    except OSError:
+        return None
+    return Path(raw) if raw else None
+
+
+def list_project_snapshot_bases() -> list[tuple[str, Path, Path | None]]:
+    """Every project in the snapshot store, not just the current directory.
+
+    Returns (hash, base_dir, origin_or_None) sorted by origin then hash.
+    """
+    root = SNAPSHOT_DIR / "projects"
+    if not root.is_dir():
+        return []
+
+    bases: list[tuple[str, Path, Path | None]] = []
+    for base in root.iterdir():
+        if base.is_dir():
+            bases.append((base.name, base, read_snapshot_origin(base)))
+
+    return sorted(bases, key=lambda b: (str(b[2] or "~"), b[0]))
+
+
+def list_config_snapshot_agents() -> list[tuple[str, Path]]:
+    """Every agent with config snapshots. Returns (agent_name, base_dir)."""
+    root = SNAPSHOT_DIR / "configs"
+    if not root.is_dir():
+        return []
+    return sorted(
+        (base.name, base) for base in root.iterdir() if base.is_dir()
+    )
+
+
 def create_snapshot(
     source_dir: Path,
     snapshot_base_dir: Path,
@@ -5982,6 +6042,7 @@ def _auto_snapshot(config: dict, project_dir: Path, agent_name: str) -> None:
             base = _get_project_snapshot_base(project_dir)
             link = _latest_snapshot(base)
             excludes = snap_conf["project_exclude"]
+            write_snapshot_origin(base, project_dir)
             try:
                 snap_path = create_snapshot(
                     project_dir, base,
@@ -6024,6 +6085,7 @@ def cmd_snapshot(args) -> None:
         link = _latest_snapshot(base)
         excludes = snap_conf["project_exclude"]
         print(f"Creating project snapshot: {project_dir}")
+        write_snapshot_origin(base, project_dir)
         snap_path = create_snapshot(
             project_dir, base, exclude=excludes, link_dest=link,
         )
@@ -6062,6 +6124,27 @@ def cmd_snapshot(args) -> None:
                 print(f"  pruned {removed} old snapshot(s)")
 
 
+def _print_snapshot_rows(snaps: list[tuple[str, Path, int]]) -> None:
+    """Render one group's snapshots, or '(none)'."""
+    if not snaps:
+        print("  (none)")
+        return
+    for ts, _path, sz in snaps:
+        print(f"  {ts}  {human_size(sz)}")
+
+
+def _project_label(phash: str, origin: Path | None) -> str:
+    """Human name for a hashed project dir.
+
+    Unlabelled dirs predate the origin sidecar; orphaned ones outlived the
+    project they snapshotted. Both stay addressable by hash.
+    """
+    if origin is None:
+        return f"[{phash}] (unknown project — no origin recorded)"
+    suffix = "" if origin.is_dir() else "  (missing — project moved/deleted)"
+    return f"{origin}{suffix}"
+
+
 def cmd_snapshot_list(args) -> None:
     """List snapshots with timestamps and disk usage."""
     config, _ = load_config()
@@ -6070,37 +6153,60 @@ def cmd_snapshot_list(args) -> None:
 
     project_only = getattr(args, "project_only", False)
     config_only = getattr(args, "config", False)
+    show_all = getattr(args, "all_projects", False)
     show_project = not config_only
     show_config = not project_only
 
-    if show_project:
+    if show_project and show_all:
+        bases = list_project_snapshot_bases()
+        total = 0
+        print("Project snapshots (all projects):")
+        if not bases:
+            print("  (none)")
+        for phash, base, origin in bases:
+            snaps = list_snapshots(base)
+            if not snaps:
+                continue  # a bare origin sidecar is not worth a heading
+            total += sum(sz for _ts, _p, sz in snaps)
+            here = " *" if origin and origin == project_dir else ""
+            print(f"\n  {_project_label(phash, origin)}{here}")
+            print(f"    hash: {phash}")
+            for ts, _path, sz in snaps:
+                print(f"    {ts}  {human_size(sz)}")
+        print(f"\n  total: {human_size(total)}")
+        print()
+    elif show_project:
         base = _get_project_snapshot_base(project_dir)
         snaps = list_snapshots(base)
         print(f"Project snapshots ({project_dir}):")
         if snaps:
             phash = get_project_hash(project_dir)
             print(f"  hash: {phash}")
-            for ts, _path, sz in snaps:
-                print(f"  {ts}  {human_size(sz)}")
-        else:
-            print("  (none)")
+        _print_snapshot_rows(snaps)
         print()
 
-    if show_config:
+    if show_config and show_all:
+        agents = list_config_snapshot_agents()
+        print("Config snapshots (all agents):")
+        if not agents:
+            print("  (none)")
+        for name, base in agents:
+            snaps = list_snapshots(base)
+            if not snaps:
+                continue
+            print(f"\n  [{name}]")
+            for ts, _path, sz in snaps:
+                print(f"    {ts}  {human_size(sz)}")
+    elif show_config:
         config_dir = _resolve_config_dir(config, agent_name)
         base = _get_config_snapshot_base(agent_name)
-        snaps = list_snapshots(base)
         label = (
             str(config_dir) if config_dir else "(not configured)"
         )
         print(
             f"Config snapshots [{agent_name}] ({label}):",
         )
-        if snaps:
-            for ts, _path, sz in snaps:
-                print(f"  {ts}  {human_size(sz)}")
-        else:
-            print("  (none)")
+        _print_snapshot_rows(list_snapshots(base))
 
 
 def cmd_snapshot_diff(args) -> None:
@@ -6358,7 +6464,23 @@ def cmd_snapshot_prune(args) -> None:
         do_project = True
         do_config = True
 
-    if do_project:
+    if do_project and getattr(args, "all_projects", False):
+        # Pruning has always been scoped to the cwd project's hash, so every
+        # other project — and every dir orphaned by a moved or deleted
+        # project — grew without bound and could not be reclaimed at all (#24).
+        max_count = snap_conf["max_project_snapshots"]
+        bases = list_project_snapshot_bases()
+        total = 0
+        for phash, base, origin in bases:
+            removed = prune_snapshots(base, max_count)
+            total += removed
+            if removed:
+                print(f"  {_project_label(phash, origin)}: removed {removed}")
+        print(
+            f"Project snapshots (all {len(bases)} project(s)): "
+            f"removed {total}, max={max_count} each",
+        )
+    elif do_project:
         base = _get_project_snapshot_base(project_dir)
         max_count = snap_conf["max_project_snapshots"]
         removed = prune_snapshots(base, max_count)
@@ -6367,7 +6489,20 @@ def cmd_snapshot_prune(args) -> None:
             f"max={max_count}",
         )
 
-    if do_config:
+    if do_config and getattr(args, "all_projects", False):
+        max_count = snap_conf["max_config_snapshots"]
+        agents = list_config_snapshot_agents()
+        total = 0
+        for name, base in agents:
+            removed = prune_snapshots(base, max_count)
+            total += removed
+            if removed:
+                print(f"  [{name}]: removed {removed}")
+        print(
+            f"Config snapshots (all {len(agents)} agent(s)): "
+            f"removed {total}, max={max_count} each",
+        )
+    elif do_config:
         base = _get_config_snapshot_base(agent_name)
         max_count = snap_conf["max_config_snapshots"]
         removed = prune_snapshots(base, max_count)
@@ -7549,6 +7684,12 @@ def main() -> None:
         action="store_true",
         help="Show only project snapshots",
     )
+    p_snl.add_argument(
+        "--all", "--all-projects", dest="all_projects",
+        action="store_true",
+        help="List snapshots from every project and agent, not just "
+             "the current directory (combines with the filters above)",
+    )
 
     # snapshot-diff
     p_snd = sub.add_parser(
@@ -7631,7 +7772,15 @@ def main() -> None:
     )
     p_snp.add_argument(
         "--all", dest="all_types", action="store_true",
-        help="Prune both project and config snapshots",
+        help="Prune both project and config snapshots (the default)",
+    )
+    # NOT spelled --all: that already means "both types" here, and
+    # repurposing it would silently change what an existing command does.
+    p_snp.add_argument(
+        "--all-projects", dest="all_projects", action="store_true",
+        help="Prune every project and agent in the store, not just the "
+             "current directory — the only way to reclaim snapshots left "
+             "behind by projects you have moved or deleted",
     )
 
     # learn

--- a/scripts/tests/test_snapshot_store.py
+++ b/scripts/tests/test_snapshot_store.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Cross-project addressability of the snapshot store (#23, #24).
+
+Snapshots live under ``snapshots/projects/<sha256(path)[:12]>/``. That hash is
+one-way, so before the origin sidecar the store could only ever be addressed
+from inside the originating directory: ``snapshot-list`` could not name another
+project (#23) and ``snapshot-prune`` could not reclaim one (#24) — including
+dirs orphaned by a project that was moved or deleted.
+
+Run with:
+    python3 scripts/tests/test_snapshot_store.py
+"""
+
+import importlib.machinery
+import importlib.util
+import pathlib
+import tempfile
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+
+
+def load_agent_sandbox():
+    """Import the no-extension ``sandbox/agent-sandbox`` script as a module."""
+    path = REPO_ROOT / "sandbox" / "agent-sandbox"
+    loader = importlib.machinery.SourceFileLoader("agent_sandbox_snapshot_test", str(path))
+    spec = importlib.util.spec_from_loader("agent_sandbox_snapshot_test", loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+MOD = load_agent_sandbox()
+
+TIMESTAMPS = (
+    "20260101T100000", "20260102T100000", "20260103T100000",
+    "20260104T100000", "20260105T100000", "20260106T100000",
+)
+
+
+class SnapshotStoreTestCase(unittest.TestCase):
+    """Redirects SNAPSHOT_DIR at a temp store for the duration of a test."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.store = pathlib.Path(self._tmp.name)
+        self._real_snapshot_dir = MOD.SNAPSHOT_DIR
+        MOD.SNAPSHOT_DIR = self.store
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        MOD.SNAPSHOT_DIR = self._real_snapshot_dir
+        self._tmp.cleanup()
+
+    def make_project(self, phash, origin=None, count=None):
+        """Create a hashed project dir with `count` snapshots in the store."""
+        base = self.store / "projects" / phash
+        for ts in TIMESTAMPS[: len(TIMESTAMPS) if count is None else count]:
+            (base / ts).mkdir(parents=True)
+            (base / ts / "f").write_text("x")
+        if origin is not None:
+            MOD.write_snapshot_origin(base, pathlib.Path(origin))
+        return base
+
+
+class TestOriginSidecar(SnapshotStoreTestCase):
+    def test_roundtrip(self):
+        base = self.make_project("aaaaaaaaaaaa", origin="/home/u/alpha")
+        self.assertEqual(MOD.read_snapshot_origin(base), pathlib.Path("/home/u/alpha"))
+
+    def test_unlabelled_dir_reads_as_none(self):
+        """Dirs predating the sidecar must stay readable, not raise."""
+        base = self.make_project("bbbbbbbbbbbb")
+        self.assertIsNone(MOD.read_snapshot_origin(base))
+
+    def test_sidecar_is_not_mistaken_for_a_snapshot(self):
+        """list_snapshots() filters on timestamp-shaped dirs; .origin is a file."""
+        base = self.make_project("cccccccccccc", origin="/home/u/alpha", count=2)
+        self.assertEqual(len(MOD.list_snapshots(base)), 2)
+
+    def test_write_never_raises_on_unwritable_store(self):
+        """A missing label must never fail the snapshot it labels."""
+        base = self.store / "projects" / "dddddddddddd"
+        base.mkdir(parents=True)
+        base.chmod(0o500)
+        self.addCleanup(base.chmod, 0o700)
+        MOD.write_snapshot_origin(base, pathlib.Path("/home/u/alpha"))  # must not raise
+        self.assertIsNone(MOD.read_snapshot_origin(base))
+
+
+class TestListProjectBases(SnapshotStoreTestCase):
+    def test_empty_store(self):
+        self.assertEqual(MOD.list_project_snapshot_bases(), [])
+
+    def test_lists_every_project_with_its_origin(self):
+        self.make_project("f0b4f623dc47", origin="/home/u/alpha")
+        self.make_project("29cf69c51318", origin="/home/u/beta")
+        self.make_project("deadbeef1234")  # legacy, unlabelled
+
+        found = MOD.list_project_snapshot_bases()
+        self.assertEqual(len(found), 3)
+        by_hash = {h: origin for h, _base, origin in found}
+        self.assertEqual(by_hash["f0b4f623dc47"], pathlib.Path("/home/u/alpha"))
+        self.assertEqual(by_hash["29cf69c51318"], pathlib.Path("/home/u/beta"))
+        self.assertIsNone(by_hash["deadbeef1234"])
+
+    def test_label_flags_orphans_and_unlabelled(self):
+        """#24: a dir whose project is gone is exactly what needs reclaiming,
+        so the listing has to say so rather than print a bare hash."""
+        gone = MOD._project_label("0985dd0c546f", pathlib.Path("/home/u/deleted"))
+        self.assertIn("missing", gone)
+
+        unlabelled = MOD._project_label("deadbeef1234", None)
+        self.assertIn("deadbeef1234", unlabelled)
+        self.assertIn("unknown project", unlabelled)
+
+        live = MOD._project_label("f0b4f623dc47", pathlib.Path(self.store))
+        self.assertNotIn("missing", live)
+        self.assertIn(str(self.store), live)
+
+
+class TestPruneAcrossProjects(SnapshotStoreTestCase):
+    def snap_count(self, phash):
+        return len(MOD.list_snapshots(self.store / "projects" / phash))
+
+    def test_prune_reaches_every_project_including_orphans(self):
+        """The #24 defect: prune only ever touched the cwd project's hash."""
+        self.make_project("f0b4f623dc47", origin="/home/u/alpha")
+        self.make_project("29cf69c51318", origin="/home/u/beta")
+        self.make_project("0985dd0c546f", origin="/home/u/deleted")
+        self.make_project("deadbeef1234")
+
+        total = sum(
+            MOD.prune_snapshots(base, 3)
+            for _h, base, _o in MOD.list_project_snapshot_bases()
+        )
+
+        self.assertEqual(total, 4 * (len(TIMESTAMPS) - 3))
+        for phash in ("f0b4f623dc47", "29cf69c51318", "0985dd0c546f", "deadbeef1234"):
+            self.assertEqual(self.snap_count(phash), 3, phash)
+
+    def test_prune_is_idempotent(self):
+        self.make_project("f0b4f623dc47", origin="/home/u/alpha")
+        base = self.store / "projects" / "f0b4f623dc47"
+        self.assertEqual(MOD.prune_snapshots(base, 3), len(TIMESTAMPS) - 3)
+        self.assertEqual(MOD.prune_snapshots(base, 3), 0)
+        self.assertEqual(self.snap_count("f0b4f623dc47"), 3)
+
+    def test_prune_keeps_the_newest(self):
+        self.make_project("f0b4f623dc47", origin="/home/u/alpha")
+        base = self.store / "projects" / "f0b4f623dc47"
+        MOD.prune_snapshots(base, 2)
+        kept = [ts for ts, _p, _sz in MOD.list_snapshots(base)]
+        self.assertEqual(kept, list(TIMESTAMPS[-2:]))
+
+
+class TestConfigSnapshotAgents(SnapshotStoreTestCase):
+    def test_empty_store(self):
+        self.assertEqual(MOD.list_config_snapshot_agents(), [])
+
+    def test_lists_every_agent(self):
+        for agent in ("claude", "codex", "gemini"):
+            (self.store / "configs" / agent / TIMESTAMPS[0]).mkdir(parents=True)
+        self.assertEqual(
+            [name for name, _base in MOD.list_config_snapshot_agents()],
+            ["claude", "codex", "gemini"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #23. Closes #24.

## The shared root cause

These two issues look unrelated but are the same defect seen from two sides.

Project snapshots live under `snapshots/projects/<sha256(project_path)[:12]>/`. That hash is **one-way**, and nothing anywhere recorded which project a given directory came from. So the store could only ever be addressed from *inside* the originating directory:

- **#23** — `snapshot-list` could not show another project. Worse, the issue asks for output "grouped or labeled by project name", and that was not implementable as things stood: the path had been hashed away, so the best possible output was a list of bare hashes.
- **#24** — `snapshot-prune` only ever applied `max_project_snapshots` to the cwd project's hash dir. Every *other* project, and every dir orphaned by a project that was moved or deleted, grew without bound with no way to reclaim it.

Fixing the listing without fixing the hash gets you a wall of hex; fixing prune without it gives you nothing to aim at. Hence one PR.

## A note on #24 as filed

I could not reproduce the literal report ("run `snapshot-prune`, project snapshots are not pruned"). On current `main` I built a synthetic store and ran all four flag combinations from inside and outside the project; every one pruned the cwd project correctly.

What *is* reproducible is the scoping gap above, which matches the title and is a real unbounded-growth bug. That is what this PR fixes. If the reporter was hitting something else, I'm happy to reopen with their `agent-sandbox snapshot-list --all` output — which, conveniently, this PR makes possible to ask for.

## What changed

Record the project path in a `.origin` sidecar when a project snapshot is created, then build both commands on it.

```
$ agent-sandbox snapshot-list --all --project-only
Project snapshots (all projects):

  /home/u/alpha *
    hash: f0b4f623dc47
    20260731T094810  14 B

  /home/u/beta
    hash: 29cf69c51318
    20260731T094810  13 B

  /home/u/deleted  (missing — project moved/deleted)
    hash: 0985dd0c546f
    20260731T094810  13 B

  [deadbeef1234] (unknown project — no origin recorded)
    hash: deadbeef1234
    20260101T120000  7 B

  total: 47 B
```

```
$ agent-sandbox snapshot-prune --all-projects --project-only
  /home/u/beta: removed 4
  /home/u/deleted  (missing — project moved/deleted): removed 4
  [deadbeef1234] (unknown project — no origin recorded): removed 4
Project snapshots (all 4 project(s)): removed 12, max=3 each
```

### Design decisions worth reviewing

**`--all-projects`, not `--all`, on prune.** `snapshot-prune --all` already exists and means "both project *and* config types". Repurposing it would silently change what an existing command does. The two flags are orthogonal axes and the docs now say so explicitly: `--all` picks *which kinds*, `--all-projects` picks *whose*. `snapshot-list` has no such clash, so it takes `--all` exactly as the issue requests (with `--all-projects` as an alias so the cross-cutting name works on both).

**Orphans are labelled, not hidden.** A directory whose project no longer exists is precisely the thing you want to reclaim, so it is surfaced as `(missing — project moved/deleted)` rather than filtered out.

**Pre-existing dirs keep working.** Snapshots taken before this change have no sidecar; they list and prune normally as `(unknown project — no origin recorded)`, and self-heal the next time that project is snapshotted. No migration step.

**The sidecar cannot break snapshots.** It is a file, so `list_snapshots()`'s "timestamp-shaped directory" filter ignores it (covered by a test). A failed write is swallowed — a missing *label* must never fail the *snapshot*.

## How to test

```bash
python3 scripts/tests/test_snapshot_store.py   # Ran 12 tests — OK
```

New tests cover the sidecar round-trip, unlabelled dirs, the sidecar not being mistaken for a snapshot, an unwritable store, prune reaching every project including orphans, prune idempotency, and prune keeping the newest.

Manual end-to-end, three projects with one deliberately deleted plus one legacy unlabelled dir:

```bash
for d in alpha beta gone; do agent-sandbox snapshot -p /tmp/multi/$d --project-only; done
rm -rf /tmp/multi/gone
agent-sandbox snapshot-list --all --project-only
agent-sandbox snapshot-prune --all-projects --project-only   # idempotent on re-run
```

## Backward compatibility

Default output and every existing flag are unchanged — verified across `snapshot-list`, `snapshot-list --project-only|--config-only`, `snapshot-prune`, `snapshot-prune --all|--project-only|--config-only`, plus the mutually-exclusive group still rejecting `--project-only --config-only`.

Full suite green (11/11 test files). `ruff check` on `sandbox/agent-sandbox` reports 76 findings before and after — no new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)