### PR TITLE
feat(sandbox): host-open bridge — xdg-open shim + mount the sandbox bin dir

### DIFF
--- a/sandbox/CHEATSHEET.md
+++ b/sandbox/CHEATSHEET.md
@@ -22,6 +22,7 @@ Quick reference for what the sandbox blocks and what it lets through.
 | `~/.config/gcloud/` | Read-only | Vertex AI credentials |
 | Version managers (`.nvm`, `.rustup`, `.pyenv`, `.sdkman`) | Read-only | Auto-detected from PATH |
 | Toolchain caches (`.cargo/registry`, `.npm/`, `.uv-cache/`, `.go/`) | Read-Write | Persistent across sessions |
+| `~/.agent-sandbox/bin/` | Read-only | Sandbox helpers, first in PATH: git-push blocker + `xdg-open` host-open bridge (#284) — inside Zellij, URL opens are forwarded to the host browser via `zellij run` |
 | `/tmp` | Read-Write | Fresh tmpfs, isolated from host |
 | Home directory (`~/`) | Tmpfs | Ephemeral overlay, hides everything not explicitly mounted |
 

--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -2925,6 +2925,46 @@ def ensure_git_wrapper() -> Path:
     return bin_dir
 
 
+# ---------------------------------------------------------------------------
+# Host-open bridge: xdg-open shim (#284)
+# ---------------------------------------------------------------------------
+
+XDG_OPEN_SHIM = """\
+#!/bin/bash
+# agent-sandbox: host-open bridge for xdg-open (#284)
+#
+# Inside the bwrap sandbox the home is hidden and /tmp is private, so the
+# stock xdg-open cannot see ~/.config/mimeapps.list (wrong browser picked)
+# and X11 browsers cannot start (no /tmp/.X11-unix). Instead of launching
+# a blank-profile browser inside the sandbox, forward the open to the
+# HOST: the Zellij socket is already mounted for the status pipes, and
+# `zellij run` executes commands host-side -- the URL lands in the user's
+# real default browser with their real profile. The helper pane closes
+# itself as soon as the host xdg-open returns.
+#
+# Outside Zellij, fall back to the stock xdg-open inside the sandbox.
+if [ -n "${ZELLIJ:-}" ] && command -v zellij >/dev/null 2>&1; then
+    exec zellij run --name "xdg-open" --close-on-exit --floating -- xdg-open "$@"
+fi
+exec /usr/bin/xdg-open "$@"
+"""
+
+
+def ensure_xdg_open_shim() -> Path:
+    """Create (or verify) the host-open xdg-open shim (#284)."""
+    bin_dir = SANDBOX_DIR / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    shim = bin_dir / "xdg-open"
+    try:
+        if shim.exists() and shim.read_text() == XDG_OPEN_SHIM:
+            return bin_dir
+    except OSError:
+        pass
+    shim.write_text(XDG_OPEN_SHIM)
+    shim.chmod(0o755)
+    return bin_dir
+
+
 def prepare_seatbelt_git_blocking(config: dict) -> dict[str, str]:
     """Set up git push blocking for the seatbelt backend.
 
@@ -3048,6 +3088,14 @@ def build_bwrap_cmd(config: dict, project_dir: Path,
 
     # --- 3. Hide entire $HOME ------------------------------------------------
     cmd += ["--tmpfs", home]
+
+    # --- 3b. Sandbox helper bin (git wrapper + xdg-open shim, #284) ----------
+    # SANDBOX_DIR/bin is first in the sandbox PATH (see PATH construction
+    # below) but was historically never mounted by the bwrap backend, so the
+    # git wrapper and the host-open xdg-open shim living there were inert.
+    sandbox_bin = SANDBOX_DIR / "bin"
+    if sandbox_bin.is_dir():
+        cmd += ["--ro-bind", str(sandbox_bin), str(sandbox_bin)]
 
     # --- 4. Read-only dirs (including user projects) -------------------------
     for d in sandbox.get("ro_dirs", []):
@@ -3515,9 +3563,11 @@ def cmd_init(args) -> None:
         shutil.copy2(agents_defaults_src, agents_defaults_dst)
         print(f"  agents-defaults {agents_defaults_dst}")
 
-    # Git-push wrapper
+    # Git-push wrapper + host-open xdg-open shim (#284)
     ensure_git_wrapper()
     print(f"  git wrapper   {SANDBOX_DIR / 'bin' / 'git'}")
+    ensure_xdg_open_shim()
+    print(f"  xdg-open shim {SANDBOX_DIR / 'bin' / 'xdg-open'}")
 
     # Auto-detected PATH dirs
     home_dirs = detect_home_path_dirs()
@@ -4197,9 +4247,11 @@ def cmd_run(args, agent_extra: list[str]) -> None:
     agent_name = args.agent
     agent_cfg = resolve_agent_config(config, agent_name)
 
-    # Ensure git wrapper exists (only needed for bwrap backend)
-    if backend == "agent-sandbox" and config.get("security", {}).get("block_git_push", True):
-        ensure_git_wrapper()
+    # Ensure git wrapper + xdg-open shim exist (only needed for bwrap backend)
+    if backend == "agent-sandbox":
+        ensure_xdg_open_shim()
+        if config.get("security", {}).get("block_git_push", True):
+            ensure_git_wrapper()
 
     # Logging
     log_conf = config.get("logging", {})
@@ -7285,7 +7337,8 @@ def cmd_learn(args) -> None:
     agent_name = args.agent
     agent_cfg = resolve_agent_config(config, agent_name)
 
-    # Ensure git wrapper exists
+    # Ensure git wrapper + xdg-open shim exist
+    ensure_xdg_open_shim()
     if config.get("security", {}).get("block_git_push", True):
         ensure_git_wrapper()
 

--- a/scripts/tests/test_xdg_open_shim.py
+++ b/scripts/tests/test_xdg_open_shim.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Host-open bridge (#284) — xdg-open shim + sandbox bin dir mount.
+
+Inside bwrap the home is hidden and /tmp is private: the stock xdg-open
+can't see ~/.config/mimeapps.list and X11 browsers can't start. The shim
+forwards URL opens to the host through `zellij run` (the Zellij socket is
+already mounted for the status pipes) and falls back to the stock
+xdg-open outside Zellij. `ensure_xdg_open_shim()` writes it into
+SANDBOX_DIR/bin — which the bwrap builder now actually mounts.
+
+Run with:
+    python3 -m pytest scripts/tests/test_xdg_open_shim.py
+"""
+
+import importlib.machinery
+import importlib.util
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def load_module(rel_path: str, name: str):
+    path = REPO_ROOT / rel_path
+    spec = importlib.util.spec_from_loader(
+        name, importlib.machinery.SourceFileLoader(name, str(path))
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestXdgOpenShim(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.sandbox = load_module("sandbox/agent-sandbox", "agent_sandbox_shim_test")
+
+    def test_shim_is_valid_bash_with_zellij_bridge_and_fallback(self):
+        shim = self.sandbox.XDG_OPEN_SHIM
+        # Host bridge goes through zellij run; fallback execs the real binary
+        # (absolute path — the shim itself shadows `xdg-open` on PATH).
+        self.assertIn('zellij run', shim)
+        self.assertIn('--close-on-exit', shim)
+        self.assertIn('exec /usr/bin/xdg-open "$@"', shim)
+        with tempfile.NamedTemporaryFile("w", suffix=".sh") as fh:
+            fh.write(shim)
+            fh.flush()
+            proc = subprocess.run(["bash", "-n", fh.name], capture_output=True)
+            self.assertEqual(proc.returncode, 0, proc.stderr.decode())
+
+    def test_ensure_writes_executable_shim_and_is_idempotent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = self.sandbox.SANDBOX_DIR
+            self.sandbox.SANDBOX_DIR = Path(tmp)
+            try:
+                bin_dir = self.sandbox.ensure_xdg_open_shim()
+                shim = bin_dir / "xdg-open"
+                self.assertTrue(shim.exists())
+                self.assertTrue(shim.stat().st_mode & 0o111, "shim not executable")
+                self.assertEqual(shim.read_text(), self.sandbox.XDG_OPEN_SHIM)
+                mtime = shim.stat().st_mtime_ns
+                # Second call must not rewrite an up-to-date shim.
+                self.sandbox.ensure_xdg_open_shim()
+                self.assertEqual(shim.stat().st_mtime_ns, mtime)
+                # A stale/modified shim gets refreshed to the shipped content.
+                shim.write_text("#!/bin/bash\necho stale\n")
+                self.sandbox.ensure_xdg_open_shim()
+                self.assertEqual(shim.read_text(), self.sandbox.XDG_OPEN_SHIM)
+            finally:
+                self.sandbox.SANDBOX_DIR = orig
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #284

## What

Links opened by sandboxed agents now land in the **user's real default browser with their real profile**, via a host-open bridge:

- `ensure_xdg_open_shim()` writes an `xdg-open` shim into `~/.agent-sandbox/bin/` (same generated-wrapper pattern as the git-push blocker). Inside Zellij it execs `zellij run --name xdg-open --close-on-exit --floating -- xdg-open "$@"` — **`zellij run` executes host-side** through the Zellij socket the sandbox already mounts for the status pipes. Outside Zellij it falls back to the stock xdg-open (previous behavior).
- The bwrap builder now actually **ro-binds `SANDBOX_DIR/bin`**. The dir was already first in the sandbox PATH and populated by `ensure_git_wrapper()`, but the bwrap backend never mounted it — the wrappers living there were inert.

## Why

Diagnosed live (#284): inside bwrap the home is hidden and `/tmp` is private, so the stock xdg-open can't see `~/.config/mimeapps.list` (a fallback browser opens instead of the user's choice), X11 browsers can't start at all (no `/tmp/.X11-unix` — Chrome dies with "Missing X server" unless forced onto Wayland), and any browser that does start runs with a blank tmpfs profile. Mounting `mimeapps.list` alone makes it worse (Chrome gets picked via .desktop without Wayland flags and nothing opens). Forwarding the open to the host fixes browser choice, profile, and platform in one move, without widening the sandbox (no X11 socket, no extra home exposure).

## Behavior change

With the bin dir mounted, `git` inside bwrap now resolves to the push-blocking wrapper (explicit red "git push is blocked" message) instead of relying only on the sanitized-gitconfig `push.default = nothing` — defense in depth; verified that normal git operations are unaffected.

## Tests

- `scripts/tests/test_xdg_open_shim.py`: shim contract (zellij bridge + absolute-path fallback, `bash -n`), `ensure_xdg_open_shim` writes an executable shim, is idempotent (no rewrite when up to date) and refreshes stale content. Full scripts suite: **103 passed**.
- Verified live: sandboxed `xdg-open https://example.com` opens the URL in the host Chrome via a self-closing floating pane; `git --version` works and `git push` is blocked with the explicit message; dry-run shows the `--ro-bind` of the bin dir.

## Notes

- The related Serena popup from the same hidden-home root cause (#284) needs no code change: `config.toml.example` already ships `.serena` in `home_ro_dirs`; existing configs that predate that default just need the entry added.
- Composes with #279/#281/#283 (adjacent but distinct regions of the bwrap builder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)