### PR TITLE
fix(lince-lab): address macOS backend review follow-ups

### DIFF
--- a/lince-lab/lince_lab/macos_backend.py
+++ b/lince-lab/lince_lab/macos_backend.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import atexit
 import json
 import os
+import secrets
 import shlex
 import subprocess
 import sys
@@ -248,11 +249,15 @@ class MacosBackend(Backend):
 
     def delete(self, name: str, force: bool = False) -> None:
         # A running VM cannot be deleted; best-effort stop first (honoring force),
-        # then delete. stop() reaps the tracked run process + log.
+        # then delete. stop() reaps the tracked run process + log. Clone-backed
+        # snapshots are separate Tart VMs, so remove them explicitly before the
+        # parent or they would accumulate as hidden orphan disks.
         try:
             self.stop(name, force=force)
         except BackendError:
             pass
+        for tag in self.snapshot_list(name):
+            self.snapshot_delete(name, tag)
         self._run([self._tart, "delete", name])
 
     def _reap(self, name: str) -> None:
@@ -428,7 +433,18 @@ class MacosBackend(Backend):
     ) -> ExecResult:
         ip = self._ip(name)
         remote = self._remote_command(argv, workdir, env)
-        cmd = ["ssh", *self._ssh_opts(), f"{GUEST_USER}@{ip}", remote]
+        # OpenSSH reserves client exit 255 for transport failures, but a remote
+        # command may legitimately exit 255 too. Run the command in a subshell,
+        # frame its real status on stderr with an unpredictable nonce, and make
+        # the outer remote shell exit 0. A missing frame or nonzero ssh status is
+        # then unambiguously a transport/protocol failure; do not retry because
+        # arbitrary recipe steps may not be idempotent.
+        marker = f"__LINCE_LAB_GUEST_EXIT_{secrets.token_hex(16)}__"
+        framed_remote = (
+            f"( {remote} ); __lince_lab_rc=$?; "
+            f"printf '\\n{marker}%s\\n' \"$__lince_lab_rc\" >&2; exit 0"
+        )
+        cmd = ["ssh", *self._ssh_opts(), f"{GUEST_USER}@{ip}", framed_remote]
         proc = subprocess.run(
             cmd,
             capture_output=True,
@@ -438,9 +454,22 @@ class MacosBackend(Backend):
             start_new_session=True,
             env=self._ssh_env(),
         )
-        # CRITICAL: return the guest exit code verbatim; do NOT raise — the bisect
-        # signal. (ssh returns the remote command's exit code on a live channel.)
-        return ExecResult(exit_code=proc.returncode, stdout=proc.stdout, stderr=proc.stderr)
+        stderr = proc.stderr or ""
+        frame_prefix = f"\n{marker}"
+        guest_stderr, separator, framed_status = stderr.rpartition(frame_prefix)
+        if proc.returncode != 0 or not separator:
+            detail = stderr.strip()
+            suffix = f": {detail}" if detail else ""
+            raise BackendError(f"ssh transport failed for {name!r} (exit {proc.returncode}){suffix}")
+        if not framed_status.endswith("\n") or not framed_status[:-1].isdigit():
+            raise BackendError(f"invalid ssh guest-exit frame for {name!r}")
+
+        guest_code = int(framed_status[:-1])
+        if not 0 <= guest_code <= 255:
+            raise BackendError(f"invalid guest exit code {guest_code} for {name!r}")
+        # CRITICAL: return the guest exit code verbatim; do NOT raise on guest
+        # nonzero — that is the bisect signal. Only transport failures raise.
+        return ExecResult(exit_code=guest_code, stdout=proc.stdout or "", stderr=guest_stderr)
 
     def _run_ssh(self, argv: list[str]) -> subprocess.CompletedProcess[str]:
         """Run an ssh/scp command with askpass env, raising on a nonzero exit."""

--- a/lince-lab/lince_lab/recipe.py
+++ b/lince-lab/lince_lab/recipe.py
@@ -417,7 +417,9 @@ def apply_egress_lockdown(
     network is still up. That seam runs the Linux nft script on the Lima backend;
     the macOS backend overrides it (pfctl enforcement is tracked for #266). A
     nonzero result raises :class:`~lince_lab.errors.BackendError`: a VM that cannot
-    enforce egress must NOT go on to run the (now-untrusted) recipe steps.
+    enforce egress must NOT go on to run the (now-untrusted) recipe steps. This
+    fail-closed invariant is explicitly suspended on macOS until #266: the macOS
+    backend warns and leaves guest egress unrestricted during that deferral.
     """
     # Cap the lock-down exec so a wedged script errors out instead of hanging
     # forever; honor a tighter step_timeout when the caller provides one.

--- a/lince-lab/tests/test_macos_backend.py
+++ b/lince-lab/tests/test_macos_backend.py
@@ -31,6 +31,21 @@ def _ok(stdout: str = "", stderr: str = "", returncode: int = 0) -> subprocess.C
     return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
 
 
+_EXEC_NONCE = "0123456789abcdef"
+_EXEC_MARKER = f"__LINCE_LAB_GUEST_EXIT_{_EXEC_NONCE}__"
+
+
+def _ssh_ok(guest_code: int = 0, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess:
+    return _ok(stdout=stdout, stderr=f"{stderr}\n{_EXEC_MARKER}{guest_code}\n")
+
+
+def _framed_remote(payload: str) -> str:
+    return (
+        f"( {payload} ); __lince_lab_rc=$?; "
+        f"printf '\\n{_EXEC_MARKER}%s\\n' \"$__lince_lab_rc\" >&2; exit 0"
+    )
+
+
 _TEMPLATE = json.dumps(
     {
         "images": [{"location": "ghcr.io/cirruslabs/macos-sequoia-base:latest", "arch": "arm64"}],
@@ -105,6 +120,22 @@ class LifecycleTestCase(unittest.TestCase):
         argvs = [c.args[0] for c in run.call_args_list]
         self.assertIn(["tart", "delete", "lince-lab-x"], argvs)
 
+    def test_delete_cascades_to_clone_backed_snapshots(self) -> None:
+        with (
+            mock.patch.object(self.backend, "snapshot_list", return_value=["base", "candidate-2"]),
+            mock.patch("lince_lab.macos_backend.subprocess.run", return_value=_ok()) as run,
+        ):
+            self.backend.delete("lince-lab-x")
+        deletes = [c.args[0] for c in run.call_args_list if c.args[0][:2] == ["tart", "delete"]]
+        self.assertEqual(
+            deletes,
+            [
+                ["tart", "delete", "lince-lab-x__snap__base"],
+                ["tart", "delete", "lince-lab-x__snap__candidate-2"],
+                ["tart", "delete", "lince-lab-x"],
+            ],
+        )
+
     def test_status_running_and_absent(self) -> None:
         records = [{"Name": "lince-lab-x", "State": "running"}]
         with mock.patch(
@@ -168,39 +199,58 @@ class LifecycleTestCase(unittest.TestCase):
 class ExecTestCase(unittest.TestCase):
     def setUp(self) -> None:
         self.backend = MacosBackend()
+        nonce = mock.patch("lince_lab.macos_backend.secrets.token_hex", return_value=_EXEC_NONCE)
+        self.addCleanup(nonce.stop)
+        nonce.start()
 
     def test_exec_builds_ssh_remote_command_and_returns_code(self) -> None:
         # First subprocess.run = `tart ip`; second = the ssh exec.
         with mock.patch(
             "lince_lab.macos_backend.subprocess.run",
-            side_effect=[_ok(stdout="10.0.0.5\n"), _ok(stdout="hi", returncode=0)],
+            side_effect=[_ok(stdout="10.0.0.5\n"), _ssh_ok(stdout="hi")],
         ) as run:
             result = self.backend.exec("lince-lab-x", ["sh", "-c", "echo hi"])
         ssh_argv = run.call_args_list[1].args[0]
         self.assertEqual(ssh_argv[0], "ssh")
         self.assertEqual(ssh_argv[-2], "admin@10.0.0.5")
         # The remote command is one shell-quoted string (no host-side word-split).
-        self.assertEqual(ssh_argv[-1], "sh -c 'echo hi'")
+        self.assertEqual(ssh_argv[-1], _framed_remote("sh -c 'echo hi'"))
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.stdout, "hi")
 
     def test_exec_injects_workdir_and_env(self) -> None:
         with mock.patch(
             "lince_lab.macos_backend.subprocess.run",
-            side_effect=[_ok(stdout="10.0.0.5\n"), _ok()],
+            side_effect=[_ok(stdout="10.0.0.5\n"), _ssh_ok()],
         ) as run:
             self.backend.exec("lince-lab-x", ["make", "test"], workdir="/work", env={"CI": "1"})
         remote = run.call_args_list[1].args[0][-1]
-        self.assertEqual(remote, "cd /work && env CI=1 make test")
+        self.assertEqual(remote, _framed_remote("cd /work && env CI=1 make test"))
 
     def test_exec_returns_guest_nonzero_without_raising(self) -> None:
         with mock.patch(
             "lince_lab.macos_backend.subprocess.run",
-            side_effect=[_ok(stdout="10.0.0.5\n"), _ok(stderr="boom", returncode=1)],
+            side_effect=[_ok(stdout="10.0.0.5\n"), _ssh_ok(guest_code=1, stderr="boom")],
         ):
             result = self.backend.exec("lince-lab-x", ["false"])
         self.assertEqual(result.exit_code, 1)
         self.assertEqual(result.stderr, "boom")
+
+    def test_exec_distinguishes_guest_255_from_ssh_transport_failure(self) -> None:
+        with mock.patch(
+            "lince_lab.macos_backend.subprocess.run",
+            side_effect=[_ok(stdout="10.0.0.5\n"), _ssh_ok(guest_code=255, stderr="guest failed")],
+        ):
+            result = self.backend.exec("lince-lab-x", ["sh", "-c", "exit 255"])
+        self.assertEqual(result.exit_code, 255)
+        self.assertEqual(result.stderr, "guest failed")
+
+        with mock.patch(
+            "lince_lab.macos_backend.subprocess.run",
+            side_effect=[_ok(stdout="10.0.0.5\n"), _ok(stderr="Connection reset", returncode=255)],
+        ):
+            with self.assertRaisesRegex(BackendError, "ssh transport failed"):
+                self.backend.exec("lince-lab-x", ["true"])
 
 
 class CopyTestCase(unittest.TestCase):


### PR DESCRIPTION
Follow-up to #270.

`MacosBackend.exec()` returned OpenSSH exit 255 for both transport failures and a real guest exit 255. In a bisect, a dropped SSH connection could therefore become a false bad verdict.

This patch:

- wraps the remote command and returns its status in a nonce-scoped stderr frame; guest 255 remains 255, while a missing frame or nonzero SSH status raises `BackendError`
- removes every `<vm>__snap__*` Tart clone before deleting its parent VM
- states the temporary macOS fail-open exception in `apply_egress_lockdown()` until #266

I did not use retry-on-255: recipe steps can mutate state, so running one twice is unsafe.

Validation:

- `python3 -m unittest discover -s lince-lab/tests -p 'test_*.py'` -> 262 passed, 16 skipped
- `python3 lince-lab/tests/test_macos_backend.py` -> 26 passed
- `python3 -m compileall -q lince-lab/lince_lab lince-lab/tests`
- `git diff --check`

Not run: `ruff`; it is not installed in this environment.
