### PR TITLE
docs: replace deprecated nono with Seatbelt across site and installers

### DIFF
--- a/docs/changelog/index.html
+++ b/docs/changelog/index.html
@@ -87,6 +87,93 @@
   <!-- Entries -->
   <section class="max-w-5xl mx-auto px-6 pb-20">
 
+    <!-- 2026-08-23 -->
+    <article id="2026-08-23" class="entry rounded-lg p-8 mb-8">
+      <header class="mb-6 pb-6 border-b border-border">
+        <div class="flex items-baseline gap-4 mb-2 flex-wrap">
+          <time class="font-mono text-sm text-muted" datetime="2026-08-23">2026-08-23</time>
+          <span class="tag tag-sandbox">sandbox</span>
+          <span class="tag tag-install">install</span>
+          <span class="tag tag-docs">docs</span>
+          <span class="tag tag-dashboard">dashboard</span>
+        </div>
+        <h2 class="text-2xl font-bold mb-2">Seatbelt backend, config v2, shell agents &amp; lince-lab</h2>
+        <p class="text-muted leading-relaxed">
+          macOS moves to the native <span class="font-mono text-accent">sandbox-exec</span> (Seatbelt)
+          backend; the external <span class="font-mono">nono</span> backend is deprecated.
+          Configuration converges on a single versioned policy file plus a shipped agent registry,
+          the dashboard gains shell agents, and a new <span class="font-mono text-accent">lince-lab</span>
+          module provides disposable lab VMs.
+        </p>
+      </header>
+
+      <div class="space-y-6">
+
+        <div>
+          <h3 class="font-semibold mb-2 flex items-center gap-2">
+            <span class="text-accent">&#x2192;</span> Seatbelt replaces nono on macOS
+          </h3>
+          <p class="text-sm text-muted leading-relaxed mb-2">
+            The sandbox now ships a native macOS backend built on
+            <span class="font-mono text-accent">sandbox-exec</span> (Seatbelt), which is part of the
+            operating system itself: no extra install, no external dependencies. The legacy
+            <span class="font-mono">nono</span> backend still works but is deprecated;
+            <code class="font-mono text-xs bg-surface px-1 rounded">agent-sandbox run --backend</code>
+            accepts <span class="font-mono text-accent">seatbelt</span>, and installers prefer Seatbelt
+            with a deprecation notice when falling back to nono. See the
+            <a href="https://github.com/RisorseArtificiali/lince/blob/main/docs/documentation/sandbox/migration-nono-to-seatbelt.md" class="text-accent hover:underline">migration guide</a>.
+          </p>
+        </div>
+
+        <div>
+          <h3 class="font-semibold mb-2 flex items-center gap-2">
+            <span class="text-accent">&#x2192;</span> Config v2: one policy file + agent registry
+          </h3>
+          <p class="text-sm text-muted leading-relaxed mb-2">
+            Configuration is converging on a single versioned policy file
+            (<span class="font-mono text-accent">~/.config/lince/lince.toml</span>) plus a shipped agent
+            registry. Get started with
+            <span class="font-mono text-accent">lince-config discover</span> and
+            <span class="font-mono text-accent">lince-config apply &lt;agent&gt;+&lt;level&gt;+&lt;provider&gt;</span>.
+            Existing installs keep working unchanged. See the
+            <a href="https://github.com/RisorseArtificiali/lince/blob/main/docs/migration-v2-users.md" class="text-accent hover:underline">user migration guide</a> and the
+            <a href="https://github.com/RisorseArtificiali/lince/blob/main/docs/migration-v2-developers.md" class="text-accent hover:underline">developer migration guide</a>.
+          </p>
+        </div>
+
+        <div>
+          <h3 class="font-semibold mb-2 flex items-center gap-2">
+            <span class="text-accent">&#x2192;</span> Shell agents in the dashboard
+          </h3>
+          <p class="text-sm text-muted leading-relaxed mb-2">
+            The registry now includes plain shells (<span class="font-mono text-accent">bash</span>,
+            <span class="font-mono text-accent">zsh</span>,
+            <span class="font-mono text-accent">fish</span>) as first-class "agents", so you can keep an
+            interactive shell pane next to your AI agents inside the same dashboard. The installer
+            pre-selects your host's default shell.
+          </p>
+        </div>
+
+        <div>
+          <h3 class="font-semibold mb-2 flex items-center gap-2">
+            <span class="text-accent">&#x2192;</span> lince-lab (experimental)
+          </h3>
+          <p class="text-sm text-muted leading-relaxed mb-2">
+            A new opt-in module that gives agents disposable Linux VMs (via Lima/KVM) instead of
+            sharing the host: stronger isolation for risky workloads, broker on the host, agents in
+            the lab. Linux-only in v1. See the
+            <a href="https://github.com/RisorseArtificiali/lince/tree/main/docs/documentation/lince-lab" class="text-accent hover:underline">lince-lab docs</a>.
+          </p>
+        </div>
+
+      </div>
+
+      <footer class="mt-8 pt-6 border-t border-border text-sm">
+        <a href="https://github.com/RisorseArtificiali/lince/commits/main?since=2026-05-06"
+           class="text-accent hover:underline">See all commits since May on GitHub &rarr;</a>
+      </footer>
+    </article>
+
     <!-- 2026-05-05 -->
     <article id="2026-05-05" class="entry rounded-lg p-8 mb-8">
       <header class="mb-6 pb-6 border-b border-border">

--- a/docs/index.html
+++ b/docs/index.html
@@ -137,7 +137,7 @@
         <div class="feature-card rounded-lg p-6">
           <div class="text-2xl mb-3">&#x1f310;</div>
           <h3 class="font-semibold mb-2">No vendor lock-in</h3>
-          <p class="text-sm text-muted leading-relaxed">Your workflow and security should not depend on a single vendor. LINCE supports Claude Code, Codex, Gemini, OpenCode, Aider, Amp &mdash; and any custom agent via config. Switch freely.</p>
+          <p class="text-sm text-muted leading-relaxed">Your workflow and security should not depend on a single vendor. LINCE supports Claude Code, Codex, Gemini, OpenCode, Aider, Amp, Bob, Pi &mdash; and any custom agent via config. Switch freely.</p>
         </div>
       </div>
     </div>
@@ -206,9 +206,9 @@
             <div><span class="text-accent">$</span> git clone https://github.com/RisorseArtificiali/lince</div>
             <div><span class="text-accent">$</span> cd lince/sandbox && ./install.sh</div>
             <div><span class="text-accent">$</span> cd ../lince-dashboard && ./install.sh</div>
-            <div><span class="text-accent">$</span> source ~/.bashrc && zd</div>
+            <div><span class="text-accent">$</span> source ~/.bashrc && lince</div>
           </div>
-          <p class="text-sm text-muted">Clone, install sandbox + dashboard, launch. See <a href="https://github.com/RisorseArtificiali/lince/blob/main/QUICKSTART.md" class="text-accent hover:underline">QUICKSTART.md</a> for details.</p>
+          <p class="text-sm text-muted">Clone, install sandbox + dashboard, launch. Requires Rust with the <span class="font-mono">wasm32-wasip1</span> target for the dashboard plugin. See <a href="https://github.com/RisorseArtificiali/lince/blob/main/QUICKSTART.md" class="text-accent hover:underline">QUICKSTART.md</a> for details.</p>
         </div>
       </div>
 
@@ -226,7 +226,7 @@
             <span class="text-amber font-bold">&#x26A0;</span>
             <h4 class="font-semibold">macOS</h4>
           </div>
-          <p class="text-muted">Experimental. Sandbox via <a href="https://nono.sh" class="text-accent hover:underline">nono</a> (Seatbelt). <a href="https://github.com/RisorseArtificiali/lince/issues/19" class="text-accent hover:underline">Looking for testers.</a></p>
+          <p class="text-muted">Experimental. Sandbox via the native <span class="font-mono">sandbox-exec</span> (Seatbelt) backend, built into macOS. The legacy <a href="https://nono.sh" class="text-accent hover:underline">nono</a> backend is deprecated &mdash; see the <a href="https://github.com/RisorseArtificiali/lince/blob/main/docs/documentation/sandbox/migration-nono-to-seatbelt.md" class="text-accent hover:underline">migration guide</a>. <a href="https://github.com/RisorseArtificiali/lince/issues/19" class="text-accent hover:underline">Looking for testers.</a></p>
         </div>
         <div class="feature-card rounded-lg p-4">
           <div class="flex items-center gap-2 mb-2">
@@ -250,8 +250,9 @@ You speak    <span class="text-muted">───></span>  <span class="text-cyan"
                               <span class="text-accent">Dashboard</span>  <span class="text-muted"><───</span>  routes to focused agent
                                      │
                             <span class="text-amber">agent-sandbox</span>  <span class="text-muted"><───</span>  isolates execution
-                              <span class="text-muted">├── bwrap</span>  ┐
-                              <span class="text-muted">├── nono</span>   ├── <span class="text-muted">choose per agent</span>
+                              <span class="text-muted">├── bwrap</span>    ┐
+                              <span class="text-muted">├── seatbelt</span> ├── <span class="text-muted">choose per agent</span>
+                              <span class="text-muted">├── nono</span> <span class="text-amber">(deprecated)</span>
                               <span class="text-muted">└── none</span>   ┘
                               ┌──────┼──────┐
                          <span class="text-white">Claude</span>   <span class="text-white">Codex</span>   <span class="text-white">Gemini</span>   <span class="text-muted">...any agent</span>
@@ -281,10 +282,10 @@ You speak    <span class="text-muted">───></span>  <span class="text-cyan"
         <div class="feature-card rounded-lg p-6">
           <div class="flex items-center gap-2 mb-3">
             <span class="text-accent font-bold">&#10003;</span>
-            <h3 class="font-semibold">nono</h3>
+            <h3 class="font-semibold">Seatbelt</h3>
           </div>
-          <p class="text-xs font-mono text-muted mb-3">Linux &amp; macOS</p>
-          <p class="text-sm text-muted leading-relaxed">Newer alternative. Integration with <a href="https://nono.sh" class="text-accent hover:underline">nono.sh</a>, an external project focused on security including network isolation. Uses Landlock on Linux, Seatbelt on macOS. Brings some additional dependencies.</p>
+          <p class="text-xs font-mono text-muted mb-3">macOS only</p>
+          <p class="text-sm text-muted leading-relaxed">macOS's native sandbox (<span class="font-mono">sandbox-exec</span>), built into the operating system. No extra install, zero external dependencies. The legacy <a href="https://nono.sh" class="text-accent hover:underline">nono</a> backend is deprecated &mdash; see the <a href="https://github.com/RisorseArtificiali/lince/blob/main/docs/documentation/sandbox/migration-nono-to-seatbelt.md" class="text-accent hover:underline">migration guide</a>.</p>
         </div>
         <div class="feature-card rounded-lg p-6">
           <div class="flex items-center gap-2 mb-3">

--- a/docs/install
+++ b/docs/install
@@ -45,7 +45,8 @@ case "$OS_NAME" in
     ;;
   Darwin)
     echo -e "${YELLOW}[*] Platform: macOS ($ARCH) — experimental support${NC}"
-    echo "    Sandbox via nono (Seatbelt). Some features may need validation."
+    echo "    Sandbox via the native Seatbelt backend (sandbox-exec, built into macOS)."
+    echo "    The legacy nono backend is deprecated. Some features may need validation."
     echo "    See: https://github.com/RisorseArtificiali/lince/issues/19"
     ;;
   *)
@@ -170,13 +171,14 @@ if [ "$OS_NAME" = "Linux" ]; then
     echo "    Install: sudo dnf install bubblewrap  (or: sudo apt install bubblewrap)"
   fi
 elif [ "$OS_NAME" = "Darwin" ]; then
-  if check_cmd nono; then
-    echo -e "  ${GREEN}✓${NC} nono"
+  # Seatbelt (sandbox-exec) is built into macOS — nothing to install.
+  if [ -x /usr/bin/sandbox-exec ]; then
+    echo -e "  ${GREEN}✓${NC} Seatbelt backend (sandbox-exec, built-in)"
   else
-    MISSING+=("nono")
-    echo -e "  ${YELLOW}✗${NC} nono not found"
-    echo "    Install: brew install nono"
-    echo "    See: https://github.com/nicholasgasior/nono"
+    MISSING+=("macOS with sandbox-exec support")
+    echo -e "  ${YELLOW}✗${NC} sandbox-exec not found at /usr/bin/sandbox-exec"
+    echo "    Seatbelt is built into macOS; a missing sandbox-exec usually means"
+    echo "    an unsupported or heavily modified system."
   fi
 fi
 

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -30,7 +30,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # ── State ────────────────────────────────────────────────────────────
-SELECTED_BACKENDS=()       # populated by select_backends(): "bwrap", "nono", "unsandboxed"
+SELECTED_BACKENDS=()       # populated by select_backends(): "bwrap", "seatbelt", "nono", "unsandboxed"
 SELECTED_AGENTS=()
 INSTALL_VOXCODE=false
 INSTALL_LINCE_LAB=false
@@ -51,11 +51,12 @@ AGENT_SELECTED=(1 1 0 0 0 0)  # claude and codex on by default
 # Available backends: key|display_name|description|installed
 BACKENDS=(
     "bwrap|bubblewrap (bwrap)|Built-in sandbox. Same technology as Flatpak. Minimal, zero dependencies."
-    "nono|nono (nono.sh)|External sandbox with network isolation. Landlock (Linux) + Seatbelt (macOS)."
+    "seatbelt|Seatbelt (sandbox-exec)|macOS native sandbox, built into the OS. Zero dependencies. Replaces nono on macOS."
+    "nono|nono (nono.sh) — deprecated|Legacy external sandbox. Superseded by Seatbelt on macOS. Kept for compatibility."
     "unsandboxed|Unsandboxed|No isolation — agent runs with full host access."
 )
 # Track backend selection state (1=selected, 0=not)
-BACKEND_SELECTED=(1 0 0)  # bwrap on by default
+BACKEND_SELECTED=(1 0 0 0)  # bwrap on by default
 
 # Shell agents (gh#91): key|display|description. Pre-selection is computed
 # at runtime from $SHELL by select_shells() so it tracks the host's actual
@@ -117,16 +118,18 @@ select_backends() {
     echo -e "  ${DIM}backend for that agent. Different agents can use different backends.${NC}"
     echo ""
 
-    # On macOS, bwrap is not available — deselect it and select nono
+    # On macOS, bwrap is not available — pre-select seatbelt instead
     if [ "$OS_NAME" = "Darwin" ]; then
-        BACKEND_SELECTED=(0 1 0)  # nono only
-        echo -e "  ${DIM}macOS detected — bubblewrap is Linux-only.${NC}"
+        BACKEND_SELECTED=(0 1 0 0)  # seatbelt only
+        echo -e "  ${DIM}macOS detected — bubblewrap is Linux-only, Seatbelt (sandbox-exec) pre-selected.${NC}"
         echo ""
     fi
 
     # Detect installed backends
-    local has_bwrap=false has_nono=false
+    local has_bwrap=false has_seatbelt=false has_nono=false
     command -v bwrap >/dev/null 2>&1 && has_bwrap=true
+    # Seatbelt is sandbox-exec, built into macOS
+    [ -x /usr/bin/sandbox-exec ] && has_seatbelt=true
     command -v nono >/dev/null 2>&1 && has_nono=true
 
     echo -e "  ${DIM}Toggle with number keys, press Enter when done:${NC}"
@@ -154,9 +157,18 @@ select_backends() {
                         continue
                     fi
                     ;;
+                seatbelt)
+                    if [ "$has_seatbelt" = true ]; then status=" ${GREEN}(built-in)${NC}"
+                    else status=" ${YELLOW}(requires macOS 10.5+)${NC}"; fi
+                    # Hide on Linux
+                    if [ "$OS_NAME" != "Darwin" ]; then
+                        echo -e "  ${DIM}[ ] $((i+1))) $name — macOS only${NC}"
+                        continue
+                    fi
+                    ;;
                 nono)
-                    if [ "$has_nono" = true ]; then status=" ${GREEN}(installed)${NC}"
-                    else status=" ${YELLOW}(not installed — cargo install nono-cli)${NC}"; fi
+                    if [ "$has_nono" = true ]; then status=" ${RED}(deprecated)${NC}"
+                    else status=" ${YELLOW}(not installed — deprecated, consider Seatbelt on macOS)${NC}"; fi
                     ;;
             esac
 
@@ -175,10 +187,12 @@ select_backends() {
             [1-9])
                 local idx=$((REPLY - 1))
                 if [ $idx -lt ${#BACKENDS[@]} ]; then
-                    # On macOS, don't allow selecting bwrap
+                    # On macOS, don't allow selecting bwrap; on Linux, don't allow seatbelt
                     IFS='|' read -r key _ _ <<< "${BACKENDS[$idx]}"
                     if [ "$key" = "bwrap" ] && [ "$OS_NAME" = "Darwin" ]; then
                         echo -e "  ${YELLOW}bubblewrap is not available on macOS${NC}"
+                    elif [ "$key" = "seatbelt" ] && [ "$OS_NAME" != "Darwin" ]; then
+                        echo -e "  ${YELLOW}Seatbelt (sandbox-exec) is only available on macOS${NC}"
                     else
                         if [ "${BACKEND_SELECTED[$idx]}" = "1" ]; then
                             BACKEND_SELECTED[$idx]=0
@@ -243,7 +257,7 @@ select_backends() {
             echo ""
             echo -e "  ${GREEN}Good choice. Please re-select backends.${NC}"
             # Reset to bwrap default and re-run
-            BACKEND_SELECTED=(1 0 0)
+            BACKEND_SELECTED=(1 0 0 0)
             select_backends
             return
         fi
@@ -640,7 +654,7 @@ confirm_installation() {
     echo -e "${BOLD}Installation summary${NC}"
     echo ""
 
-    if has_backend bwrap || has_backend nono; then
+    if has_backend bwrap || has_backend seatbelt || has_backend nono; then
         echo -e "  ${GREEN}✓${NC} agent-sandbox    ${DIM}(secure isolation for agents)${NC}"
     fi
     echo -e "    Backends: ${BOLD}${SELECTED_BACKENDS[*]}${NC}"
@@ -756,8 +770,8 @@ do_install_lince_lab() {
 
 # ── Install sandbox ─────────────────────────────────────────────────
 do_install_sandbox() {
-    # Only install agent-sandbox if bwrap backend is selected
-    if ! has_backend bwrap; then
+    # Only install agent-sandbox if a sandboxed backend is selected
+    if ! has_backend bwrap && ! has_backend seatbelt && ! has_backend nono; then
         return
     fi
 
@@ -1055,11 +1069,15 @@ check_prerequisites() {
     fi
     if has_backend nono; then
         if command -v nono >/dev/null 2>&1; then
-            echo -e "  ${GREEN}✓${NC} nono"
+            echo -e "  ${YELLOW}✓${NC} nono (deprecated — consider Seatbelt if on macOS)"
         else
             warnings+=("nono not found")
-            echo -e "  ${YELLOW}✗${NC} nono — ${DIM}cargo install nono-cli${NC}"
+            echo -e "  ${YELLOW}✗${NC} nono — ${DIM}deprecated; cargo install nono-cli${NC}"
         fi
+    fi
+    if has_backend seatbelt && [ "$(uname -s)" != "Darwin" ]; then
+        warnings+=("seatbelt selected on a non-macOS host")
+        echo -e "  ${RED}✗${NC} seatbelt — ${DIM}only available on macOS${NC}"
     fi
 
     if [ ${#warnings[@]} -gt 0 ]; then
@@ -1083,8 +1101,11 @@ print_summary() {
     if has_backend bwrap; then
         echo -e "  ${GREEN}✓${NC} agent-sandbox (bwrap)"
     fi
+    if has_backend seatbelt; then
+        echo -e "  ${GREEN}✓${NC} agent-sandbox (seatbelt)"
+    fi
     if has_backend nono; then
-        echo -e "  ${GREEN}✓${NC} nono sandbox"
+        echo -e "  ${YELLOW}✓${NC} agent-sandbox (nono, deprecated)"
     fi
     if has_backend unsandboxed; then
         echo -e "  ${RED}!${NC} unsandboxed mode"
@@ -1161,7 +1182,12 @@ done
 print_banner
 
 if [ "$USE_DEFAULTS" = true ]; then
-    SELECTED_BACKENDS=("bwrap")
+    if [ "$(uname -s)" = "Darwin" ]; then
+        SELECTED_BACKENDS=("seatbelt")  # bwrap is Linux-only; seatbelt is built into macOS
+        echo -e "  ${DIM}Using defaults: all agents, seatbelt sandbox (macOS)${NC}"
+    else
+        SELECTED_BACKENDS=("bwrap")
+    fi
     for i in "${!AGENTS[@]}"; do AGENT_SELECTED[$i]=1; done
     SELECTED_AGENTS=()
     for i in "${!AGENTS[@]}"; do
@@ -1177,7 +1203,7 @@ if [ "$USE_DEFAULTS" = true ]; then
     SELECTED_SHELLS=("$DEFAULT_SHELL")
     SELECTED_AGENTS+=("$DEFAULT_SHELL")
     DEFAULT_SHELL_BIN=$(command -v "$DEFAULT_SHELL" 2>/dev/null || true)
-    echo -e "  ${DIM}Using defaults: all agents, $DEFAULT_SHELL shell, bwrap sandbox${NC}"
+    echo -e "  ${DIM}Using defaults: all agents, $DEFAULT_SHELL shell, $([ "$(uname -s)" = "Darwin" ] && echo seatbelt || echo bwrap) sandbox${NC}"
 else
     select_backends
     select_agents


### PR DESCRIPTION
## Summary

The lince.sh homepage (served from `docs/` in this repo) still presents the **nono** backend as the current macOS sandbox, while the codebase has moved to the native **Seatbelt** (`sandbox-exec`) backend and marks nono as deprecated. This PR aligns the site, the changelog, and the install scripts with the actual state of the code.

## Changes

### docs/index.html (homepage)
- macOS platform card: now describes the native Seatbelt backend, links the nono-to-Seatbelt migration guide, keeps the testers-wanted link
- Architecture diagram: `seatbelt` added between `bwrap` and `nono`; nono labeled `(deprecated)`
- Sandbox Backends section: the **nono** card is replaced with a **Seatbelt** card (macOS-only, built into the OS); nono mentioned as legacy with migration-guide link
- Vendor lock-in section: agent list now includes **Bob** and **Pi** (matching `registry.d/`)
- Manual install snippet: launches `lince` instead of `zd` (matches README) and mentions the Rust `wasm32-wasip1` prerequisite

### docs/changelog/index.html
- New **2026-08-23** entry: Seatbelt backend, config v2 (lince.toml + registry), shell agents (gh#91), lince-lab (Lima/KVM). The previous entry was 2026-05-05, so the changelog was over three months stale

### quickstart.sh
- Backend picker gains a **seatbelt** option: pre-selected on macOS, hidden on Linux (mirrors the bwrap logic)
- nono description and status lines marked **deprecated**; no longer suggests `cargo install nono-cli` as the primary path on macOS
- `--defaults` now selects **seatbelt** on macOS instead of bwrap (which is Linux-only)
- `do_install_sandbox` installs agent-sandbox when *any* sandboxed backend is selected, not just bwrap (previously a seatbelt-only install skipped the sandbox)
- Prerequisite warnings and final summary updated for seatbelt/deprecated nono

### docs/install (lince.sh/install)
- macOS prerequisite check now verifies `/usr/bin/sandbox-exec` (built-in) instead of requiring `nono` via brew
- Banner text updated: Seatbelt native, nono deprecated

## Verification

- `bash -n quickstart.sh` and `bash -n docs/install` pass
- The deployed lince.sh and lince.sh/install were diffed against `docs/` before the change: they match, so merging this PR updates the live site

## Notes

- nono remains fully functional and selectable for backward compatibility; this only changes messaging, defaults, and prerequisite checks
- The changelog 'see all commits' link on the new entry points to commits since 2026-05-06