### PR TITLE
fix(sandbox): use sys.executable for Landlock shim relaunch

### DIFF
--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -3400,7 +3400,7 @@ def build_bwrap_cmd(config: dict, project_dir: Path,
             cmd[-1:-1] = opts
         else:
             cmd += opts
-        shim: list[str] = ["python3", LANDLOCK_SHIM_MOUNT, "__landlock-exec"]
+        shim: list[str] = [sys.executable, LANDLOCK_SHIM_MOUNT, "__landlock-exec"]
         for target in bwrap_rw_targets(cmd):
             shim += ["--rw", target]
         shim += ["--ro", "/"]


### PR DESCRIPTION
## Summary

`agent-sandbox run` can fail with `Error: Python 3.11+ required (for tomllib)` even when the outer Python interpreter is 3.11+.

The Landlock hardening shim (#222) relaunches `agent-sandbox` a second time *inside* the bwrap sandbox, using the hardcoded interpreter name `"python3"` (`build_bwrap_cmd()`, `sandbox/agent-sandbox`):

```python
shim: list[str] = ["python3", LANDLOCK_SHIM_MOUNT, "__landlock-exec"]
```

This name is resolved through the sandbox's own `PATH`, which is rebuilt from scratch and puts system directories (`/usr/local/bin`, `/usr/bin`, `/bin`) before any user/conda directories. So on a system where the system `python3` is older than 3.11 (for example Ubuntu 22.04) but the user is running the outer process from a newer interpreter (e.g. a conda env), the inner relaunch picks the wrong, older `python3` and fails on `import tomllib`.

Since the whole host filesystem is read-only bind-mounted at the same path inside the sandbox (`--ro-bind / /`), an absolute interpreter path stays valid there. This PR replaces the hardcoded `"python3"` with `sys.executable`, so the shim always reuses the exact interpreter that is already running the outer process, independent of what the sandbox's `PATH` exposes.

## Change

```diff
-        shim: list[str] = ["python3", LANDLOCK_SHIM_MOUNT, "__landlock-exec"]
+        shim: list[str] = [sys.executable, LANDLOCK_SHIM_MOUNT, "__landlock-exec"]
```

`sys` is already imported at the top of the script, so no new import is needed.

## How to test

1. Use an interpreter for the outer process that is not the system `python3` but is 3.11+ (e.g. a conda env), on a system whose system `python3` is older than 3.11.
2. Run `agent-sandbox run` with a config that enables the Landlock shim (`__landlock-exec`, feature #222).
3. Before the fix: the inner relaunch fails with `Error: Python 3.11+ required (for tomllib)`.
4. After the fix: the inner relaunch succeeds, using the same interpreter as the outer process.

Also verified `python3 sandbox/agent-sandbox --help` still works after the change.

## Backward compatibility

No behavior change for users whose outer interpreter is already `/usr/bin/python3` (or otherwise the same one the sandbox `PATH` would have resolved to). No new dependencies, no changes to the CLI surface.