### PR TITLE
fix(codex): replace removed --full-auto flag with -a never

### DIFF
--- a/docs/design/config-v2-design.md
+++ b/docs/design/config-v2-design.md
@@ -358,17 +358,17 @@ data confirms this: `claude-unsandboxed` today is `command = ["claude"]`
 disabled and **no sandbox** — a security regression vs today. Verification status of
 the derivation, per field: labels/colors/titles/`sandboxed` follow the rule for all 8
 shipped pairs; the `command` field does **not** follow a single rule (claude drops
-its args, codex keeps `--full-auto`), so codex carries an explicit exception.
+its args, codex keeps `--sandbox workspace-write -a never`), so codex carries an explicit exception.
 
 Exceptions go in an optional `[variants.unsandboxed]` override table.
-**The rule is NOT exception-free**: today `codex-unsandboxed` keeps `--full-auto`
-(`command = ["codex", "--full-auto"]`, lince-dashboard/agents-defaults.toml:144) and
+**The rule is NOT exception-free**: today `codex-unsandboxed` keeps `--sandbox workspace-write -a never`
+(`command = ["codex", "--sandbox", "workspace-write", "-a", "never"]`, lince-dashboard/agents-defaults.toml:144) and
 flips `bwrap_conflict = true → false` (verified, lince-dashboard/agents-defaults.toml:123
 vs :152), so `registry.d/codex.toml` ships:
 
 ```toml
 [variants.unsandboxed]
-command = ["codex", "--full-auto"]
+command = ["codex", "--sandbox", "workspace-write", "-a", "never"]
 bwrap_conflict = false
 ```
 

--- a/docs/documentation/dashboard/agent-examples.md
+++ b/docs/documentation/dashboard/agent-examples.md
@@ -223,7 +223,7 @@ The sandbox injects `--sandbox danger-full-access` into the Codex command, disab
 
 ```bash
 agent-sandbox run -a codex -p ~/project --dry-run
-# Output shows: ... codex --full-auto --sandbox danger-full-access
+# Output shows: ... codex -a never --sandbox danger-full-access
 ```
 
 ## Status Reporting

--- a/docs/documentation/dashboard/config-reference.md
+++ b/docs/documentation/dashboard/config-reference.md
@@ -72,7 +72,7 @@ Override an existing agent (e.g. change Codex model):
 
 ```toml
 [agents.codex]
-command = ["codex", "--full-auto", "--model", "o4-mini"]
+command = ["codex", "--sandbox", "workspace-write", "-a", "never", "--model", "o4-mini"]
 pane_title_pattern = "codex"
 status_pipe_name = "lince-status"
 display_name = "OpenAI Codex (o4-mini)"

--- a/docs/documentation/sandbox/config-reference.md
+++ b/docs/documentation/sandbox/config-reference.md
@@ -96,7 +96,7 @@ Per-agent configuration. Defines how to run a specific AI coding agent inside th
 ```toml
 [agents.codex]
 command = "codex"
-default_args = ["--full-auto"]
+default_args = ["-a", "never"]
 env = {}
 home_ro_dirs = []
 home_rw_dirs = [".codex"]

--- a/lince-dashboard/MULTI-AGENT-GUIDE.md
+++ b/lince-dashboard/MULTI-AGENT-GUIDE.md
@@ -248,7 +248,7 @@ For sandboxed agents, `env_unset` is a no-op because `--clearenv` already starts
 | Field | Purpose | Example |
 |-------|---------|---------|
 | `command` | Binary to execute | `"codex"` |
-| `default_args` | Default CLI args | `["--full-auto"]` |
+| `default_args` | Default CLI args | `["-a", "never"]` |
 | `env` | Env vars to set | `{ OPENAI_API_KEY = "$OPENAI_API_KEY" }` |
 | `home_ro_dirs` | Home dirs to mount read-only | `[".codex", ".config/codex"]` |
 | `home_rw_dirs` | Home dirs to mount read-write | `[]` |
@@ -284,7 +284,7 @@ Use `--dry-run` to verify what gets injected:
 
 ```bash
 agent-sandbox run -a codex-bwrap -p ~/project --dry-run
-# Shows: ... codex --full-auto --sandbox danger-full-access
+# Shows: ... codex -a never --sandbox danger-full-access
 ```
 
 ## Status Pipes

--- a/lince-dashboard/agents-defaults.toml
+++ b/lince-dashboard/agents-defaults.toml
@@ -141,7 +141,7 @@ OPENAI_API_KEY = "$OPENAI_API_KEY"
 turn_complete = "input"
 
 [agents.codex-unsandboxed]
-command = ["codex", "--full-auto"]
+command = ["codex", "--sandbox", "workspace-write", "-a", "never"]
 pane_title_pattern = "codex"
 status_pipe_name = "lince-status"
 display_name = "OpenAI Codex (unsandboxed)"

--- a/lince-dashboard/config.toml
+++ b/lince-dashboard/config.toml
@@ -52,7 +52,7 @@ sandbox_backend = "auto"
 #
 # Example: override codex to use a custom model
 # [agents.codex]
-# default_args = ["--full-auto", "--model", "o4-mini"]
+# default_args = ["-a", "never", "--model", "o4-mini"]
 #
 # Example: add a custom agent
 # [agents.custom-agent]

--- a/lince-dashboard/hooks/lince-agent-wrapper
+++ b/lince-dashboard/hooks/lince-agent-wrapper
@@ -6,7 +6,7 @@
 #   lince-agent-wrapper <AGENT_ID> <PIPE_NAME> <command> [args...]
 #
 # Example:
-#   lince-agent-wrapper agent-5 lince-status codex --full-auto
+#   lince-agent-wrapper agent-5 lince-status codex -a never
 #
 # On exit: sends {"agent_id":"<AGENT_ID>","event":"stopped"} via zellij pipe
 #

--- a/lince-dashboard/plugin/src/agent.rs
+++ b/lince-dashboard/plugin/src/agent.rs
@@ -294,7 +294,8 @@ fn synthesize_sandboxed_command(
         "codex" => (
             vec![
                 "codex".to_string(),
-                "--full-auto".to_string(),
+                "-a".to_string(),
+                "never".to_string(),
                 "--sandbox".to_string(),
                 "danger-full-access".to_string(),
             ],

--- a/lince-dashboard/skills/lince-add-supported-agent/references/config-schema.md
+++ b/lince-dashboard/skills/lince-add-supported-agent/references/config-schema.md
@@ -25,7 +25,7 @@ Agent definitions live under `[agents.<key>]`.
 ```toml
 [agents.codex]
 command = "codex"
-default_args = ["--full-auto"]
+default_args = ["-a", "never"]
 env = { OPENAI_API_KEY = "$OPENAI_API_KEY" }
 home_ro_dirs = [".codex"]
 home_rw_dirs = []

--- a/lince-dashboard/skills/lince-add-supported-agent/references/examples.md
+++ b/lince-dashboard/skills/lince-add-supported-agent/references/examples.md
@@ -76,7 +76,7 @@ remain unknown because Codex doesn't surface them.
 ```toml
 [agents.codex]
 command = "codex"
-default_args = ["--full-auto"]
+default_args = ["-a", "never"]
 env = {}
 home_ro_dirs = [".codex"]
 home_rw_dirs = []

--- a/registry.d/codex.toml
+++ b/registry.d/codex.toml
@@ -13,7 +13,7 @@ display_name = "OpenAI Codex"
 short_label = "CDX"
 color = "cyan"
 binary = "codex"
-default_args = ["--full-auto"]
+default_args = ["-a", "never"]
 
 [sandbox]
 backend = "auto"
@@ -49,7 +49,7 @@ providers = ["__discover__"]
 # Exceptions to the derivation rule (design §3.5); all other
 # variant fields are derived from the base definition.
 [variants.unsandboxed]
-command = ["codex", "--full-auto"]
+command = ["codex", "--sandbox", "workspace-write", "-a", "never"]
 bwrap_conflict = false
 
 [env]

--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -144,7 +144,7 @@ use_real_config = false
 
 # [agents.codex]
 # command = "codex"
-# default_args = ["--full-auto"]
+# default_args = ["-a", "never"]
 # home_ro_dirs = [".codex"]
 # bwrap_conflict = true
 # disable_inner_sandbox_args = ["--sandbox", "danger-full-access"]

--- a/sandbox/agents-defaults.toml
+++ b/sandbox/agents-defaults.toml
@@ -43,7 +43,7 @@ disable_inner_sandbox_args = []
 
 [agents.codex]
 command = "codex"
-default_args = ["--full-auto"]
+default_args = ["-a", "never"]
 env = {}
 home_ro_dirs = []
 home_rw_dirs = [".codex"]

--- a/sandbox/config.toml.example
+++ b/sandbox/config.toml.example
@@ -84,7 +84,7 @@ use_real_config = false
 
 # [agents.codex]
 # command = "codex"
-# default_args = ["--full-auto"]
+# default_args = ["-a", "never"]
 # home_ro_dirs = [".codex"]
 # bwrap_conflict = true
 # disable_inner_sandbox_args = ["--sandbox", "danger-full-access"]

--- a/scripts/gen_registry.py
+++ b/scripts/gen_registry.py
@@ -134,11 +134,16 @@ HOME_SUBDIRS: dict[str, str] = {
 # Per-variant exceptions to the §3.5 derivation rule. The diff-guard verifies
 # derived+exceptions == legacy, so a new exception in the legacy file fails
 # the test instead of drifting silently.
-#   codex: keeps --full-auto outside the sandbox (claude deliberately drops
-#   --dangerously-skip-permissions — see §3.5 security note) and flips
-#   bwrap_conflict off (no outer bwrap to conflict with).
+#   codex: keeps auto-edit semantics outside the sandbox — explicit
+#   workspace-write + no approvals (codex CLI >= 0.144 removed --full-auto;
+#   claude deliberately drops --dangerously-skip-permissions — see §3.5
+#   security note) and flips bwrap_conflict off (no outer bwrap to conflict
+#   with).
 VARIANT_EXCEPTIONS: dict[str, dict] = {
-    "codex": {"command": ["codex", "--full-auto"], "bwrap_conflict": False},
+    "codex": {
+        "command": ["codex", "--sandbox", "workspace-write", "-a", "never"],
+        "bwrap_conflict": False,
+    },
 }
 
 DEFAULT_STATUS_PIPE = "lince-status"

--- a/scripts/tests/test_resolve.py
+++ b/scripts/tests/test_resolve.py
@@ -71,7 +71,7 @@ class ResolveTestCase(unittest.TestCase):
         self.assertEqual(claude["dashboard"]["status_pipe_name"], "claude-status")
         # variant derivation incl. the codex exception
         self.assertEqual(view["agents"]["codex"]["variants"]["unsandboxed"]["command"],
-                         ["codex", "--full-auto"])
+                         ["codex", "--sandbox", "workspace-write", "-a", "never"])
         self.assertFalse(view["agents"]["codex"]["variants"]["unsandboxed"]["bwrap_conflict"])
         self.assertEqual(claude["variants"]["unsandboxed"]["command"], ["claude"])
         self.assertEqual(claude["variants"]["unsandboxed"]["short_label"], "CLU")


### PR DESCRIPTION
## Problem

codex-cli 0.144 removed the `--full-auto` flag, so every codex launch through lince fails with:

```
error: unexpected argument '--full-auto' found
```

The flag was still shipped as source of truth in `sandbox/agents-defaults.toml`, propagated to `registry.d/codex.toml`, the dashboard unsandboxed variant, and hardcoded in the dashboard plugin launcher (#306).

## Fix

Replace the removed flag with its modern equivalents everywhere:

- **Sandboxed path** (`sandbox/agents-defaults.toml` → `registry.d/codex.toml`): `default_args = ["-a", "never"]`. Inside bwrap the inner sandbox is already disabled via `disable_inner_sandbox_args = ["--sandbox", "danger-full-access"]`, and the per-element dedup in `build_bwrap_cmd` means a `--sandbox` flag in `default_args` would leave a dangling `danger-full-access` token — so the approval flag alone is correct there.
- **Unsandboxed variant** (`lince-dashboard/agents-defaults.toml`, `VARIANT_EXCEPTIONS` in `scripts/gen_registry.py`, regenerated `registry.d/codex.toml`): `["codex", "--sandbox", "workspace-write", "-a", "never"]` — the old `--full-auto` semantics (workspace writes) without approval prompts.
- **Dashboard plugin launcher** (`lince-dashboard/plugin/src/agent.rs`): `-a never` in place of `--full-auto`, before the explicit `--sandbox danger-full-access`.
- Updated `scripts/tests/test_resolve.py` and all docs / examples / skill references that still advertised the dead flag (config references, agent examples, MULTI-AGENT-GUIDE, lince-add-supported-agent references, config-v2 design notes, `config.toml.example`, in-script comment examples).

## Test

- `pytest scripts/tests/`: **119 passed**, 1 failure — `test_discover.py::test_exactly_installed_agents_proposed` is pre-existing on clean `upstream/main` (unrelated: `lince-config apply` suggestion strings).
- `cargo check` on the dashboard plugin passes. The wasm32-wasip1 build was not run: no rustup toolchain is currently installed on the authoring machine.
- `python3 scripts/gen_registry.py` regenerates cleanly (all registry files in sync with legacy defaults).

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)