### PR TITLE
fix(sandbox): restore local X11 clipboard image paste

### DIFF
--- a/docs/documentation/configuration-keys.md
+++ b/docs/documentation/configuration-keys.md
@@ -25,6 +25,7 @@ Filesystem exposure and backend selection.
 | `ro_dirs` | list[string] | `["~/project"]` | Directories with read-only access |
 | `persist_toolchains` | bool | `true` | Persist cargo/npm/go/uv caches between sessions |
 | `auto_expose_path` | bool | `true` | Auto-detect $PATH entries under $HOME and expose them read-only |
+| `expose_x11` | bool | `true` | Expose the active local X11 socket and authentication for image paste; disabled when security.unshare_net is true. Grants display access beyond the clipboard. |
 | `expose_gpu` | bool | `true` | Expose host GPU device nodes (/dev/nvidia*, /dev/dri) inside the bwrap sandbox (#280); ignored at paranoid unless the paranoid fragment itself opts in |
 | `home_ro_dirs` | list[string] | `[".config/gcloud"]` | Extra home subdirectories to expose read-only (relative to $HOME) |
 | `home_rw_dirs` | list[string] | `[]` | Real home subdirectories to mount read-write (relative to $HOME); shadows any isolated toolchain cache in the same subtree (#286) |

--- a/lince-config/lince-config
+++ b/lince-config/lince-config
@@ -438,6 +438,7 @@ SANDBOX_CONFIG_SCHEMA = {
                                                 "between sessions", True),
                 "auto_expose_path": _d(_BOOL, "Auto-detect $PATH entries under $HOME "
                                               "and expose them read-only", True),
+                "expose_x11": _d(_BOOL, "Expose the active local X11 socket and authentication for image paste; disabled when security.unshare_net is true. Grants display access beyond the clipboard.", default=True),
                 "expose_gpu": _d(_BOOL, "Expose host GPU device nodes "
                                         "(/dev/nvidia*, /dev/dri) inside the "
                                         "bwrap sandbox (#280); ignored at "

--- a/lince-dashboard/skills/lince-configure/references/sandbox-config.md
+++ b/lince-dashboard/skills/lince-configure/references/sandbox-config.md
@@ -23,6 +23,7 @@ Filesystem exposure and backend selection.
 | `ro_dirs` | list[string] | `["~/project"]` | Directories with read-only access |
 | `persist_toolchains` | bool | `true` | Persist cargo/npm/go/uv caches between sessions |
 | `auto_expose_path` | bool | `true` | Auto-detect $PATH entries under $HOME and expose them read-only |
+| `expose_x11` | bool | `true` | Expose the active local X11 socket and authentication for image paste; disabled when security.unshare_net is true. Grants display access beyond the clipboard. |
 | `expose_gpu` | bool | `true` | Expose host GPU device nodes (/dev/nvidia*, /dev/dri) inside the bwrap sandbox (#280); ignored at paranoid unless the paranoid fragment itself opts in |
 | `home_ro_dirs` | list[string] | `[".config/gcloud"]` | Extra home subdirectories to expose read-only (relative to $HOME) |
 | `home_rw_dirs` | list[string] | `[]` | Real home subdirectories to mount read-write (relative to $HOME); shadows any isolated toolchain cache in the same subtree (#286) |

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -22,7 +22,6 @@ Claude Code's `--dangerously-skip-permissions` flag removes all confirmation pro
 | **Process killing/inspection** | Host processes invisible | `--unshare-pid` (PID namespace) |
 | **System modification** | Cannot write to `/usr`, `/etc`, `/var` | Read-only root filesystem |
 | **DBus/desktop access** | Session bus socket hidden | `--tmpfs /run` |
-| **X11/Wayland keylogging** | Display sockets hidden | `--tmpfs /tmp` |
 | **Cron/systemd persistence** | Cannot create services or cron jobs | Read-only `/etc`, tmpfs `/run` |
 
 ### What it allows
@@ -37,14 +36,23 @@ Claude Code's `--dangerously-skip-permissions` flag removes all confirmation pro
 | **Package caches** | `cargo build` can download crates, npm can cache | Persistent writable dirs for registry/cache subdirectories |
 | **Filesystem snapshots** | Undo agent damage to project or config dirs | rsync hardlink-based snapshots with interactive restore |
 
+Local display access supports clipboard image paste. On Linux, the active
+Wayland socket is re-exposed; X11/Xwayland clients also receive the socket selected
+by `DISPLAY` and a read-only authentication file from `XAUTHORITY` (or
+`~/.Xauthority`). This works in normal/default, permissive, and learn mode.
+X11 access grants desktop access beyond the clipboard. Set
+`[sandbox] expose_x11 = false` to omit automatic X11 exposure; it is always
+omitted when `[security] unshare_net = true`, including the standard paranoid
+profiles. Remote/SSH X11 displays are not automatically exposed.
+
 ## How it works
 
 agent-sandbox builds a [bubblewrap](https://github.com/containers/bubblewrap) command that sets up a Linux mount namespace. In plain terms, it creates a "view" of the filesystem where:
 
 ```
 /                           read-only   (entire OS visible but unmodifiable)
-├── /tmp                    fresh tmpfs (empty, writable, isolated)
-├── /run                    fresh tmpfs (hides DBus, Wayland sockets)
+├── /tmp                    fresh tmpfs (selected sockets/files re-exposed)
+├── /run/user/$UID          fresh tmpfs (selected sockets re-exposed; DBus hidden)
 ├── /dev                    minimal     (null, zero, random only)
 ├── /proc                   namespaced  (only sandbox processes visible)
 └── /home/you               tmpfs       (entire home hidden)

--- a/sandbox/agent-sandbox
+++ b/sandbox/agent-sandbox
@@ -86,6 +86,11 @@ auto_expose_path = true
 # exposes the GPU when its own fragment sets expose_gpu = true.
 # expose_gpu = true
 
+# Expose the local X11 display for image paste (also on Xwayland).
+# Disabled when security.unshare_net is true. X11 access includes desktop
+# access beyond the clipboard; set false to omit this automatic exposure.
+# expose_x11 = true
+
 # Extra home subdirectories to expose read-only (relative to $HOME).
 # Each is mounted only if it exists on the host, so listing a dir you
 # don't use is harmless.
@@ -178,8 +183,7 @@ passthrough = [
     "ZELLIJ_SESSION_NAME",
     "LINCE_AGENT_ID",
     # Lets Chromium-based browsers use their native Wayland backend (#284).
-    # The host's Chrome typically runs on Xwayland, and the sandbox has no
-    # X11 socket, so without this it dies with "Missing X server or $DISPLAY".
+    # Also works when X11 exposure is disabled or no X11 display is available.
     "XDG_SESSION_TYPE",
 ]
 
@@ -2991,6 +2995,35 @@ def prepare_seatbelt_git_blocking(config: dict) -> dict[str, str]:
 # bwrap command builder
 # ---------------------------------------------------------------------------
 
+def x11_bwrap_args(config: dict) -> list[str]:
+    """Expose only the active local X11 socket and its authentication file.
+
+    Call after filesystem overlays and --clearenv. Network-isolated sandboxes
+    must not gain a new connection to the host desktop through a Unix socket.
+    Remote/SSH displays are deliberately not auto-exposed.
+    """
+    if (not config.get("sandbox", {}).get("expose_x11", True)
+            or config.get("security", {}).get("unshare_net", False)):
+        return []
+    display = os.environ.get("DISPLAY", "")
+    match = re.fullmatch(r"(?:unix/|unix)?:([0-9]+)(?:\.[0-9]+)?", display)
+    if not match:
+        return []
+    socket = Path(f"/tmp/.X11-unix/X{int(match.group(1))}")
+    if not socket.is_socket():
+        return []
+    args = ["--ro-bind", str(socket), str(socket),
+            "--setenv", "DISPLAY", display]
+    authority = Path(os.environ.get("XAUTHORITY") or (Path.home() / ".Xauthority"))
+    if authority.is_file():
+        # A stable tmpfs destination also handles symlinks and files beneath
+        # hidden runtime/home directories without exposing their parent dirs.
+        target = "/tmp/.lince-xauthority"
+        args += ["--ro-bind", str(authority.resolve()), target,
+                 "--setenv", "XAUTHORITY", target]
+    return args
+
+
 def build_bwrap_cmd(config: dict, project_dir: Path,
                     agent_extra_args: list[str],
                     log_file: Path | None = None,
@@ -3310,6 +3343,8 @@ def build_bwrap_cmd(config: dict, project_dir: Path,
     # Users can override via [env.extra] GIT_SSH_COMMAND = "..." if needed.
     if "GIT_SSH_COMMAND" not in env_conf.get("extra", {}):
         cmd += ["--setenv", "GIT_SSH_COMMAND", "ssh -F /dev/null"]
+
+    cmd += x11_bwrap_args(config)
 
     # --- Wayland env vars (clipboard access for wl-paste) --------------------
     for wl_var in ("WAYLAND_DISPLAY", "XDG_RUNTIME_DIR"):
@@ -7278,6 +7313,8 @@ def build_learn_bwrap_cmd(
     cmd += ["--setenv", "GOMODCACHE", f"{home}/.go/pkg/mod"]
     cmd += ["--setenv", "UV_CACHE_DIR", f"{home}/.uv-cache"]
     cmd += ["--setenv", "UV_TOOL_DIR", f"{home}/.uv-tools"]
+
+    cmd += x11_bwrap_args(config)
 
     # Wayland env vars
     for wl_var in ("WAYLAND_DISPLAY", "XDG_RUNTIME_DIR"):

--- a/sandbox/config.toml.example
+++ b/sandbox/config.toml.example
@@ -26,6 +26,11 @@ auto_expose_path = true
 # exposes the GPU when its own fragment sets expose_gpu = true.
 # expose_gpu = true
 
+# Expose the local X11 display for image paste (also on Xwayland).
+# Disabled when security.unshare_net is true. X11 access includes desktop
+# access beyond the clipboard; set false to omit this automatic exposure.
+# expose_x11 = true
+
 # Extra home subdirectories to expose read-only (relative to $HOME).
 # Each is mounted only if it exists on the host, so listing a dir you
 # don't use is harmless.
@@ -118,8 +123,7 @@ passthrough = [
     "ZELLIJ_SESSION_NAME",
     "LINCE_AGENT_ID",
     # Lets Chromium-based browsers use their native Wayland backend (#284).
-    # The host's Chrome typically runs on Xwayland, and the sandbox has no
-    # X11 socket, so without this it dies with "Missing X server or $DISPLAY".
+    # Also works when X11 exposure is disabled or no X11 display is available.
     "XDG_SESSION_TYPE",
 ]
 

--- a/schemas/sandbox-config.schema.json
+++ b/schemas/sandbox-config.schema.json
@@ -39,6 +39,11 @@
           "description": "Auto-detect $PATH entries under $HOME and expose them read-only",
           "default": true
         },
+        "expose_x11": {
+          "type": "boolean",
+          "description": "Expose the active local X11 socket and authentication for image paste; disabled when security.unshare_net is true. Grants display access beyond the clipboard.",
+          "default": true
+        },
         "expose_gpu": {
           "type": "boolean",
           "description": "Expose host GPU device nodes (/dev/nvidia*, /dev/dri) inside the bwrap sandbox (#280); ignored at paranoid unless the paranoid fragment itself opts in",

--- a/scripts/tests/test_x11_clipboard.py
+++ b/scripts/tests/test_x11_clipboard.py
@@ -1,0 +1,106 @@
+"""X11 clipboard access survives bwrap's tmpfs overlays and clearenv."""
+
+import importlib.machinery
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+
+class X11ClipboardTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        path = Path(__file__).resolve().parents[2] / "sandbox/agent-sandbox"
+        loader = importlib.machinery.SourceFileLoader("sandbox_x11_test", str(path))
+        spec = importlib.util.spec_from_loader(loader.name, loader)
+        cls.mod = importlib.util.module_from_spec(spec)
+        loader.exec_module(cls.mod)
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.auth = self.root / "Xauthority"
+        self.auth.write_text("test-cookie")
+        env = mock.patch.dict(self.mod.os.environ, {
+            "DISPLAY": ":7.0", "XAUTHORITY": str(self.auth),
+        }, clear=True)
+        env.start()
+        self.addCleanup(env.stop)
+        sockets = mock.patch.object(Path, "is_socket", autospec=True,
+                                    side_effect=lambda p: str(p) == "/tmp/.X11-unix/X7")
+        sockets.start()
+        self.addCleanup(sockets.stop)
+
+    def test_local_display_and_authentication(self):
+        args = self.mod.x11_bwrap_args({})
+        self.assertEqual(args, [
+            "--ro-bind", "/tmp/.X11-unix/X7", "/tmp/.X11-unix/X7",
+            "--setenv", "DISPLAY", ":7.0",
+            "--ro-bind", str(self.auth), "/tmp/.lince-xauthority",
+            "--setenv", "XAUTHORITY", "/tmp/.lince-xauthority",
+        ])
+
+    def test_home_authentication_fallback(self):
+        del self.mod.os.environ["XAUTHORITY"]
+        auth = self.root / ".Xauthority"
+        auth.write_text("test-cookie")
+        with mock.patch.object(Path, "home", return_value=self.root):
+            self.assertIn(str(auth), self.mod.x11_bwrap_args({}))
+
+    def test_runtime_authentication_symlink(self):
+        link = self.root / "auth-link"
+        link.symlink_to(self.auth)
+        self.mod.os.environ["XAUTHORITY"] = str(link)
+        self.assertIn(str(self.auth), self.mod.x11_bwrap_args({}))
+        self.assertNotIn(str(link), self.mod.x11_bwrap_args({}))
+
+    def test_missing_authentication_keeps_socket_access(self):
+        self.auth.unlink()
+        args = self.mod.x11_bwrap_args({})
+        self.assertIn("DISPLAY", args)
+        self.assertNotIn("XAUTHORITY", args)
+
+    def test_disabled_or_network_isolated(self):
+        for config in ({"sandbox": {"expose_x11": False}},
+                       {"security": {"unshare_net": True}}):
+            with self.subTest(config=config):
+                self.assertEqual(self.mod.x11_bwrap_args(config), [])
+
+    def test_absent_remote_or_invalid_display(self):
+        for display in ("", ":9", "localhost:7", "host:7", ":../7", ":7/bad"):
+            with self.subTest(display=display):
+                self.mod.os.environ["DISPLAY"] = display
+                self.assertEqual(self.mod.x11_bwrap_args({}), [])
+
+    def test_unix_display_formats(self):
+        for display in (":7", "unix:7", "unix/:7.0"):
+            with self.subTest(display=display):
+                self.mod.os.environ["DISPLAY"] = display
+                self.assertIn("/tmp/.X11-unix/X7", self.mod.x11_bwrap_args({}))
+
+    def test_builders_expose_x11_after_overlays_and_clearenv(self):
+        config = {
+            "sandbox": {"auto_expose_path": False, "persist_toolchains": False,
+                        "expose_gpu": False},
+            "security": {"block_git_push": False},
+        }
+        agent = {"command": "true", "home_ro_dirs": [], "home_rw_dirs": []}
+        with mock.patch.object(self.mod, "SANDBOX_DIR", self.root):
+            commands = [
+                self.mod.build_bwrap_cmd(config, self.root, [], agent_config=agent),
+                self.mod.build_learn_bwrap_cmd(config, self.root, agent),
+            ]
+        expected = self.mod.x11_bwrap_args(config)
+        for cmd in commands:
+            with self.subTest(builder=cmd):
+                start = cmd.index("/tmp/.X11-unix/X7") - 1
+                self.assertEqual(cmd[start:start + len(expected)], expected)
+                self.assertGreater(start, cmd.index("--clearenv"))
+                self.assertGreater(start, max(i for i, arg in enumerate(cmd)
+                                              if arg == "--tmpfs"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Ctrl-V in Codex could fail inside a Linux sandbox with an unreachable X11 server, including under Xwayland. Restore the active local X11 socket, DISPLAY and read-only authentication after bwrap's filesystem overlays and environment reset in regular and learn-mode launchers.

Add `sandbox.expose_x11` (default true) to disable automatic exposure when desired. Automatic X11 exposure is always skipped with `security.unshare_net`, and remote/SSH displays are excluded. Synchronize configuration examples, schema and generated references, and document that X11 access extends beyond the clipboard.

Validation:
- 41 tests and 13 subtests passed, covering clipboard mounts and environment, authentication fallback/symlinks, missing displays, opt-out/network isolation, both builders, existing GPU/broker behavior, and schema/configuration synchronization.
- `git diff --check` passed.
- The reporter confirmed that image paste works on their desktop.

Closes #315
