### PR TITLE
Require Zellij 0.45.1 for reliable Codex scrollback

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ For a detailed step-by-step guide with scenarios (Mini/Full/Custom), troubleshoo
 ### Prerequisites
 
 - **Linux** (tested on Fedora 43, works on Ubuntu/Debian/Arch)
-- **Zellij** >= 0.40
+- **Zellij** >= 0.45.1
 - **Claude Code** (`npm install -g @anthropic-ai/claude-code`)
 - **bubblewrap** (`sudo dnf install bubblewrap` / `sudo apt install bubblewrap`)
 - **Rust** with `wasm32-wasip1` target (for building the dashboard plugin)

--- a/docs/install
+++ b/docs/install
@@ -143,22 +143,26 @@ else
   fi
 fi
 
-# Zellij
-if check_cmd zellij; then
-  echo -e "  ${GREEN}✓${NC} zellij $(zellij --version 2>/dev/null | awk '{print $2}')"
-else
-  MISSING+=("zellij (>= 0.40)")
-  echo -e "  ${YELLOW}✗${NC} zellij not found"
-  echo ""
-  echo "    Install Zellij:"
-  if [ "$OS_NAME" = "Darwin" ]; then
-    echo "      brew install zellij"
-  else
-    echo "      mkdir -p ~/.local/bin && curl -L https://github.com/zellij-org/zellij/releases/latest/download/zellij-x86_64-unknown-linux-musl.tar.gz | tar xz && mv zellij ~/.local/bin/"
-    echo "      # Or via cargo:"
-    echo "      cargo install --locked zellij"
-  fi
-  echo ""
+# Zellij — standalone bootstrap, before the repository is available.
+check_zellij_version() {
+    local detected
+    detected=$(zellij --version 2>/dev/null) || detected="unavailable"
+    if printf '%s\n' "$detected" | awk '
+        /^zellij [0-9]+\.[0-9]+\.[0-9]+$/ {
+            split($2, v, ".")
+            ok = (v[1] > 0 || v[2] > 45 || (v[2] == 45 && v[3] >= 1))
+        }
+        END { exit !ok }
+    '; then
+        printf '%s\n' "$detected"
+        return 0
+    fi
+    printf 'Zellij >= 0.45.1 required for reliable Codex scrollback (found: %s).\n' "$detected" >&2
+    printf 'Install/upgrade: https://github.com/zellij-org/zellij/releases (then restart Zellij).\n' >&2
+    return 1
+}
+if ! check_zellij_version; then
+  MISSING+=("zellij (>= 0.45.1)")
 fi
 
 # Sandbox backend

--- a/lince-dashboard/README.md
+++ b/lince-dashboard/README.md
@@ -24,7 +24,7 @@ Sandboxed agents run inside [agent-sandbox](../sandbox/) (bubblewrap, Linux) or 
 
 ## Prerequisites
 
-- **Zellij** >= 0.40 (0.43.x recommended)
+- **Zellij** >= 0.45.1
 - **Rust** with `wasm32-wasip1` target (`rustup target add wasm32-wasip1`)
 - **At least one supported AI coding agent** (Claude Code, Codex, Gemini, OpenCode, Aider, Amp)
 - **A sandbox backend** (at least one):
@@ -136,7 +136,7 @@ lince-dashboard/
 
 ### Plugin won't load
 - Check the WASM file exists: `ls ~/.config/zellij/plugins/lince-dashboard.wasm`
-- Verify Zellij version: `zellij --version` (need >= 0.40)
+- Verify Zellij version: `zellij --version` (need >= 0.45.1)
 - Check layout path: `zellij --layout ~/.config/zellij/layouts/dashboard.kdl`
 - Grant permissions when Zellij prompts
 

--- a/lince-dashboard/install.sh
+++ b/lince-dashboard/install.sh
@@ -9,6 +9,9 @@ NC='\033[0m'
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# shellcheck source=scripts/check-zellij.sh
+source "$SCRIPT_DIR/../scripts/check-zellij.sh"
+
 # Sandbox isolation levels (paranoid/normal/permissive) are no longer chosen at
 # install time. Under Config v2 they are a dimension of each agent, offered by
 # the dashboard's New Agent wizard at spawn time; the old install-time selection
@@ -99,11 +102,7 @@ echo -e "${GREEN}[1/14] Checking prerequisites...${NC}"
 
 MISSING=()
 
-if ! command -v zellij >/dev/null 2>&1; then
-    MISSING+=("zellij (>= 0.40)")
-else
-    echo -e "${GREEN}  ✓ zellij $(zellij --version 2>/dev/null | awk '{print $2}')${NC}"
-fi
+check_zellij_version || exit 1
 
 if ! command -v rustc >/dev/null 2>&1; then
     MISSING+=("rustc")

--- a/lince-dashboard/update.sh
+++ b/lince-dashboard/update.sh
@@ -9,6 +9,9 @@ NC='\033[0m'
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# shellcheck source=scripts/check-zellij.sh
+source "$SCRIPT_DIR/../scripts/check-zellij.sh"
+
 # Pick a backup path that never clobbers an earlier backup, even when two
 # updates run within the same second (timestamp collision → -1, -2, ... suffix).
 unique_backup_path() {
@@ -30,6 +33,8 @@ echo ""
 
 # Ensure rustup toolchain takes precedence
 export PATH="$HOME/.cargo/bin:$PATH"
+
+check_zellij_version || exit 1
 
 # ── Build ──────────────────────────────────────────────────────────────
 echo -e "${GREEN}[1/8] Building plugin...${NC}"

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -19,6 +19,9 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# shellcheck source=scripts/check-zellij.sh
+source "$SCRIPT_DIR/scripts/check-zellij.sh"
+
 # ── Colors & formatting ──────────────────────────────────────────────
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -956,13 +959,8 @@ check_prerequisites() {
         echo -e "  ${RED}✗${NC} git not found"
     fi
 
-    # Zellij
-    if command -v zellij >/dev/null 2>&1; then
-        echo -e "  ${GREEN}✓${NC} zellij $(zellij --version 2>/dev/null | awk '{print $2}')"
-    else
-        warnings+=("zellij not found (required for dashboard)")
-        echo -e "  ${YELLOW}✗${NC} zellij not found — needed for dashboard"
-    fi
+    # A hard prerequisite: do not install components with broken scrollback.
+    check_zellij_version || exit 1
 
     # Rustup (distro rustc alone cannot provide wasm32 targets needed for dashboard)
     if command -v rustup >/dev/null 2>&1; then

--- a/scripts/check-zellij.sh
+++ b/scripts/check-zellij.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Minimum supported runtime: includes the Codex scrollback fixes (#4941, #5357).
+# Keep this check in sync with the standalone bootstrap in docs/install.
+check_zellij_version() {
+    local detected
+    detected=$(zellij --version 2>/dev/null) || detected="unavailable"
+    if printf '%s\n' "$detected" | awk '
+        /^zellij [0-9]+\.[0-9]+\.[0-9]+$/ {
+            split($2, v, ".")
+            ok = (v[1] > 0 || v[2] > 45 || (v[2] == 45 && v[3] >= 1))
+        }
+        END { exit !ok }
+    '; then
+        printf '%s\n' "$detected"
+        return 0
+    fi
+    printf 'Zellij >= 0.45.1 required for reliable Codex scrollback (found: %s).\n' "$detected" >&2
+    printf 'Install/upgrade: https://github.com/zellij-org/zellij/releases (then restart Zellij).\n' >&2
+    return 1
+}

--- a/scripts/tests/test_zellij_version.py
+++ b/scripts/tests/test_zellij_version.py
@@ -1,0 +1,49 @@
+"""Check installer version gates without running installation side effects."""
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+HELPER = (ROOT / 'scripts/check-zellij.sh').read_text()
+BOOTSTRAP = (ROOT / 'docs/install').read_text()
+BOOTSTRAP_CHECK = BOOTSTRAP[BOOTSTRAP.index('check_zellij_version() {'):].split('\nif ! check_zellij_version;', 1)[0]
+
+
+class ZellijVersionTest(unittest.TestCase):
+    def test_version_gate(self):
+        cases = [
+            (None, 0, False), ('zellij 0.44.0', 0, False),
+            ('zellij 0.44.3', 0, False), ('zellij 0.45.0', 0, False),
+            ('zellij 0.45.1', 0, True), ('zellij 0.45.10', 0, True),
+            ('zellij 0.46.0', 0, True), ('zellij 1.0.0', 0, True),
+            ('zellij 0.45.1-rc.1', 0, False), ('garbage', 0, False),
+            ('', 0, False), ('zellij 0.45.1', 1, False),
+        ]
+        for check in (HELPER, BOOTSTRAP_CHECK):
+            for version, status, accepted in cases:
+                with self.subTest(version=version, status=status, bootstrap=check == BOOTSTRAP_CHECK):
+                    with tempfile.TemporaryDirectory() as directory:
+                        path = Path(directory)
+                        (path / 'awk').symlink_to(shutil.which('awk'))
+                        if version is not None:
+                            stub = path / 'zellij'
+                            stub.write_text('#!/bin/bash\nprintf "%s\\n" "$TEST_VERSION"\nexit "$TEST_STATUS"\n')
+                            stub.chmod(0o755)
+                        result = subprocess.run(
+                            ['/bin/bash', '-c', check + '\ncheck_zellij_version'],
+                            env={**os.environ, 'PATH': directory, 'TEST_VERSION': version or '', 'TEST_STATUS': str(status)},
+                            capture_output=True, text=True,
+                        )
+                        self.assertEqual(result.returncode == 0, accepted, result.stderr)
+                        if not accepted:
+                            self.assertIn('Zellij >= 0.45.1 required', result.stderr)
+
+    def test_bootstrap_matches_shared_check(self):
+        self.assertEqual(HELPER[HELPER.index('check_zellij_version() {'):].strip(), BOOTSTRAP_CHECK.strip())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Older Zellij runtimes can lose Codex scrollback, blocking review of long agent sessions. Require Zellij >= 0.45.1, the version verified interactively with Lince, which includes the partial-scroll-region and line-wrap fixes (zellij-org/zellij#4941 and #5357).

The web bootstrap, quickstart, dashboard installer and dashboard updater now reject missing, older or unrecognized runtimes with an upgrade hint. Repository entry points share one check; the standalone bootstrap embeds the same function, with a test keeping it synchronized. Update the documented prerequisites.

Validation: 24 version-check cases across the shared and bootstrap checks, including missing/failing binaries, old releases, the minimum, newer releases and prereleases; bootstrap parity test; Bash syntax checks for all five affected scripts; `git diff --check`. User confirmed scrolling works with Zellij 0.45.1 in the Lince dashboard. The installed dashboard plugin was used without changing its Rust API dependency.
