### PR TITLE
fix(codex): improve Zellij scrolling, status and multiline input

### DIFF
--- a/lince-dashboard/MULTI-AGENT-GUIDE.md
+++ b/lince-dashboard/MULTI-AGENT-GUIDE.md
@@ -98,7 +98,12 @@ Claude Code has native hooks that report rich status (tool usage, tokens, subage
 
 The dashboard injects this wrapper automatically for agents with `has_native_hooks = false`. You don't need to do anything.
 
-Codex can also use its native `notify` command hook to emit `idle` when a turn completes. The dashboard install/update scripts configure that automatically when possible.
+Codex uses lifecycle hooks to report `RUNNING`, `INPUT`, `PERMISSION`, and
+`STOPPED`. Dashboard install/update merges Lince handlers into
+`$CODEX_HOME/hooks.json` (default `~/.codex/hooks.json`), preserving user hooks.
+Open `/hooks` in Codex to review/trust the handlers, then start a new session.
+The legacy `notify` hook remains a turn-completion fallback; by itself it
+cannot report when work starts. See [Codex troubleshooting](README.md#status-not-updating).
 
 Pi (`@mariozechner/pi-coding-agent`) supports lince's full status protocol via a TypeScript extension installed at `~/.pi/agent/extensions/lince-pi-hook.ts`. The extension subscribes to Pi's `session_start`, `turn_start`, `tool_call`, `turn_end`, and `session_shutdown` events and emits the same JSON status schema the dashboard parses for Claude. As a result Pi runs with `has_native_hooks = true` — current tool name and idle/running transitions appear in real time, identical to Claude Code. The dashboard install/update scripts copy the extension automatically.
 
@@ -294,7 +299,7 @@ The dashboard now listens on two pipe names:
 | Pipe | Used by | Events |
 |------|---------|--------|
 | `claude-status` | Claude Code (native hooks) | Rich: idle, running, permission, PreToolUse, tokens, subagents |
-| `lince-status` | All other agents (via wrapper) | Lifecycle: start, stopped |
+| `lince-status` | Other agents, including Codex native hooks | Native lifecycle events; `stopped` from the generic wrapper |
 
 Both pipes are active simultaneously. No configuration needed.
 

--- a/lince-dashboard/README.md
+++ b/lince-dashboard/README.md
@@ -106,7 +106,7 @@ lince-dashboard/
 │       └── state_file.rs       # Save/restore agent state (.lince-dashboard)
 ├── hooks/
 │   ├── claude-status-hook.sh   # Claude Code hook → pipe + file
-│   ├── codex-status-hook.sh    # Codex notify hook → pipe + file
+│   ├── codex-status-hook.sh    # Codex lifecycle/notify hooks → pipe + file
 │   ├── bob-status-hook.sh      # Bob (IBM) hook → pipe + file
 │   ├── lince-agent-wrapper     # Generic wrapper for agents without native hooks
 │   └── install-hooks.sh        # Hook installer
@@ -144,9 +144,29 @@ lince-dashboard/
 - Verify hooks are installed: check `~/.claude/settings.json` for `hooks` section
 - Test hook manually: `echo '{"hook_event_name":"Stop"}' | LINCE_AGENT_ID=test-1 bash ~/.local/bin/claude-status-hook.sh`
 - Check file fallback: `cat /tmp/lince-dashboard/claude-test-1.state`
-- Verify Codex notify is installed: check `~/.codex/config.toml` for the LINCE managed `notify` block
+- For Codex, run `bash hooks/install-codex-hooks.sh`, then open `/hooks` in Codex and review/trust the `codex-status-hook.sh` handlers. Restart the Codex session. The installer merges lifecycle events into `$CODEX_HOME/hooks.json` (default `~/.codex/hooks.json`) and preserves other hooks. Legacy `notify` alone can only report turn completion, so it cannot switch the dashboard to `RUNNING`.
 - Verify Bob hooks are installed: check `~/.bob/settings/settings.json` for `bob-status-hook.sh` entries under `hooks`
 - Ensure sandbox passes env vars (see [Sandbox Integration](https://lince.sh/documentation/#/dashboard/usage-guide?id=sandbox-integration))
+
+### Codex scrolling and multiline input
+
+Lince starts Codex with `--no-alt-screen` to retain Zellij's pane scrollback.
+After updating Lince, start a new Codex pane. Use the mouse wheel, or `Ctrl+s`
+then `PageUp`/`PageDown` (`Esc` returns to normal mode).
+
+The shipped Zellij config maps `Shift+Enter` to LF, Codex's `Ctrl+j` newline.
+Existing Zellij configs are preserved by updates: add this inside `keybinds`
+in your active config and restart Zellij:
+
+```kdl
+shared_among "normal" "locked" {
+    bind "Shift Enter" { Write 10; }
+}
+```
+
+The host terminal must send a distinct key sequence for `Shift+Enter`.
+If it sends ordinary Enter, use `Ctrl+j`, or `Ctrl+g` to compose in your editor.
+A trailing backslash is not a portable multiline shortcut for Codex.
 
 ### Agent panes not hiding
 - This is a known Zellij behavior — `hide_pane_with_id` requires `ChangeApplicationState` permission

--- a/lince-dashboard/agents-defaults.toml
+++ b/lince-dashboard/agents-defaults.toml
@@ -132,16 +132,23 @@ sandbox_level = "normal"          # paranoid | normal | permissive (or custom; s
 OPENAI_API_KEY = "$OPENAI_API_KEY"
 
 # Native hook events emitted by codex-status-hook.sh → canonical AgentStatus.
-# Codex notify currently fires on turn completion; the hook forwards the
-# payload's `type` field (typically "agent-turn-complete") as the native event,
-# falling back to "turn_complete" if missing. Both map to "input" (waiting
-# for the user's next prompt). See LINCE-118 / LINCE-122.
+# Lifecycle hooks report the full turn; notify remains a completion fallback.
 [agents.codex.event_map]
+SessionStart = "input"
+UserPromptSubmit = "running"
+PreToolUse = "running"
+PostToolUse = "running"
+PermissionRequest = "permission"
+PreCompact = "running"
+PostCompact = "running"
+Stop = "input"
+Interrupt = "input"
+SessionEnd = "stopped"
 "agent-turn-complete" = "input"
 turn_complete = "input"
 
 [agents.codex-unsandboxed]
-command = ["codex", "--sandbox", "workspace-write", "-a", "never"]
+command = ["codex", "--no-alt-screen", "--sandbox", "workspace-write", "-a", "never"]
 pane_title_pattern = "codex"
 status_pipe_name = "lince-status"
 display_name = "OpenAI Codex (unsandboxed)"
@@ -156,6 +163,16 @@ providers = ["__discover__"]
 OPENAI_API_KEY = "$OPENAI_API_KEY"
 
 [agents.codex-unsandboxed.event_map]
+SessionStart = "input"
+UserPromptSubmit = "running"
+PreToolUse = "running"
+PostToolUse = "running"
+PermissionRequest = "permission"
+PreCompact = "running"
+PostCompact = "running"
+Stop = "input"
+Interrupt = "input"
+SessionEnd = "stopped"
 "agent-turn-complete" = "input"
 turn_complete = "input"
 

--- a/lince-dashboard/hooks/codex-hooks-config.py
+++ b/lince-dashboard/hooks/codex-hooks-config.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Install/remove only Lince's handlers, preserving other Codex hooks."""
+
+import json
+import os
+from pathlib import Path
+import shutil
+import sys
+import tempfile
+
+
+COMMAND = "codex-status-hook.sh"
+EVENTS = (
+    "SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse",
+    "PermissionRequest", "PreCompact", "PostCompact", "Stop", "Interrupt",
+    "SessionEnd",
+)
+
+
+def update(path: Path, *, remove: bool = False) -> None:
+    if remove and not path.exists():
+        return
+    raw = path.read_text() if path.exists() else None
+    data = json.loads(raw) if raw is not None else {}
+    hooks = data.setdefault("hooks", {})
+    # Validate before editing; a malformed user file must remain untouched.
+    if not isinstance(hooks, dict):
+        raise ValueError("hooks must be an object")
+    for event, groups in hooks.items():
+        if not isinstance(groups, list):
+            raise ValueError(f"{event}: expected a list of matcher groups")
+        for group in groups:
+            if not isinstance(group, dict) or not isinstance(group.get("hooks"), list):
+                raise ValueError(f"{event}: invalid matcher group")
+            if any(not isinstance(handler, dict) for handler in group["hooks"]):
+                raise ValueError(f"{event}: invalid handler")
+
+    for event in EVENTS:
+        groups = hooks.get(event, [])
+        remaining = []
+        for group in groups:
+            handlers = [h for h in group["hooks"] if not (
+                h.get("type") == "command" and h.get("command") == COMMAND
+            )]
+            if handlers == group["hooks"]:
+                remaining.append(group)
+            elif handlers:
+                remaining.append({**group, "hooks": handlers})
+        if not remove:
+            remaining.append({"hooks": [{
+                "type": "command", "command": COMMAND, "timeout": 3,
+            }]})
+        if remaining:
+            hooks[event] = remaining
+        else:
+            hooks.pop(event, None)
+
+    updated = json.dumps(data, indent=2) + "\n"
+    if raw is not None and json.loads(raw) == data:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        backup = path.with_name(path.name + ".lince.bak")
+        suffix = 1
+        while backup.exists():
+            backup = path.with_name(path.name + f".lince.bak.{suffix}")
+            suffix += 1
+        shutil.copy2(path, backup)
+    fd, temp = tempfile.mkstemp(prefix=path.name + ".", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w") as output:
+            output.write(updated)
+        if path.exists():
+            shutil.copymode(path, temp)
+        os.replace(temp, path)
+    finally:
+        if os.path.exists(temp):
+            os.unlink(temp)
+
+
+if __name__ == "__main__":
+    update(Path(sys.argv[1]), remove="--remove" in sys.argv[2:])

--- a/lince-dashboard/hooks/codex-status-hook.sh
+++ b/lince-dashboard/hooks/codex-status-hook.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# codex-status-hook.sh — Codex notify hook that reports turn-complete status
+# codex-status-hook.sh — Codex lifecycle/notify hook that reports agent status
 # to the lince-dashboard Zellij plugin via pipe (primary) and file (fallback).
 #
 # Emits a minimal JSON contract: {"agent_id": "<id>", "event": "<native_name>"}
@@ -8,8 +8,8 @@
 # See LINCE-118 / LINCE-122.
 #
 # Codex notify runs an external program and appends a JSON payload as an argv
-# item (some integrations may prefer stdin, so we support both). The payload's
-# `type` field (e.g. "agent-turn-complete") is forwarded as the native event.
+# item; lifecycle hooks deliver JSON on stdin using `hook_event_name`.
+# Prefer that field, then the legacy notify `type` field.
 # If `type` is missing, we synthesize "turn_complete" to preserve historical
 # semantics (codex notify fires on turn completion).
 #
@@ -50,8 +50,11 @@ extract_json_field() {
     fi
 }
 
-EVENT_TYPE=$(extract_json_field "type")
-NATIVE_EVENT="${EVENT_TYPE:-turn_complete}"
+NATIVE_EVENT=$(extract_json_field "hook_event_name")
+if [ -z "$NATIVE_EVENT" ]; then
+    EVENT_TYPE=$(extract_json_field "type")
+    NATIVE_EVENT="${EVENT_TYPE:-turn_complete}"
+fi
 
 PAYLOAD="{\"agent_id\":\"${AGENT_ID}\",\"event\":\"${NATIVE_EVENT}\"}"
 

--- a/lince-dashboard/hooks/install-codex-hooks.sh
+++ b/lince-dashboard/hooks/install-codex-hooks.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
-# install-codex-hooks.sh — Install Codex notify integration for lince-dashboard.
+# install-codex-hooks.sh — Install Codex lifecycle and notify integration.
 #
 # What it does:
 #   1. Copies the Codex notify hook to ~/.local/bin/
 #   2. Copies the shared agent wrapper to ~/.local/bin/
 #   3. Inserts a managed top-level notify entry into ~/.codex/config.toml
 #      unless the user already has a different notify command configured
-#   4. Prints sandbox env passthrough requirements
+#   4. Merges lifecycle handlers into Codex hooks.json (preserving user hooks)
+#   5. Prints sandbox env passthrough requirements and hook trust instructions
 #
 # Notes:
-#   - Codex notify runs on turn completion, so this complements the generic
-#     lince-agent-wrapper instead of replacing it.
+#   - Legacy notify reports completion only; lifecycle hooks also report work.
 
 set -euo pipefail
 
@@ -24,7 +24,7 @@ HOOK_SRC="$SCRIPT_DIR/codex-status-hook.sh"
 HOOK_DEST="$HOME/.local/bin/codex-status-hook.sh"
 WRAPPER_SRC="$SCRIPT_DIR/lince-agent-wrapper"
 WRAPPER_DEST="$HOME/.local/bin/lince-agent-wrapper"
-CONFIG_DIR="$HOME/.codex"
+CONFIG_DIR="${CODEX_HOME:-$HOME/.codex}"
 CONFIG_FILE="$CONFIG_DIR/config.toml"
 BLOCK_START="# >>> LINCE Dashboard Codex notify >>>"
 BLOCK_END="# <<< LINCE Dashboard Codex notify <<<"
@@ -41,14 +41,14 @@ if ! command -v python3 >/dev/null 2>&1; then
     exit 1
 fi
 
-echo -e "${GREEN}[1/4] Installing Codex notify hook...${NC}"
+echo -e "${GREEN}[1/5] Installing Codex status hook...${NC}"
 mkdir -p "$HOME/.local/bin"
 cp "$HOOK_SRC" "$HOOK_DEST"
 chmod +x "$HOOK_DEST"
 echo -e "${GREEN}  Installed: $HOOK_DEST${NC}"
 
 echo ""
-echo -e "${GREEN}[2/4] Installing shared agent wrapper...${NC}"
+echo -e "${GREEN}[2/5] Installing shared agent wrapper...${NC}"
 if [ -f "$WRAPPER_SRC" ]; then
     cp "$WRAPPER_SRC" "$WRAPPER_DEST"
     chmod +x "$WRAPPER_DEST"
@@ -58,7 +58,7 @@ else
 fi
 
 echo ""
-echo -e "${GREEN}[3/4] Configuring Codex notify...${NC}"
+echo -e "${GREEN}[3/5] Configuring Codex notify...${NC}"
 
 mkdir -p "$CONFIG_DIR"
 if [ ! -f "$CONFIG_FILE" ]; then
@@ -106,6 +106,8 @@ elif [ "$OTHER_NOTIFY" = "OTHER" ]; then
     echo -e "${YELLOW}  ⚠ Existing Codex notify setting found in $CONFIG_FILE — leaving it unchanged${NC}"
     echo -e "${YELLOW}    Add this manually if you want LINCE idle updates:${NC}"
     echo "    $HOOK_LINE"
+elif [ "$OTHER_NOTIFY" = "OURS" ]; then
+    echo -e "${GREEN}  ✓ Notify already configured${NC}"
 else
     TMP_FILE="$(mktemp)"
     awk -v start="$BLOCK_START" -v end="$BLOCK_END" '
@@ -138,7 +140,14 @@ else
 fi
 
 echo ""
-echo -e "${GREEN}[4/4] Sandbox configuration requirements${NC}"
+echo -e "${GREEN}[4/5] Configuring Codex lifecycle hooks...${NC}"
+python3 "$SCRIPT_DIR/codex-hooks-config.py" "$CONFIG_DIR/hooks.json"
+echo "  Hooks: $CONFIG_DIR/hooks.json"
+echo "  In Codex, open /hooks and review/trust the codex-status-hook.sh handlers."
+echo "  Codex skips new or changed hooks until trusted. Then start a new session."
+
+echo ""
+echo -e "${GREEN}[5/5] Sandbox configuration requirements${NC}"
 echo ""
 echo -e "${YELLOW}  IMPORTANT: For Codex status updates to work inside agent-sandbox, you must${NC}"
 echo -e "${YELLOW}  add these environment variables to your sandbox config passthrough:${NC}"
@@ -155,4 +164,4 @@ echo "Config:      $CONFIG_FILE"
 echo ""
 echo "To verify:"
 echo "  LINCE_AGENT_ID=test-1 bash $HOOK_DEST '{\"type\":\"agent-turn-complete\"}'"
-echo "  cat /tmp/lince-dashboard/test-1.state  # should show: idle"
+echo "  cat /tmp/lince-dashboard/test-1.state  # should show: agent-turn-complete"

--- a/lince-dashboard/hooks/update-codex-hooks.sh
+++ b/lince-dashboard/hooks/update-codex-hooks.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# update-codex-hooks.sh — Refresh Codex notify integration.
+# update-codex-hooks.sh — Refresh Codex lifecycle and notify integration.
 
 set -euo pipefail
 

--- a/lince-dashboard/plugin/src/agent.rs
+++ b/lince-dashboard/plugin/src/agent.rs
@@ -294,6 +294,7 @@ fn synthesize_sandboxed_command(
         "codex" => (
             vec![
                 "codex".to_string(),
+                "--no-alt-screen".to_string(),
                 "-a".to_string(),
                 "never".to_string(),
                 "--sandbox".to_string(),

--- a/lince-dashboard/tests/hook-contract.sh
+++ b/lince-dashboard/tests/hook-contract.sh
@@ -169,6 +169,22 @@ run_capture codex-fallback \
     "${HOOKS_DIR}/codex-status-hook.sh"
 validate_payload codex-fallback "test-codex" '^turn_complete$'
 
+# Lifecycle hooks use stdin and take precedence over the legacy notify type.
+for event in SessionStart UserPromptSubmit PreToolUse PermissionRequest PostToolUse PreCompact PostCompact Stop Interrupt SessionEnd; do
+    run_capture "codex-$event" \
+        bash -c 'printf "{\"hook_event_name\":\"%s\",\"type\":\"agent-turn-complete\"}" "$1" | bash "$0"' \
+        "${HOOKS_DIR}/codex-status-hook.sh" "$event"
+    validate_payload "codex-$event" "test-codex" "^${event}$"
+    if [ "$(cat "$STATE_DIR/test-codex.state")" != "$event" ]; then
+        echo "FAIL [codex-$event] file fallback did not receive lifecycle event"
+        FAIL=1
+    fi
+done
+
+run_capture codex-argv \
+    bash "${HOOKS_DIR}/codex-status-hook.sh" '{"type":"agent-turn-complete"}'
+validate_payload codex-argv "test-codex" '^agent-turn-complete$'
+
 # --- bob-status-hook.sh: hook_event_name forwarded verbatim ----------------
 # Bob's contract is Claude-style (hook_event_name on stdin) but has no
 # Notification event; missing hook_event_name must exit 0 with no payload.

--- a/lince-dashboard/tests/test_codex_hooks.py
+++ b/lince-dashboard/tests/test_codex_hooks.py
@@ -1,0 +1,105 @@
+"""Exercise installation, preservation, and dashboard lifecycle transitions."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import tomllib
+import unittest
+
+
+DASHBOARD = Path(__file__).resolve().parents[1]
+HOOKS = DASHBOARD / "hooks"
+EXPECTED = {
+    "SessionStart": "input", "UserPromptSubmit": "running",
+    "PreToolUse": "running", "PermissionRequest": "permission",
+    "PostToolUse": "running", "PreCompact": "running", "PostCompact": "running",
+    "Stop": "input", "Interrupt": "input", "SessionEnd": "stopped",
+}
+
+
+class CodexHooksTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.home = Path(self.temp.name)
+        self.codex = self.home / "custom-codex-home"
+        self.codex.mkdir()
+        self.config = self.codex / "config.toml"
+        self.hooks = self.codex / "hooks.json"
+        self.env = {**os.environ, "HOME": str(self.home), "CODEX_HOME": str(self.codex)}
+
+    def install(self):
+        return subprocess.run(
+            ["bash", str(HOOKS / "install-codex-hooks.sh")], env=self.env,
+            capture_output=True, text=True,
+        )
+
+    def test_install_and_update_are_idempotent(self):
+        self.config.write_text('model = "test-model"\n[projects."/tmp/example"]\ntrust_level = "trusted"\n')
+        self.assertEqual(self.install().returncode, 0)
+        first = (self.config.read_bytes(), self.hooks.read_bytes())
+        self.assertEqual(self.install().returncode, 0)
+        self.assertEqual(first, (self.config.read_bytes(), self.hooks.read_bytes()))
+        self.assertFalse(list(self.codex.glob("hooks.json.lince.bak*")))
+        cfg = tomllib.loads(self.config.read_text())
+        self.assertEqual(cfg["notify"], ["codex-status-hook.sh"])
+        self.assertEqual(cfg["model"], "test-model")
+        self.assertTrue((self.home / ".local/bin/codex-status-hook.sh").is_file())
+        self.assertFalse((self.home / ".codex").exists())
+
+    def test_existing_unmanaged_lince_notify_is_not_duplicated(self):
+        original = 'notify = ["codex-status-hook.sh"]\n[features]\nhooks = true\n'
+        self.config.write_text(original)
+        self.assertEqual(self.install().returncode, 0)
+        self.assertEqual(self.config.read_text(), original)
+
+    def test_preserves_user_notify_and_hooks_and_uninstalls_only_ours(self):
+        config = 'notify = ["my-notifier", "--flag"]\n'
+        original = {"description": "User hooks", "hooks": {
+            "Stop": [{"matcher": "*", "hooks": [{"type": "command", "command": "my-stop"}]}],
+            "SubagentStop": [{"hooks": [{"type": "command", "command": "my-subagent"}]}],
+        }}
+        self.config.write_text(config)
+        self.hooks.write_text(json.dumps(original))
+        self.assertEqual(self.install().returncode, 0)
+        self.assertEqual(self.config.read_text(), config)
+        self.assertEqual(json.loads(self.hooks.with_name("hooks.json.lince.bak").read_text()), original)
+        installed = json.loads(self.hooks.read_text())
+        self.assertEqual(installed["hooks"]["Stop"][0], original["hooks"]["Stop"][0])
+        subprocess.run(["python3", str(HOOKS / "codex-hooks-config.py"), str(self.hooks), "--remove"], check=True)
+        self.assertEqual(json.loads(self.hooks.read_text()), original)
+
+    def test_malformed_hooks_are_preserved(self):
+        for raw in ('{invalid json', '{"hooks": []}', '{"hooks": {"Stop": [{}]}}'):
+            with self.subTest(raw=raw):
+                self.hooks.write_text(raw)
+                result = self.install()
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(self.hooks.read_text(), raw)
+
+    def test_installed_lifecycle_reaches_dashboard_status_for_both_variants(self):
+        self.assertEqual(self.install().returncode, 0)
+        installed = json.loads(self.hooks.read_text())["hooks"]
+        agents = tomllib.loads((DASHBOARD / "agents-defaults.toml").read_text())["agents"]
+        registry = tomllib.loads((DASHBOARD.parent / "registry.d/codex.toml").read_text())
+        for event, expected_status in EXPECTED.items():
+            with self.subTest(event=event):
+                self.assertEqual(installed[event][0]["hooks"][0]["command"], "codex-status-hook.sh")
+                result = subprocess.run(
+                    ["bash", str(self.home / ".local/bin/codex-status-hook.sh")],
+                    input=json.dumps({"hook_event_name": event}), text=True, capture_output=True,
+                    env={**self.env, "ZELLIJ": "", "LINCE_AGENT_ID": "test-lifecycle",
+                         "LINCE_STATUS_DIR": str(self.home / "state")},
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stdout, "")  # no accidental model context
+                native_event = (self.home / "state/test-lifecycle.state").read_text().strip()
+                for variant in ("codex", "codex-unsandboxed"):
+                    self.assertEqual(agents[variant]["event_map"][native_event], expected_status)
+                self.assertEqual(registry["event_map"][native_event], expected_status)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lince-dashboard/uninstall.sh
+++ b/lince-dashboard/uninstall.sh
@@ -6,6 +6,7 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 echo -e "${BLUE}================================================${NC}"
 echo -e "${BLUE}   LINCE Dashboard — Uninstaller${NC}"
@@ -218,7 +219,7 @@ fi
 echo ""
 
 # ── Codex notify in config.toml ────────────────────────────────────────
-CODEX_CONFIG="$HOME/.codex/config.toml"
+CODEX_CONFIG="${CODEX_HOME:-$HOME/.codex}/config.toml"
 CODEX_BLOCK_START="# >>> LINCE Dashboard Codex notify >>>"
 CODEX_BLOCK_END="# <<< LINCE Dashboard Codex notify <<<"
 if [ -f "$CODEX_CONFIG" ]; then
@@ -241,6 +242,14 @@ else
     echo "  Codex config not found — skipping notify cleanup"
 fi
 echo ""
+
+CODEX_HOOKS="${CODEX_HOME:-$HOME/.codex}/hooks.json"
+if [ -f "$CODEX_HOOKS" ] && grep -Fq 'codex-status-hook.sh' "$CODEX_HOOKS"; then
+    if confirm "  Remove Lince Codex lifecycle handlers from $CODEX_HOOKS?"; then
+        python3 "$SCRIPT_DIR/hooks/codex-hooks-config.py" "$CODEX_HOOKS" --remove
+        echo -e "${GREEN}  ✓ Removed Lince handlers (other hooks preserved)${NC}"
+    fi
+fi
 
 # ── Shell aliases ────────────────────────────────────────────────
 ALIAS_REMOVED=false

--- a/lince-dashboard/zellij-config/config.kdl
+++ b/lince-dashboard/zellij-config/config.kdl
@@ -1,4 +1,9 @@
 keybinds clear-defaults=true {
+    shared_among "normal" "locked" {
+        // Send LF (Ctrl+J) to the composer even without enhanced keyboard
+        // support inside the pane. The host must distinguish Shift+Enter.
+        bind "Shift Enter" { Write 10; }
+    }
     locked {
         bind "Ctrl l" { SwitchToMode "normal"; }
     }

--- a/registry.d/codex.toml
+++ b/registry.d/codex.toml
@@ -13,7 +13,7 @@ display_name = "OpenAI Codex"
 short_label = "CDX"
 color = "cyan"
 binary = "codex"
-default_args = ["-a", "never"]
+default_args = ["--no-alt-screen", "-a", "never"]
 
 [sandbox]
 backend = "auto"
@@ -49,7 +49,7 @@ providers = ["__discover__"]
 # Exceptions to the derivation rule (design §3.5); all other
 # variant fields are derived from the base definition.
 [variants.unsandboxed]
-command = ["codex", "--sandbox", "workspace-write", "-a", "never"]
+command = ["codex", "--no-alt-screen", "--sandbox", "workspace-write", "-a", "never"]
 bwrap_conflict = false
 
 [env]
@@ -57,5 +57,15 @@ OPENAI_API_KEY = "$OPENAI_API_KEY"
 
 # Once per agent; all variants inherit (design §3.5).
 [event_map]
+SessionStart = "input"
+UserPromptSubmit = "running"
+PreToolUse = "running"
+PostToolUse = "running"
+PermissionRequest = "permission"
+PreCompact = "running"
+PostCompact = "running"
+Stop = "input"
+Interrupt = "input"
+SessionEnd = "stopped"
 agent-turn-complete = "input"
 turn_complete = "input"

--- a/sandbox/agents-defaults.toml
+++ b/sandbox/agents-defaults.toml
@@ -43,7 +43,7 @@ disable_inner_sandbox_args = []
 
 [agents.codex]
 command = "codex"
-default_args = ["-a", "never"]
+default_args = ["--no-alt-screen", "-a", "never"]
 env = {}
 home_ro_dirs = []
 home_rw_dirs = [".codex"]

--- a/scripts/gen_registry.py
+++ b/scripts/gen_registry.py
@@ -141,7 +141,7 @@ HOME_SUBDIRS: dict[str, str] = {
 #   with).
 VARIANT_EXCEPTIONS: dict[str, dict] = {
     "codex": {
-        "command": ["codex", "--sandbox", "workspace-write", "-a", "never"],
+        "command": ["codex", "--no-alt-screen", "--sandbox", "workspace-write", "-a", "never"],
         "bwrap_conflict": False,
     },
 }

--- a/scripts/tests/test_resolve.py
+++ b/scripts/tests/test_resolve.py
@@ -71,7 +71,7 @@ class ResolveTestCase(unittest.TestCase):
         self.assertEqual(claude["dashboard"]["status_pipe_name"], "claude-status")
         # variant derivation incl. the codex exception
         self.assertEqual(view["agents"]["codex"]["variants"]["unsandboxed"]["command"],
-                         ["codex", "--sandbox", "workspace-write", "-a", "never"])
+                         ["codex", "--no-alt-screen", "--sandbox", "workspace-write", "-a", "never"])
         self.assertFalse(view["agents"]["codex"]["variants"]["unsandboxed"]["bwrap_conflict"])
         self.assertEqual(claude["variants"]["unsandboxed"]["command"], ["claude"])
         self.assertEqual(claude["variants"]["unsandboxed"]["short_label"], "CLU")


### PR DESCRIPTION
## Problem

Codex started inside Lince/Zellij loses pane scrollback, the dashboard remains on `INPUT` while Codex is working, and multiline prompt input does not work with `Shift+Enter`.

## Changes

- start Codex with `--no-alt-screen` to preserve Zellij scrollback;
- integrate Codex lifecycle hooks into `$CODEX_HOME/hooks.json`, preserving existing user hooks;
- map `SessionStart`, `UserPromptSubmit`, tool use, permission, stop, and session end events to Lince states;
- update install, update, and uninstall scripts and document review/trust through `/hooks`;
- add `Shift+Enter` → LF to the shipped Zellij configuration, with `Ctrl+J` documented as an alternative;
- add tests for idempotent installation, hook preservation, malformed files, status transitions, and the hook contract.

Closes #308

## Validation

- `python3 -m unittest discover -s lince-dashboard/tests -p 'test_codex_hooks.py' -v`
- `bash lince-dashboard/tests/hook-contract.sh`
- `bash lince-dashboard/tests/event-map-coverage.sh`
- `python3 scripts/tests/test_registry_sync.py`
- `python3 scripts/tests/test_resolve.py`
- `cargo check --locked` with `/usr/bin/cargo` and `/usr/bin/rustc`
- `zellij --config lince-dashboard/zellij-config/config.kdl setup --check`
- `git diff --check`

The full Rust WASM suite was not run because this environment does not have the WASM target configured in rustup.
