### PR TITLE
fix(sandbox): mount real ~/.m2 in bob-permissive — three-tier parity

### DIFF
--- a/registry.d/bob.toml
+++ b/registry.d/bob.toml
@@ -30,6 +30,7 @@ credential_proxy = false
 block_git_push = true
 allow_domains = ["api.github.com", "github.com", "objects.githubusercontent.com"]
 home_ro_dirs = [".config/gh", ".ssh/known_hosts"]
+home_rw_dirs = [".m2"]
 passthrough = ["GH_TOKEN", "GITHUB_TOKEN", "GH_ENTERPRISE_TOKEN"]
 
 [dashboard]

--- a/sandbox/profiles/bob-permissive.toml
+++ b/sandbox/profiles/bob-permissive.toml
@@ -12,6 +12,11 @@
 
 [sandbox]
 home_ro_dirs = [".config/gh", ".ssh/known_hosts"]
+# Maven three-tier policy (#286): permissive mounts the REAL ~/.m2
+# read-write, matching the other Maven-capable agents (claude, codex,
+# gemini, opencode, pi). Normal uses the isolated toolchains/m2-repository
+# cache; paranoid isn't shipped for bob yet.
+home_rw_dirs = [".m2"]
 
 [env]
 # Keyring-auth users rely on GH_TOKEN/GITHUB_TOKEN; --clearenv would wipe them.


### PR DESCRIPTION
Closes #298

## What

`sandbox/profiles/bob-permissive.toml` was the only Maven-capable permissive fragment without `home_rw_dirs = [".m2"]` (leftover from #286 — bob landed the same day as the three-tier policy and got missed).

At permissive level Bob therefore saw the isolated `toolchains/m2-repository` cache (the normal-level bind), while claude / codex / gemini / opencode / pi saw the real `~/.m2`.

## Fix

- Add `home_rw_dirs = [".m2"]` to `[sandbox]` in `bob-permissive.toml`, same comment style as `claude-permissive.toml`.
- Regenerate `registry.d/bob.toml` with `scripts/gen_registry.py` (one-line diff).

## Verification

- `scripts/tests/test_registry_sync.py`: 7 passed (drift guard green).
- Full `scripts/tests/`: 106 passed, 1 pre-existing failure in `test_discover.py::test_exactly_installed_agents_proposed` (provider-suggestion `+anthropic`, reproduced on a clean stash — unrelated to this change).
- Normal level is unchanged: bob already gets the isolated m2 cache via the global `persist_toolchains` bind; the permissive fragment now shadows it with the real `~/.m2`, exactly as the #286 three-tier table describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)