### PR TITLE
feat(sandbox): pass GH_ENTERPRISE_TOKEN through in permissive profiles

### DIFF
--- a/registry.d/claude.toml
+++ b/registry.d/claude.toml
@@ -42,7 +42,7 @@ credential_proxy = false
 block_git_push = true
 allow_domains = ["api.github.com", "github.com", "objects.githubusercontent.com"]
 home_ro_dirs = [".config/gh", ".ssh/known_hosts"]
-passthrough = ["GH_TOKEN", "GITHUB_TOKEN"]
+passthrough = ["GH_TOKEN", "GITHUB_TOKEN", "GH_ENTERPRISE_TOKEN"]
 
 [dashboard]
 status_pipe_name = "claude-status"

--- a/registry.d/codex.toml
+++ b/registry.d/codex.toml
@@ -39,7 +39,7 @@ credential_proxy = false
 block_git_push = true
 allow_domains = ["api.github.com", "github.com", "objects.githubusercontent.com"]
 home_ro_dirs = [".config/gh", ".cache", ".ssh/known_hosts"]
-passthrough = ["GH_TOKEN", "GITHUB_TOKEN"]
+passthrough = ["GH_TOKEN", "GITHUB_TOKEN", "GH_ENTERPRISE_TOKEN"]
 
 [dashboard]
 has_native_hooks = true

--- a/registry.d/gemini.toml
+++ b/registry.d/gemini.toml
@@ -40,7 +40,7 @@ credential_proxy = false
 block_git_push = true
 allow_domains = ["api.github.com", "github.com", "objects.githubusercontent.com"]
 home_ro_dirs = [".config/gh", ".cache", ".ssh/known_hosts"]
-passthrough = ["GH_TOKEN", "GITHUB_TOKEN"]
+passthrough = ["GH_TOKEN", "GITHUB_TOKEN", "GH_ENTERPRISE_TOKEN"]
 
 [dashboard]
 has_native_hooks = false

--- a/registry.d/opencode.toml
+++ b/registry.d/opencode.toml
@@ -43,7 +43,7 @@ credential_proxy = false
 block_git_push = true
 allow_domains = ["api.github.com", "github.com", "objects.githubusercontent.com"]
 home_ro_dirs = [".config/gh", ".cache", ".ssh/known_hosts"]
-passthrough = ["GH_TOKEN", "GITHUB_TOKEN"]
+passthrough = ["GH_TOKEN", "GITHUB_TOKEN", "GH_ENTERPRISE_TOKEN"]
 
 [dashboard]
 has_native_hooks = true

--- a/registry.d/pi.toml
+++ b/registry.d/pi.toml
@@ -43,7 +43,7 @@ credential_proxy = false
 block_git_push = true
 allow_domains = ["api.github.com", "github.com", "objects.githubusercontent.com"]
 home_ro_dirs = [".config/gh", ".cache", ".ssh/known_hosts"]
-passthrough = ["GH_TOKEN", "GITHUB_TOKEN"]
+passthrough = ["GH_TOKEN", "GITHUB_TOKEN", "GH_ENTERPRISE_TOKEN"]
 
 [dashboard]
 has_native_hooks = true

--- a/sandbox/profiles/claude-permissive.toml
+++ b/sandbox/profiles/claude-permissive.toml
@@ -37,7 +37,8 @@ home_ro_dirs = [".config/gh", ".ssh/known_hosts"]
 # GH_TOKEN / GITHUB_TOKEN being exported in their shell — the sandbox's
 # default --clearenv would otherwise wipe them. Append-merged with the
 # user's [env].passthrough.
-passthrough = ["GH_TOKEN", "GITHUB_TOKEN"]
+# GH_ENTERPRISE_TOKEN serves gh CLI users on GitHub Enterprise hosts.
+passthrough = ["GH_TOKEN", "GITHUB_TOKEN", "GH_ENTERPRISE_TOKEN"]
 
 [security]
 credential_proxy = false

--- a/sandbox/profiles/codex-permissive.toml
+++ b/sandbox/profiles/codex-permissive.toml
@@ -7,7 +7,8 @@ home_ro_dirs = [".config/gh", ".cache", ".ssh/known_hosts"]
 
 [env]
 # Keyring-auth users rely on GH_TOKEN/GITHUB_TOKEN; --clearenv would wipe them.
-passthrough = ["GH_TOKEN", "GITHUB_TOKEN"]
+# GH_ENTERPRISE_TOKEN serves gh CLI users on GitHub Enterprise hosts.
+passthrough = ["GH_TOKEN", "GITHUB_TOKEN", "GH_ENTERPRISE_TOKEN"]
 
 [security]
 # credential_proxy off in permissive: the agent reads API keys directly

--- a/sandbox/profiles/gemini-permissive.toml
+++ b/sandbox/profiles/gemini-permissive.toml
@@ -7,7 +7,8 @@ home_ro_dirs = [".config/gh", ".cache", ".ssh/known_hosts"]
 
 [env]
 # Keyring-auth users rely on GH_TOKEN/GITHUB_TOKEN; --clearenv would wipe them.
-passthrough = ["GH_TOKEN", "GITHUB_TOKEN"]
+# GH_ENTERPRISE_TOKEN serves gh CLI users on GitHub Enterprise hosts.
+passthrough = ["GH_TOKEN", "GITHUB_TOKEN", "GH_ENTERPRISE_TOKEN"]
 
 [security]
 # credential_proxy off in permissive: the agent reads API keys directly

--- a/sandbox/profiles/opencode-permissive.toml
+++ b/sandbox/profiles/opencode-permissive.toml
@@ -7,7 +7,8 @@ home_ro_dirs = [".config/gh", ".cache", ".ssh/known_hosts"]
 
 [env]
 # Keyring-auth users rely on GH_TOKEN/GITHUB_TOKEN; --clearenv would wipe them.
-passthrough = ["GH_TOKEN", "GITHUB_TOKEN"]
+# GH_ENTERPRISE_TOKEN serves gh CLI users on GitHub Enterprise hosts.
+passthrough = ["GH_TOKEN", "GITHUB_TOKEN", "GH_ENTERPRISE_TOKEN"]
 
 [security]
 # credential_proxy off in permissive: the agent reads API keys directly

--- a/sandbox/profiles/pi-permissive.toml
+++ b/sandbox/profiles/pi-permissive.toml
@@ -7,7 +7,8 @@ home_ro_dirs = [".config/gh", ".cache", ".ssh/known_hosts"]
 
 [env]
 # Keyring-auth users rely on GH_TOKEN/GITHUB_TOKEN; --clearenv would wipe them.
-passthrough = ["GH_TOKEN", "GITHUB_TOKEN"]
+# GH_ENTERPRISE_TOKEN serves gh CLI users on GitHub Enterprise hosts.
+passthrough = ["GH_TOKEN", "GITHUB_TOKEN", "GH_ENTERPRISE_TOKEN"]
 
 [security]
 # credential_proxy off in permissive: the agent reads API keys directly


### PR DESCRIPTION
Closes #282

## What

Adds `GH_ENTERPRISE_TOKEN` to the `[env] passthrough` of all five shipped permissive profile fragments (`claude`, `codex`, `gemini`, `opencode`, `pi`) and regenerates `registry.d/` (`[sandbox.levels.permissive].passthrough` for each agent).

## Why

Permissive exists so the `gh` CLI works inside the sandbox, and it already passes `GH_TOKEN` / `GITHUB_TOKEN` because `--clearenv` would wipe them. GitHub **Enterprise** users authenticate via `GH_ENTERPRISE_TOKEN` — same mechanism, same trust posture, currently wiped. Hand-editing the installed profile isn't durable: fragments are shipped-owned and overwritten on every install/update (#199), which is exactly how this gap surfaced on a live setup.

## Notes

- Scripts suite green (101 passed), including registry sync (`test_registry_sync.py` regen parity).
- Composes cleanly with #279 (Bob): `bob-permissive.toml` there already ships the token, so after both merge all permissive fragments are consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)